### PR TITLE
fix: add Pub/Sub liveness to worker health check

### DIFF
--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -76,19 +76,12 @@ export default function Leaderboard() {
   const [coverageLoading, setCoverageLoading] = useState(false);
 
   useEffect(() => {
-    const fetchCoverage = async () => {
-      try {
-        const [config, status] = await Promise.all([
-          getCoverageConfig(),
-          getCoverageStatus(),
-        ]);
-        setCoverageConfig(config);
-        setCoverageStatus(status);
-      } catch (err) {
-        console.error('Failed to fetch coverage data:', err);
-      }
-    };
-    fetchCoverage();
+    getCoverageConfig()
+      .then(setCoverageConfig)
+      .catch((err) => console.error('Failed to fetch coverage config:', err));
+    getCoverageStatus()
+      .then(setCoverageStatus)
+      .catch((err) => console.error('Failed to fetch coverage status:', err));
   }, []);
 
   const handleToggleCoverage = async () => {

--- a/worker/src/worker-api.ts
+++ b/worker/src/worker-api.ts
@@ -19,12 +19,18 @@ import * as crypto from 'crypto';
 // Types
 // ---------------------------------------------------------------------------
 
+export interface HealthStatus {
+  ok: boolean;
+  pubsub?: { connected: boolean; lastError?: string };
+}
+
 export interface WorkerApiHandlers {
   onConfig: (maxConcurrentOverride: number | null) => void;
   onCancel: (jobId: string) => void;
   onNotify: () => void;
   onDrain: (drain: boolean) => void;
   onPullImage: () => void;
+  getHealth?: () => HealthStatus;
 }
 
 // ---------------------------------------------------------------------------
@@ -88,7 +94,8 @@ export function startWorkerApi(handlers: WorkerApiHandlers): Promise<void> {
 
       // GET /health — no auth
       if (method === 'GET' && url === '/health') {
-        jsonResponse(res, 200, { ok: true });
+        const health = handlers.getHealth?.() ?? { ok: true };
+        jsonResponse(res, health.ok ? 200 : 503, health);
         return;
       }
 

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -1028,6 +1028,18 @@ async function main(): Promise<void> {
       console.error('Subscription error:', error);
     });
 
+    // Periodically check for coverage work when idle (Pub/Sub mode has no
+    // polling loop, so we need a separate timer to request coverage jobs).
+    const COVERAGE_CHECK_INTERVAL_MS = 30_000;
+    setInterval(async () => {
+      if (isShuttingDown || isDraining) return;
+      if (activeSimCount > 0) return; // Only request coverage when idle
+      const created = await requestCoverageJob();
+      if (created) {
+        console.log('[Coverage] Coverage job created, will arrive via Pub/Sub');
+      }
+    }, COVERAGE_CHECK_INTERVAL_MS);
+
     console.log('Worker is running. Waiting for simulation tasks...');
   } else {
     console.log('Worker is running in polling mode.');

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -1051,9 +1051,13 @@ async function main(): Promise<void> {
     setInterval(async () => {
       if (isShuttingDown || isDraining) return;
       if (activeSimCount > 0) return; // Only request coverage when idle
-      const created = await requestCoverageJob();
-      if (created) {
-        console.log('[Coverage] Coverage job created, will arrive via Pub/Sub');
+      try {
+        const created = await requestCoverageJob();
+        if (created) {
+          console.log('[Coverage] Coverage job created, will arrive via Pub/Sub');
+        }
+      } catch (err) {
+        console.error('[Coverage] Failed to request coverage job:', err);
       }
     }, COVERAGE_CHECK_INTERVAL_MS);
 

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -47,7 +47,7 @@ import {
   extractWinner,
   extractWinningTurn,
 } from './condenser.js';
-import { startWorkerApi, stopWorkerApi } from './worker-api.js';
+import { startWorkerApi, stopWorkerApi, HealthStatus } from './worker-api.js';
 import { GAMES_PER_CONTAINER } from './constants.js';
 import { createLogger } from './logger.js';
 
@@ -82,6 +82,10 @@ let jobNotifyResolve: (() => void) | null = null;
 
 // Drain flag — when true, worker stops accepting new work
 let isDraining = false;
+
+// Pub/Sub health tracking — healthy until an error occurs, reset on message receipt
+let pubSubHealthy = true;
+let lastPubSubError: string | null = null;
 
 // ============================================================================
 // Worker Naming
@@ -990,6 +994,13 @@ async function main(): Promise<void> {
     onNotify: notifyJobAvailable,
     onDrain: setDraining,
     onPullImage: pullSimulationImage,
+    getHealth: (): HealthStatus => {
+      if (!usePubSub) return { ok: true };
+      return {
+        ok: pubSubHealthy,
+        pubsub: { connected: pubSubHealthy, ...(lastPubSubError ? { lastError: lastPubSubError } : {}) },
+      };
+    },
   });
 
   // Initial heartbeat (await to apply override before Pub/Sub starts)
@@ -1023,8 +1034,14 @@ async function main(): Promise<void> {
     console.log('Subscription:', SUBSCRIPTION_NAME);
     console.log(`Subscribing to Pub/Sub messages (maxMessages=${simSemaphore.maxSlots})...`);
 
-    subscription.on('message', handleMessage);
+    subscription.on('message', (msg: any) => {
+      pubSubHealthy = true;
+      lastPubSubError = null;
+      handleMessage(msg);
+    });
     subscription.on('error', (error: unknown) => {
+      pubSubHealthy = false;
+      lastPubSubError = error instanceof Error ? error.message : String(error);
       console.error('Subscription error:', error);
     });
 


### PR DESCRIPTION
## Summary
- Worker health endpoint (`/health`) now checks Pub/Sub subscription state instead of always returning 200
- Tracks `pubSubHealthy` flag: set to `false` on subscription errors, reset to `true` on message receipt
- Returns **503** with diagnostic payload (`{ ok: false, pubsub: { connected: false, lastError: "..." } }`) when Pub/Sub is disconnected
- Docker healthcheck (`curl -f`) will detect the 503, and after 3 retries the `restart: unless-stopped` policy auto-restarts the container

## Context
A transient authentication error killed the Pub/Sub streaming pull listener while the container continued reporting healthy. The worker silently dropped all simulation messages for 43+ hours until manually restarted.

## Test plan
- [ ] `npx tsc --noEmit` passes in `worker/`
- [ ] Deploy worker with the fix, verify `/health` returns `{ ok: true, pubsub: { connected: true } }` when healthy
- [ ] Simulate subscription error (e.g., revoke SA permissions temporarily) and confirm `/health` returns 503
- [ ] Confirm Docker restarts the container after 3 consecutive unhealthy checks

🤖 Generated with [Claude Code](https://claude.ai/code)