### PR TITLE
fix: correct Firestore collection name for coverage match results

### DIFF
--- a/DATA_FLOW.md
+++ b/DATA_FLOW.md
@@ -231,8 +231,8 @@ pairs have sufficient game data for reliable TrueSkill rankings.
 **Job creation flow (`POST /api/coverage/next-job`):**
 
 - Auth: worker secret only (no Firebase auth)
-- Guard: returns 204 if disabled, all pairs covered, fewer than 4 decks, or
-  an active coverage job already exists (race condition prevention)
+- Guard: returns 200 with `{ reason }` if no work available. Possible reasons:
+  `disabled`, `active-job-exists`, `all-pairs-covered`, `deck-resolution-failed`
 - Creates a job with `simulations: 100`, `parallelism: 1`,
   `source: 'coverage'`
 - Job enters the normal queue — same pipeline as user-created jobs

--- a/api/app/api/coverage/next-job/route.ts
+++ b/api/app/api/coverage/next-job/route.ts
@@ -25,23 +25,23 @@ export async function POST(request: NextRequest) {
   try {
     const config = await getCoverageStore().getConfig();
     if (!config.enabled) {
-      return new NextResponse(null, { status: 204 });
+      return NextResponse.json({ reason: 'disabled' }, { status: 204 });
     }
 
     // Prevent race condition: only one coverage job at a time
     if (await hasActiveCoverageJob()) {
-      return new NextResponse(null, { status: 204 });
+      return NextResponse.json({ reason: 'active-job-exists' }, { status: 204 });
     }
 
     const pod = await generateNextPod(config.targetGamesPerPair);
     if (!pod) {
-      return new NextResponse(null, { status: 204 });
+      return NextResponse.json({ reason: 'all-pairs-covered' }, { status: 204 });
     }
 
     const { decks, errors } = await resolveDeckIds(pod);
     if (errors.length > 0) {
       console.error(`[Coverage] Failed to resolve decks: ${errors.join(', ')}`);
-      return new NextResponse(null, { status: 204 });
+      return NextResponse.json({ reason: 'deck-resolution-failed', errors }, { status: 204 });
     }
 
     const job = await jobStore.createJob(decks, COVERAGE_SIMULATIONS, {

--- a/api/app/api/coverage/next-job/route.ts
+++ b/api/app/api/coverage/next-job/route.ts
@@ -25,23 +25,23 @@ export async function POST(request: NextRequest) {
   try {
     const config = await getCoverageStore().getConfig();
     if (!config.enabled) {
-      return NextResponse.json({ reason: 'disabled' }, { status: 204 });
+      return NextResponse.json({ reason: 'disabled' });
     }
 
     // Prevent race condition: only one coverage job at a time
     if (await hasActiveCoverageJob()) {
-      return NextResponse.json({ reason: 'active-job-exists' }, { status: 204 });
+      return NextResponse.json({ reason: 'active-job-exists' });
     }
 
     const pod = await generateNextPod(config.targetGamesPerPair);
     if (!pod) {
-      return NextResponse.json({ reason: 'all-pairs-covered' }, { status: 204 });
+      return NextResponse.json({ reason: 'all-pairs-covered' });
     }
 
     const { decks, errors } = await resolveDeckIds(pod);
     if (errors.length > 0) {
       console.error(`[Coverage] Failed to resolve decks: ${errors.join(', ')}`);
-      return NextResponse.json({ reason: 'deck-resolution-failed', errors }, { status: 204 });
+      return NextResponse.json({ reason: 'deck-resolution-failed', errors });
     }
 
     const job = await jobStore.createJob(decks, COVERAGE_SIMULATIONS, {

--- a/api/lib/coverage-service.ts
+++ b/api/lib/coverage-service.ts
@@ -209,7 +209,7 @@ async function getAllMatchResults(): Promise<{ deckIds: string[] }[]> {
 
   if (USE_FIRESTORE) {
     const { getFirestore } = require('firebase-admin/firestore') as typeof import('firebase-admin/firestore');
-    const snapshot = await getFirestore().collection('match_results').select('deckIds').get();
+    const snapshot = await getFirestore().collection('matchResults').select('deckIds').get();
     return snapshot.docs.map((doc) => ({
       deckIds: doc.data().deckIds as string[],
     }));

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -830,6 +830,19 @@ async function requestCoverageJob(): Promise<boolean> {
       console.log(`[Coverage] Requested coverage job: ${data.id}`);
       return true;
     }
+    if (res.status === 204) {
+      // Parse reason if available (API returns JSON with reason field)
+      try {
+        const data = await res.json();
+        if (data?.reason) {
+          console.log(`[Coverage] No work: ${data.reason}`);
+        }
+      } catch {
+        // No body or not JSON — that's fine
+      }
+    } else {
+      console.warn(`[Coverage] Unexpected response: ${res.status}`);
+    }
     return false;
   } catch (error) {
     if (error instanceof Error && error.name !== 'TimeoutError') {

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -818,6 +818,8 @@ function waitForNotifyOrTimeout(ms: number): Promise<void> {
  * Request a coverage job from the API when idle.
  * Returns true if a coverage job was created (will be picked up next poll cycle).
  */
+let lastCoverageReason: string | null = null;
+
 async function requestCoverageJob(): Promise<boolean> {
   try {
     const res = await fetch(`${getApiUrl()}/api/coverage/next-job`, {
@@ -828,17 +830,15 @@ async function requestCoverageJob(): Promise<boolean> {
     if (res.status === 201) {
       const data = await res.json();
       console.log(`[Coverage] Requested coverage job: ${data.id}`);
+      lastCoverageReason = null;
       return true;
     }
-    if (res.status === 204) {
-      // Parse reason if available (API returns JSON with reason field)
-      try {
-        const data = await res.json();
-        if (data?.reason) {
-          console.log(`[Coverage] No work: ${data.reason}`);
-        }
-      } catch {
-        // No body or not JSON — that's fine
+    if (res.status === 200) {
+      const data = await res.json();
+      const reason = data?.reason;
+      if (reason && reason !== lastCoverageReason) {
+        console.log(`[Coverage] No work: ${reason}`);
+        lastCoverageReason = reason;
       }
     } else {
       console.warn(`[Coverage] Unexpected response: ${res.status}`);


### PR DESCRIPTION
## Summary
- **Bug fix**: Coverage service was reading from Firestore collection `match_results` (snake_case) while the rating store writes to `matchResults` (camelCase) — coverage could never see game data, so pair coverage always showed 0%
- **Diagnostic logging**: API `POST /api/coverage/next-job` now returns a `reason` field on 204 responses (`disabled`, `active-job-exists`, `all-pairs-covered`, `deck-resolution-failed`)
- **Worker logging**: `requestCoverageJob()` now logs the reason when coverage is skipped, instead of silently returning false

## Test plan
- [ ] Deploy and verify worker logs show `[Coverage] No work: disabled` or `[Coverage] Requested coverage job: <id>` instead of silence
- [ ] Enable coverage on Leaderboard admin panel and confirm coverage jobs start being created
- [ ] Verify coverage status endpoint reflects actual match result data (non-zero progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)