### PR TITLE
fix: use static imports in coverage store factory

### DIFF
--- a/api/lib/coverage-store-factory.ts
+++ b/api/lib/coverage-store-factory.ts
@@ -3,23 +3,13 @@
  * otherwise to SQLite.
  */
 import type { CoverageStore } from './coverage-store';
+import { firestoreCoverageStore } from './coverage-store-firestore';
+import { sqliteCoverageStore } from './coverage-store-sqlite';
 
 const USE_FIRESTORE =
   typeof process.env.GOOGLE_CLOUD_PROJECT === 'string' &&
   process.env.GOOGLE_CLOUD_PROJECT.length > 0;
 
-let _store: CoverageStore | null = null;
-
 export function getCoverageStore(): CoverageStore {
-  if (_store) return _store;
-  if (USE_FIRESTORE) {
-    const { firestoreCoverageStore } = require('./coverage-store-firestore') as {
-      firestoreCoverageStore: CoverageStore;
-    };
-    return (_store = firestoreCoverageStore);
-  }
-  const { sqliteCoverageStore } = require('./coverage-store-sqlite') as {
-    sqliteCoverageStore: CoverageStore;
-  };
-  return (_store = sqliteCoverageStore);
+  return USE_FIRESTORE ? firestoreCoverageStore : sqliteCoverageStore;
 }


### PR DESCRIPTION
## Summary
- The coverage store factory used dynamic `require()` to load Firestore/SQLite implementations
- In the Next.js webpack production build, these dynamic requires returned empty modules, causing `getCoverageStore()` to return `undefined`
- This caused every `POST /api/coverage/next-job` request to crash with `TypeError: Cannot read properties of undefined (reading 'getConfig')` → 500
- Switched to static imports matching the pattern used by `job-store-factory` and other working factories

**Root cause of the 500s visible in worker logs**: the coverage system has been non-functional since initial deployment (PR #137) because the factory never loaded.

## Test plan
- [ ] Verify API no longer returns 500 on `POST /api/coverage/next-job`
- [ ] Check worker logs for `[Coverage] No work: disabled` (expected if coverage toggle is off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)