### PR TITLE
fix: use @google-cloud/firestore instead of firebase-admin in coverage

### DIFF
--- a/api/lib/coverage-service.ts
+++ b/api/lib/coverage-service.ts
@@ -2,7 +2,22 @@
  * Coverage service: computes pair coverage from match_results and generates
  * optimal 4-player pods using a greedy algorithm.
  */
+import { Firestore } from '@google-cloud/firestore';
 import { listAllDecks } from './deck-store-factory';
+
+const USE_FIRESTORE =
+  typeof process.env.GOOGLE_CLOUD_PROJECT === 'string' &&
+  process.env.GOOGLE_CLOUD_PROJECT.length > 0;
+
+let _firestore: Firestore | null = null;
+function getFirestoreClient(): Firestore {
+  if (!_firestore) {
+    _firestore = new Firestore({
+      projectId: process.env.GOOGLE_CLOUD_PROJECT || 'magic-bracket-simulator',
+    });
+  }
+  return _firestore;
+}
 
 /** Canonical key for a pair of deck IDs (alphabetically sorted). */
 function pairKey(a: string, b: string): string {
@@ -176,16 +191,8 @@ export async function generateNextPod(targetGamesPerPair: number): Promise<strin
  * Used to prevent race conditions when multiple workers request coverage work.
  */
 export async function hasActiveCoverageJob(): Promise<boolean> {
-  const USE_FIRESTORE =
-    typeof process.env.GOOGLE_CLOUD_PROJECT === 'string' &&
-    process.env.GOOGLE_CLOUD_PROJECT.length > 0;
-
   if (USE_FIRESTORE) {
-    const { Firestore } = await import('@google-cloud/firestore');
-    const firestore = new Firestore({
-      projectId: process.env.GOOGLE_CLOUD_PROJECT || 'magic-bracket-simulator',
-    });
-    const snapshot = await firestore
+    const snapshot = await getFirestoreClient()
       .collection('jobs')
       .where('source', '==', 'coverage')
       .where('status', 'in', ['QUEUED', 'RUNNING'])
@@ -206,16 +213,8 @@ export async function hasActiveCoverageJob(): Promise<boolean> {
  * Get all match results (deck_ids arrays) from the database.
  */
 async function getAllMatchResults(): Promise<{ deckIds: string[] }[]> {
-  const USE_FIRESTORE =
-    typeof process.env.GOOGLE_CLOUD_PROJECT === 'string' &&
-    process.env.GOOGLE_CLOUD_PROJECT.length > 0;
-
   if (USE_FIRESTORE) {
-    const { Firestore } = await import('@google-cloud/firestore');
-    const firestore = new Firestore({
-      projectId: process.env.GOOGLE_CLOUD_PROJECT || 'magic-bracket-simulator',
-    });
-    const snapshot = await firestore.collection('matchResults').select('deckIds').get();
+    const snapshot = await getFirestoreClient().collection('matchResults').select('deckIds').get();
     return snapshot.docs.map((doc) => ({
       deckIds: doc.data().deckIds as string[],
     }));

--- a/api/lib/coverage-service.ts
+++ b/api/lib/coverage-service.ts
@@ -181,8 +181,11 @@ export async function hasActiveCoverageJob(): Promise<boolean> {
     process.env.GOOGLE_CLOUD_PROJECT.length > 0;
 
   if (USE_FIRESTORE) {
-    const { getFirestore } = require('firebase-admin/firestore') as typeof import('firebase-admin/firestore');
-    const snapshot = await getFirestore()
+    const { Firestore } = await import('@google-cloud/firestore');
+    const firestore = new Firestore({
+      projectId: process.env.GOOGLE_CLOUD_PROJECT || 'magic-bracket-simulator',
+    });
+    const snapshot = await firestore
       .collection('jobs')
       .where('source', '==', 'coverage')
       .where('status', 'in', ['QUEUED', 'RUNNING'])
@@ -208,8 +211,11 @@ async function getAllMatchResults(): Promise<{ deckIds: string[] }[]> {
     process.env.GOOGLE_CLOUD_PROJECT.length > 0;
 
   if (USE_FIRESTORE) {
-    const { getFirestore } = require('firebase-admin/firestore') as typeof import('firebase-admin/firestore');
-    const snapshot = await getFirestore().collection('matchResults').select('deckIds').get();
+    const { Firestore } = await import('@google-cloud/firestore');
+    const firestore = new Firestore({
+      projectId: process.env.GOOGLE_CLOUD_PROJECT || 'magic-bracket-simulator',
+    });
+    const snapshot = await firestore.collection('matchResults').select('deckIds').get();
     return snapshot.docs.map((doc) => ({
       deckIds: doc.data().deckIds as string[],
     }));

--- a/api/lib/coverage-store-firestore.ts
+++ b/api/lib/coverage-store-firestore.ts
@@ -1,11 +1,16 @@
 /**
  * Firestore implementation of CoverageStore (GCP mode).
+ * Uses @google-cloud/firestore directly (same pattern as firestore-job-store)
+ * so it works without Firebase Admin initialization.
  */
 import type { CoverageStore, CoverageConfig } from './coverage-store';
-import { getFirestore } from 'firebase-admin/firestore';
+import { Firestore } from '@google-cloud/firestore';
 
-const COLLECTION = 'config';
-const DOC_ID = 'coverage';
+const firestore = new Firestore({
+  projectId: process.env.GOOGLE_CLOUD_PROJECT || 'magic-bracket-simulator',
+});
+
+const configDoc = firestore.collection('config').doc('coverage');
 
 const DEFAULT_CONFIG: CoverageConfig = {
   enabled: false,
@@ -16,7 +21,7 @@ const DEFAULT_CONFIG: CoverageConfig = {
 
 export const firestoreCoverageStore: CoverageStore = {
   async getConfig(): Promise<CoverageConfig> {
-    const doc = await getFirestore().collection(COLLECTION).doc(DOC_ID).get();
+    const doc = await configDoc.get();
     if (!doc.exists) return DEFAULT_CONFIG;
     const data = doc.data()!;
     return {
@@ -35,7 +40,7 @@ export const firestoreCoverageStore: CoverageStore = {
       updatedAt: new Date().toISOString(),
       updatedBy,
     };
-    await getFirestore().collection(COLLECTION).doc(DOC_ID).set(config);
+    await configDoc.set(config);
     return config;
   },
 };


### PR DESCRIPTION
## Summary
- Coverage store and service used `firebase-admin/firestore`'s `getFirestore()`, which requires Firebase Admin initialization
- The coverage endpoint authenticates via worker secret (not Firebase Auth), so Firebase Admin is never initialized on this code path
- This caused `"The default Firebase app does not exist"` → 500 on every coverage request
- Switched to `@google-cloud/firestore` directly, matching `firestore-job-store.ts` and `rating-store-firestore.ts`

## Test plan
- [ ] Verify API logs no longer show Firebase Admin initialization errors
- [ ] Worker logs should show `[Coverage] No work: disabled` (or job creation if enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)