### PR TITLE
fix: bump api memory to 1GiB to resolve OOM-kills

### DIFF
--- a/api/apphosting.yaml
+++ b/api/apphosting.yaml
@@ -2,7 +2,10 @@
 runConfig:
   minInstances: 0
   maxInstances: 1
-  memory: 512MiB
+  # Bumped from 512MiB → 1GiB: container was OOM-killing at ~520-535 MiB under
+  # normal load, causing Envoy to return 503 "upstream connect error" which
+  # surfaces in the browser as "Failed to fetch" on routes like /leaderboard.
+  memory: 1GiB
   cpu: 1
   concurrency: 80
 


### PR DESCRIPTION
## Summary

- Bumps `memory` in `api/apphosting.yaml` from `512MiB` to `1GiB`
- Root cause of user-reported "Failed to fetch" on `/leaderboard`: the API container was being OOM-killed under normal load, causing Envoy to return `503 upstream connect error / connection termination`, which the browser surfaces as "Failed to fetch"

## Evidence

Cloud Run logs around the failure window showed dozens of:

```
Memory limit of 512 MiB exceeded with 533 MiB used. Consider increasing the memory limit
…
While handling this request, the container instance was found to be using too much memory and was terminated.
```

OOMs were not limited to `/api/leaderboard` — they hit `/api/jobs/:id`, `/api/workers/heartbeat`, `/api/coverage/next-job`, and the per-simulation PATCH routes too. The leaderboard is just the most visible because it's a page users navigate to directly, and the fetch fails outright rather than silently retrying.

Peak memory was ~533 MiB — only ~20 MiB over the 512 MiB limit — so this is a gradual-growth situation rather than a runaway leak. 1 GiB gives roughly 2× headroom.

## Why just bump memory (vs. optimize routes)

Several routes are hitting the limit, not a single pathological one. A targeted per-route optimization wouldn't stop the container from OOM-killing on the next pressure spike. Bumping memory fixes it for all routes in one change. We can still chase per-route memory optimizations later as a follow-up.

## Test plan

- [ ] CI lint/build/test pass
- [ ] After deploy, hit `GET /api/leaderboard?minGames=5&limit=500` and confirm 2xx response
- [ ] Load https://magic-bracket-simulator.web.app/leaderboard in browser and confirm rankings render
- [ ] Check Cloud Run logs for `Memory limit … exceeded` — should be absent post-deploy
- [ ] Confirm no new alerts from the Sentry "Error Spike" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)