### PR TITLE
refactor(api): lazy-load SQLite stores via dynamic import

### DIFF
--- a/api/app/api/coverage/config/route.ts
+++ b/api/app/api/coverage/config/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const config = await getCoverageStore().getConfig();
+    const config = await (await getCoverageStore()).getConfig();
     return NextResponse.json(config);
   } catch (error) {
     console.error('GET /api/coverage/config error:', error);
@@ -52,7 +52,7 @@ export async function PATCH(request: NextRequest) {
       return errorResponse('No valid fields to update', 400);
     }
 
-    const config = await getCoverageStore().updateConfig(update, user.email);
+    const config = await (await getCoverageStore()).updateConfig(update, user.email);
     return NextResponse.json(config);
   } catch (error) {
     console.error('PATCH /api/coverage/config error:', error);

--- a/api/app/api/coverage/next-job/route.ts
+++ b/api/app/api/coverage/next-job/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const config = await getCoverageStore().getConfig();
+    const config = await (await getCoverageStore()).getConfig();
     if (!config.enabled) {
       return NextResponse.json({ reason: 'disabled' });
     }

--- a/api/app/api/coverage/status/route.ts
+++ b/api/app/api/coverage/status/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const config = await getCoverageStore().getConfig();
+    const config = await (await getCoverageStore()).getConfig();
     const status = await getCoverageStatus(config.targetGamesPerPair);
     return NextResponse.json(status);
   } catch (error) {

--- a/api/lib/coverage-store-factory.ts
+++ b/api/lib/coverage-store-factory.ts
@@ -4,12 +4,22 @@
  */
 import type { CoverageStore } from './coverage-store';
 import { firestoreCoverageStore } from './coverage-store-firestore';
-import { sqliteCoverageStore } from './coverage-store-sqlite';
 
 const USE_FIRESTORE =
   typeof process.env.GOOGLE_CLOUD_PROJECT === 'string' &&
   process.env.GOOGLE_CLOUD_PROJECT.length > 0;
 
-export function getCoverageStore(): CoverageStore {
-  return USE_FIRESTORE ? firestoreCoverageStore : sqliteCoverageStore;
+// Lazy dynamic import of the SQLite-backed coverage store.
+// See job-store-factory.ts for rationale.
+let _sqliteStore: CoverageStore | null = null;
+async function getSqliteStore(): Promise<CoverageStore> {
+  if (!_sqliteStore) {
+    const mod = await import('./coverage-store-sqlite');
+    _sqliteStore = mod.sqliteCoverageStore;
+  }
+  return _sqliteStore;
+}
+
+export async function getCoverageStore(): Promise<CoverageStore> {
+  return USE_FIRESTORE ? firestoreCoverageStore : getSqliteStore();
 }

--- a/api/lib/job-store-factory.ts
+++ b/api/lib/job-store-factory.ts
@@ -4,7 +4,6 @@
  */
 import { Job, JobStatus, JobResults, DeckSlot, SimulationStatus, SimulationState, WorkerInfo, GAMES_PER_CONTAINER, JobSource } from './types';
 import { isTerminalSimState } from '@shared/types/state-machine';
-import * as sqliteStore from './job-store';
 import * as firestoreStore from './firestore-job-store';
 import * as workerStore from './worker-store-factory';
 import { cancelRecoveryCheck } from './cloud-tasks';
@@ -15,6 +14,20 @@ const log = createLogger('JobStore');
 const recoveryLog = createLogger('Recovery');
 
 const USE_FIRESTORE = typeof process.env.GOOGLE_CLOUD_PROJECT === 'string' && process.env.GOOGLE_CLOUD_PROJECT.length > 0;
+
+// Lazy dynamic import of the SQLite-backed store. Using `await import()` (not
+// `require()`) so webpack can statically analyze the dependency and emit it
+// as a separate chunk that is only loaded when first accessed. This keeps
+// better-sqlite3 and the full SQLite schema in db.ts out of the production
+// container startup path entirely when running in GCP mode.
+type SqliteJobStore = typeof import('./job-store');
+let _sqliteStore: SqliteJobStore | null = null;
+async function sqliteStore(): Promise<SqliteJobStore> {
+  if (!_sqliteStore) {
+    _sqliteStore = await import('./job-store');
+  }
+  return _sqliteStore;
+}
 
 // Log mode detection at startup
 log.info('Running in mode', { mode: USE_FIRESTORE ? 'GCP' : 'LOCAL' });
@@ -33,7 +46,7 @@ export async function getJob(id: string): Promise<Job | null> {
   if (USE_FIRESTORE) {
     return firestoreStore.getJob(id);
   }
-  const job = sqliteStore.getJob(id);
+  const job = (await sqliteStore()).getJob(id);
   return job ?? null;
 }
 
@@ -41,7 +54,7 @@ export async function getJobByIdempotencyKey(key: string): Promise<Job | null> {
   if (USE_FIRESTORE) {
     return firestoreStore.getJobByIdempotencyKey(key);
   }
-  const job = sqliteStore.getJobByIdempotencyKey(key);
+  const job = (await sqliteStore()).getJobByIdempotencyKey(key);
   return job ?? null;
 }
 
@@ -61,7 +74,7 @@ export async function createJob(
       source: options?.source,
     });
   }
-  return sqliteStore.createJob(
+  return (await sqliteStore()).createJob(
     decks,
     simulations,
     options?.idempotencyKey,
@@ -75,14 +88,14 @@ export async function listJobs(userId?: string): Promise<Job[]> {
   if (USE_FIRESTORE) {
     return firestoreStore.listJobs(userId);
   }
-  return sqliteStore.listJobs();
+  return (await sqliteStore()).listJobs();
 }
 
 export async function listActiveJobs(): Promise<Job[]> {
   if (USE_FIRESTORE) {
     return firestoreStore.listActiveJobs();
   }
-  return sqliteStore.listActiveJobs();
+  return (await sqliteStore()).listActiveJobs();
 }
 
 export async function updateJobStatus(id: string, status: JobStatus): Promise<void> {
@@ -90,7 +103,7 @@ export async function updateJobStatus(id: string, status: JobStatus): Promise<vo
     await firestoreStore.updateJobStatus(id, status);
     return;
   }
-  sqliteStore.updateJobStatus(id, status);
+  (await sqliteStore()).updateJobStatus(id, status);
 }
 
 export async function setJobStartedAt(id: string, workerId?: string, workerName?: string): Promise<void> {
@@ -98,7 +111,7 @@ export async function setJobStartedAt(id: string, workerId?: string, workerName?
     await firestoreStore.setJobStartedAt(id, workerId, workerName);
     return;
   }
-  sqliteStore.setJobStartedAt(id, workerId, workerName);
+  (await sqliteStore()).setJobStartedAt(id, workerId, workerName);
 }
 
 export async function conditionalUpdateJobStatus(
@@ -110,7 +123,7 @@ export async function conditionalUpdateJobStatus(
   if (USE_FIRESTORE) {
     return firestoreStore.conditionalUpdateJobStatus(id, expectedStatuses, newStatus, metadata);
   }
-  return sqliteStore.conditionalUpdateJobStatus(id, expectedStatuses, newStatus, metadata);
+  return (await sqliteStore()).conditionalUpdateJobStatus(id, expectedStatuses, newStatus, metadata);
 }
 
 export async function setNeedsAggregation(id: string, value: boolean): Promise<void> {
@@ -118,7 +131,7 @@ export async function setNeedsAggregation(id: string, value: boolean): Promise<v
     await firestoreStore.setNeedsAggregation(id, value);
     return;
   }
-  sqliteStore.setNeedsAggregation(id, value);
+  (await sqliteStore()).setNeedsAggregation(id, value);
 }
 
 export async function setJobCompleted(id: string, dockerRunDurationsMs?: number[]): Promise<void> {
@@ -126,7 +139,7 @@ export async function setJobCompleted(id: string, dockerRunDurationsMs?: number[
     await firestoreStore.setJobCompleted(id, dockerRunDurationsMs);
     return;
   }
-  sqliteStore.setJobCompleted(id, { dockerRunDurationsMs });
+  (await sqliteStore()).setJobCompleted(id, { dockerRunDurationsMs });
 }
 
 export async function setJobFailed(id: string, errorMessage: string, dockerRunDurationsMs?: number[]): Promise<void> {
@@ -134,7 +147,7 @@ export async function setJobFailed(id: string, errorMessage: string, dockerRunDu
     await firestoreStore.setJobFailed(id, errorMessage);
     return;
   }
-  sqliteStore.setJobFailed(id, errorMessage, { dockerRunDurationsMs });
+  (await sqliteStore()).setJobFailed(id, errorMessage, { dockerRunDurationsMs });
 }
 
 export async function setJobResults(jobId: string, results: JobResults): Promise<void> {
@@ -142,14 +155,14 @@ export async function setJobResults(jobId: string, results: JobResults): Promise
     await firestoreStore.setJobResults(jobId, results);
     return;
   }
-  sqliteStore.setJobResults(jobId, results);
+  (await sqliteStore()).setJobResults(jobId, results);
 }
 
 export async function claimNextJob(): Promise<Job | null> {
   if (USE_FIRESTORE) {
     return firestoreStore.claimNextJob();
   }
-  const job = sqliteStore.claimNextJob();
+  const job = (await sqliteStore()).claimNextJob();
   return job ?? null;
 }
 
@@ -157,7 +170,7 @@ export async function cancelJob(id: string): Promise<boolean> {
   if (USE_FIRESTORE) {
     return firestoreStore.cancelJob(id);
   }
-  return sqliteStore.cancelJob(id);
+  return (await sqliteStore()).cancelJob(id);
 }
 
 export async function deleteJob(id: string): Promise<void> {
@@ -165,7 +178,7 @@ export async function deleteJob(id: string): Promise<void> {
     await firestoreStore.deleteJob(id);
     return;
   }
-  sqliteStore.deleteJob(id);
+  (await sqliteStore()).deleteJob(id);
 }
 
 // ─── Per-Simulation Tracking ─────────────────────────────────────────────────
@@ -175,7 +188,7 @@ export async function initializeSimulations(jobId: string, count: number): Promi
     await firestoreStore.initializeSimulations(jobId, count);
     return;
   }
-  sqliteStore.initializeSimulations(jobId, count);
+  (await sqliteStore()).initializeSimulations(jobId, count);
 }
 
 export async function updateSimulationStatus(
@@ -187,28 +200,28 @@ export async function updateSimulationStatus(
     await firestoreStore.updateSimulationStatus(jobId, simId, update);
     return;
   }
-  sqliteStore.updateSimulationStatus(jobId, simId, update);
+  (await sqliteStore()).updateSimulationStatus(jobId, simId, update);
 }
 
 export async function getSimulationStatus(jobId: string, simId: string): Promise<SimulationStatus | null> {
   if (USE_FIRESTORE) {
     return firestoreStore.getSimulationStatus(jobId, simId);
   }
-  return sqliteStore.getSimulationStatus(jobId, simId);
+  return (await sqliteStore()).getSimulationStatus(jobId, simId);
 }
 
 export async function getSimulationStatuses(jobId: string): Promise<SimulationStatus[]> {
   if (USE_FIRESTORE) {
     return firestoreStore.getSimulationStatuses(jobId);
   }
-  return sqliteStore.getSimulationStatuses(jobId);
+  return (await sqliteStore()).getSimulationStatuses(jobId);
 }
 
 export async function resetJobForRetry(id: string): Promise<boolean> {
   if (USE_FIRESTORE) {
     return firestoreStore.resetJobForRetry(id);
   }
-  return sqliteStore.resetJobForRetry(id);
+  return (await sqliteStore()).resetJobForRetry(id);
 }
 
 export async function deleteSimulations(jobId: string): Promise<void> {
@@ -216,7 +229,7 @@ export async function deleteSimulations(jobId: string): Promise<void> {
     await firestoreStore.deleteSimulations(jobId);
     return;
   }
-  sqliteStore.deleteSimulations(jobId);
+  (await sqliteStore()).deleteSimulations(jobId);
 }
 
 /**
@@ -231,7 +244,7 @@ export async function incrementCompletedSimCount(
     return firestoreStore.incrementCompletedSimCount(jobId);
   }
   // Local mode fallback: count from simulation statuses
-  const sims = sqliteStore.getSimulationStatuses(jobId);
+  const sims = (await sqliteStore()).getSimulationStatuses(jobId);
   const completedSimCount = sims.filter(s => s.state === 'COMPLETED' || s.state === 'CANCELLED').length;
   return { completedSimCount, totalSimCount: sims.length };
 }
@@ -247,7 +260,7 @@ export async function conditionalUpdateSimulationStatus(
   if (USE_FIRESTORE) {
     return firestoreStore.conditionalUpdateSimulationStatus(jobId, simId, expectedStates, update);
   }
-  return sqliteStore.conditionalUpdateSimulationStatus(jobId, simId, expectedStates, update);
+  return (await sqliteStore()).conditionalUpdateSimulationStatus(jobId, simId, expectedStates, update);
 }
 
 /**

--- a/api/lib/worker-store-factory.ts
+++ b/api/lib/worker-store-factory.ts
@@ -3,57 +3,66 @@
  * otherwise to SQLite (worker-store).
  */
 import type { WorkerInfo } from './types';
-import * as sqliteStore from './worker-store';
 import * as firestoreStore from './firestore-worker-store';
 
 const USE_FIRESTORE = typeof process.env.GOOGLE_CLOUD_PROJECT === 'string' && process.env.GOOGLE_CLOUD_PROJECT.length > 0;
+
+// Lazy dynamic import — see job-store-factory.ts for rationale.
+type SqliteWorkerStore = typeof import('./worker-store');
+let _sqliteStore: SqliteWorkerStore | null = null;
+async function sqliteStore(): Promise<SqliteWorkerStore> {
+  if (!_sqliteStore) {
+    _sqliteStore = await import('./worker-store');
+  }
+  return _sqliteStore;
+}
 
 export async function upsertHeartbeat(info: WorkerInfo): Promise<void> {
   if (USE_FIRESTORE) {
     await firestoreStore.upsertHeartbeat(info);
     return;
   }
-  sqliteStore.upsertHeartbeat(info);
+  (await sqliteStore()).upsertHeartbeat(info);
 }
 
 export async function getActiveWorkers(staleThresholdMs = 60_000): Promise<WorkerInfo[]> {
   if (USE_FIRESTORE) {
     return firestoreStore.getActiveWorkers(staleThresholdMs);
   }
-  return sqliteStore.getActiveWorkers(staleThresholdMs);
+  return (await sqliteStore()).getActiveWorkers(staleThresholdMs);
 }
 
 export async function getMaxConcurrentOverride(workerId: string): Promise<number | null> {
   if (USE_FIRESTORE) {
     return firestoreStore.getMaxConcurrentOverride(workerId);
   }
-  return sqliteStore.getMaxConcurrentOverride(workerId);
+  return (await sqliteStore()).getMaxConcurrentOverride(workerId);
 }
 
 export async function setMaxConcurrentOverride(workerId: string, override: number | null): Promise<boolean> {
   if (USE_FIRESTORE) {
     return firestoreStore.setMaxConcurrentOverride(workerId, override);
   }
-  return sqliteStore.setMaxConcurrentOverride(workerId, override);
+  return (await sqliteStore()).setMaxConcurrentOverride(workerId, override);
 }
 
 export async function getWorkerApiUrl(workerId: string): Promise<string | null> {
   if (USE_FIRESTORE) {
     return firestoreStore.getWorkerApiUrl(workerId);
   }
-  return sqliteStore.getWorkerApiUrl(workerId);
+  return (await sqliteStore()).getWorkerApiUrl(workerId);
 }
 
 export async function getOwnerEmail(workerId: string): Promise<string | null> {
   if (USE_FIRESTORE) {
     return firestoreStore.getOwnerEmail(workerId);
   }
-  return sqliteStore.getOwnerEmail(workerId);
+  return (await sqliteStore()).getOwnerEmail(workerId);
 }
 
 export async function getQueueDepth(): Promise<number> {
   if (USE_FIRESTORE) {
     return firestoreStore.getQueueDepth();
   }
-  return sqliteStore.getQueueDepth();
+  return (await sqliteStore()).getQueueDepth();
 }


### PR DESCRIPTION
## Summary

Replaces static imports of SQLite-backed stores in \`job-store-factory\`, \`worker-store-factory\`, and \`coverage-store-factory\` with lazy \`await import()\` calls, so the GCP container doesn't parse the SQLite schema setup in \`db.ts\` (and by extension the \`better-sqlite3\` native addon) at startup.

## Why

Part of the architectural audit after the OOM‑kills on the 512 MiB container. Static imports chained through:

\`\`\`
job-store-factory.ts
  → job-store.ts         (\`import { getDb } from './db'\`)
    → db.ts              (\`import Database from 'better-sqlite3'\`)
      → better-sqlite3   (native \`.node\` binding)
\`\`\`

In GCP mode these code paths are never executed, but webpack still pulled them into the route bundles because the imports were top-level. Dynamic \`await import()\` lets webpack emit the target as a code-split chunk so it only runs when first referenced.

Uses \`await import()\` rather than bare \`require()\` because of the lesson from TytaniumDev/MagicBracketSimulator#143: direct \`require()\` in a factory returned empty modules under the Next.js webpack bundle. \`import()\` is the webpack-safe escape hatch.

## What changes

- **\`api/lib/job-store-factory.ts\`**: static \`import * as sqliteStore\` → cached async getter; 23 call sites wrapped in \`(await sqliteStore()).x(...)\`
- **\`api/lib/worker-store-factory.ts\`**: same pattern; 7 call sites
- **\`api/lib/coverage-store-factory.ts\`**: \`getCoverageStore()\` now returns \`Promise<CoverageStore>\`
- **\`api/app/api/coverage/config/route.ts\`**, **\`.../next-job/route.ts\`**, **\`.../status/route.ts\`**: updated to \`await getCoverageStore()\`

No behavioral change in either GCP or LOCAL mode. Every call site is already inside an \`async\` function.

## Test plan

- [x] \`tsc --noEmit\` passes
- [x] \`next build\` succeeds
- [x] Pure-logic unit tests pass (state-machine, condenser/pipeline)
- [ ] CI lint / build / test pass on Linux runner
- [ ] After deploy: verify the coverage endpoints still return config (sanity check on the new async factory)
- [ ] After deploy: check Cloud Run RSS at idle — expected ~3‑5 MiB reduction from skipping the better-sqlite3 native load

Note on expected savings: the webpack-level impact is somewhat opaque because the build still emits the SQLite module code into chunks, but the code path that evaluates \`import Database from 'better-sqlite3'\` (which triggers the native addon bootstrap) should only run when the factory is first called — which never happens in GCP mode. Actual RSS delta will be measured post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)