### PR TITLE
fix(worker,api): slow heartbeat to 60s and drop per-beat Firestore read

### DIFF
--- a/api/app/api/workers/heartbeat/route.ts
+++ b/api/app/api/workers/heartbeat/route.ts
@@ -6,7 +6,19 @@ import { errorResponse, badRequestResponse } from '@/lib/api-response';
 
 /**
  * POST /api/workers/heartbeat — Worker heartbeat.
- * Called by workers every 15 seconds to report status.
+ *
+ * Writes the worker's current status to Firestore so the frontend knows
+ * which workers are online. Expected cadence: every 60 seconds
+ * (see HEARTBEAT_INTERVAL_MS in worker/src/worker.ts).
+ *
+ * Runtime concurrency overrides are delivered via the worker's own push
+ * HTTP API (POST /config) — the heartbeat response does NOT ship them on
+ * every beat, because the read was billing a Firestore read for every
+ * 15-second beat on data that almost never changes.
+ *
+ * Workers query for their initial override via `?initial=1` on their very
+ * first heartbeat after startup. That's the only path where the API does
+ * the extra Firestore read.
  */
 export async function POST(request: NextRequest) {
   if (!isWorkerRequest(request)) {
@@ -37,12 +49,20 @@ export async function POST(request: NextRequest) {
 
     await workerStore.upsertHeartbeat(info);
 
-    // Return any stored override so the worker can apply it dynamically
-    const override = await workerStore.getMaxConcurrentOverride(workerId);
-    return NextResponse.json({
-      ok: true,
-      ...(override !== null && override !== undefined && { maxConcurrentOverride: override }),
-    });
+    // Initial-sync beat only: return any stored override so the worker can
+    // pick up a setting set while it was offline. Subsequent beats skip
+    // the read to keep Firestore ops (and Cloud Run wake-ups) to one
+    // write per minute per worker.
+    const isInitialSync = new URL(request.url).searchParams.get('initial') === '1';
+    if (isInitialSync) {
+      const override = await workerStore.getMaxConcurrentOverride(workerId);
+      return NextResponse.json({
+        ok: true,
+        ...(override !== null && override !== undefined && { maxConcurrentOverride: override }),
+      });
+    }
+
+    return NextResponse.json({ ok: true });
   } catch (error) {
     console.error('POST /api/workers/heartbeat error:', error);
     return errorResponse(error instanceof Error ? error.message : 'Heartbeat failed', 500);

--- a/api/lib/firestore-worker-store.ts
+++ b/api/lib/firestore-worker-store.ts
@@ -33,8 +33,11 @@ export async function upsertHeartbeat(info: WorkerInfo): Promise<void> {
  * Get workers whose last heartbeat is within the stale threshold.
  * Workers with status 'updating' get a longer threshold (5 min) to remain
  * visible during Watchtower image pulls and container restarts.
+ *
+ * Default threshold is 3 minutes to give 3x headroom over the 60-second
+ * heartbeat cadence (see HEARTBEAT_INTERVAL_MS in worker/src/worker.ts).
  */
-export async function getActiveWorkers(staleThresholdMs = 60_000): Promise<WorkerInfo[]> {
+export async function getActiveWorkers(staleThresholdMs = 180_000): Promise<WorkerInfo[]> {
   const UPDATING_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes for updating workers
   const maxThreshold = Math.max(staleThresholdMs, UPDATING_THRESHOLD_MS);
   const cutoff = new Date(Date.now() - maxThreshold).toISOString();

--- a/api/lib/worker-store-factory.ts
+++ b/api/lib/worker-store-factory.ts
@@ -25,7 +25,7 @@ export async function upsertHeartbeat(info: WorkerInfo): Promise<void> {
   (await sqliteStore()).upsertHeartbeat(info);
 }
 
-export async function getActiveWorkers(staleThresholdMs = 60_000): Promise<WorkerInfo[]> {
+export async function getActiveWorkers(staleThresholdMs = 180_000): Promise<WorkerInfo[]> {
   if (USE_FIRESTORE) {
     return firestoreStore.getActiveWorkers(staleThresholdMs);
   }

--- a/api/lib/worker-store.ts
+++ b/api/lib/worker-store.ts
@@ -42,7 +42,7 @@ export function upsertHeartbeat(info: WorkerInfo): void {
  * Workers with status 'updating' get a longer threshold (5 min) to remain
  * visible during Watchtower image pulls and container restarts.
  */
-export function getActiveWorkers(staleThresholdMs = 60_000): WorkerInfo[] {
+export function getActiveWorkers(staleThresholdMs = 180_000): WorkerInfo[] {
   const db = getDb();
   const UPDATING_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes for updating workers
   const maxThreshold = Math.max(staleThresholdMs, UPDATING_THRESHOLD_MS);

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -540,12 +540,22 @@ function setDraining(drain: boolean): void {
   console.log(drain ? 'Drain mode enabled: no new work will be accepted' : 'Drain mode disabled: accepting work');
 }
 
+// Has this worker already done its startup `?initial=1` heartbeat?
+// Runtime concurrency overrides are delivered via the push API (POST /config
+// on the worker's own HTTP server), so every subsequent heartbeat is a
+// one-way status write and does NOT re-read the override from Firestore.
+// We only do the read on the very first beat after startup so a worker that
+// was offline while an override was set still picks it up.
+let initialHeartbeatDone = false;
+
 /**
  * Send a heartbeat to the API so the frontend knows this worker is online.
- * Parses the response for dynamic concurrency overrides.
+ * On the first call (after startup), requests the stored concurrency
+ * override via `?initial=1`. Subsequent calls skip the override read.
  */
 async function sendHeartbeat(status?: 'idle' | 'busy' | 'updating', timeoutMs?: number): Promise<void> {
-  const url = `${getApiUrl()}/api/workers/heartbeat`;
+  const isInitial = !initialHeartbeatDone;
+  const url = `${getApiUrl()}/api/workers/heartbeat${isInitial ? '?initial=1' : ''}`;
   const resolvedStatus = status ?? (activeSimCount > 0 ? 'busy' : 'idle');
   try {
     const res = await fetch(url, {
@@ -568,10 +578,14 @@ async function sendHeartbeat(status?: 'idle' | 'busy' | 'updating', timeoutMs?: 
       return;
     }
 
-    // Parse response for concurrency override
-    const data = await res.json() as { ok: boolean; maxConcurrentOverride?: number };
-    if (status !== 'updating') {
+    // Only the initial sync response carries an override; apply it exactly
+    // once. After that, runtime changes arrive via the push /config path.
+    if (isInitial && status !== 'updating') {
+      const data = await res.json() as { ok: boolean; maxConcurrentOverride?: number };
       applyOverride(data.maxConcurrentOverride ?? null);
+      initialHeartbeatDone = true;
+    } else {
+      initialHeartbeatDone = true;
     }
   } catch (err) {
     log.warn('Heartbeat error', { error: err instanceof Error ? err.message : err });
@@ -1018,7 +1032,11 @@ async function main(): Promise<void> {
 
   // Initial heartbeat (await to apply override before Pub/Sub starts)
   await sendHeartbeat();
-  const HEARTBEAT_INTERVAL_MS = parseInt(process.env.HEARTBEAT_INTERVAL_MS || '15000', 10);
+  // 60s default: the heartbeat exists only so the frontend can show "worker
+  // online" within ~1-2 minutes. More frequent beats burned Firestore writes
+  // and kept the API container warm 24/7 (defeating minInstances: 0) with
+  // 2 workers beating every 15s → 11,520 writes/day.
+  const HEARTBEAT_INTERVAL_MS = parseInt(process.env.HEARTBEAT_INTERVAL_MS || '60000', 10);
   heartbeatInterval = setInterval(() => sendHeartbeat(), HEARTBEAT_INTERVAL_MS);
 
   // Periodic Docker cleanup (every hour) to free disk space

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -583,10 +583,12 @@ async function sendHeartbeat(status?: 'idle' | 'busy' | 'updating', timeoutMs?: 
     if (isInitial && status !== 'updating') {
       const data = await res.json() as { ok: boolean; maxConcurrentOverride?: number };
       applyOverride(data.maxConcurrentOverride ?? null);
-      initialHeartbeatDone = true;
     } else {
-      initialHeartbeatDone = true;
+      // Drain the response body so fetch doesn't leak the underlying
+      // connection / stream when we don't care about the payload.
+      await res.body?.cancel();
     }
+    initialHeartbeatDone = true;
   } catch (err) {
     log.warn('Heartbeat error', { error: err instanceof Error ? err.message : err });
   }


### PR DESCRIPTION
## Summary

Fixes the single biggest Firestore-quota leak in the app: worker heartbeats were burning ~23k Firestore ops/day with 2 workers, for data the worker already had in memory.

## Problem

\`worker/src/worker.ts:1021\` defaulted \`HEARTBEAT_INTERVAL_MS\` to \`15000\`, so every worker POSTed to \`/api/workers/heartbeat\` 4x per minute. The API handler did one Firestore **write** (\`upsertHeartbeat\`) **plus** one Firestore **read** (\`getMaxConcurrentOverride\`) every single call.

With 2 active workers (as reported by \`/api/health\`):

| Metric | Before | Free tier / day |
|---|---:|---:|
| Firestore writes | 11,520 / day | 20,000 |
| Firestore reads | 11,520 / day | 50,000 |
| API container wake-ups | ~every 7.5s | — |

Two problems compounding:
1. Over half of the daily Firestore write quota spent on heartbeats.
2. The constant stream of incoming requests kept the Cloud Run container warm 24/7, so \`minInstances: 0\` in \`apphosting.yaml\` was effectively a lie — we were paying for a continuously-running container.

## Fix

### 1. Bump heartbeat interval to 60s (worker)

\`HEARTBEAT_INTERVAL_MS\` default: \`15000\` → \`60000\`. The heartbeat exists so the frontend can show "worker online" within a minute or two; nothing needs 15-second granularity.

### 2. Only read the override on the *first* heartbeat after startup

Runtime concurrency overrides are already push-delivered: when an admin changes a worker's \`maxConcurrentOverride\` via \`PATCH /api/workers/:id\`, the API calls \`pushToWorker(workerApiUrl, '/config', { maxConcurrentOverride })\` (\`api/app/api/workers/[id]/route.ts:49\`), which hits the worker's local HTTP server at \`POST /config\` (\`worker/src/worker-api.ts:118\`). No Firestore round-trip needed.

The only case where a worker *must* read the override from Firestore is right after it starts up — an admin may have set the override while the worker was offline. So:

- Worker sends \`?initial=1\` on its very first heartbeat after startup; API responds with the stored override.
- All subsequent beats omit the query param; API returns \`{ok: true}\` with no read.
- \`initialHeartbeatDone\` flag gates this in the worker; retries until successful.

### 3. Bump stale-worker threshold from 60s → 180s

\`firestore-worker-store.ts\` and \`worker-store.ts\` both default \`getActiveWorkers(staleThresholdMs = 60_000)\`. With 60s heartbeats, 60s threshold = 0 beats of slack and a worker would flicker in/out of "online" on every hop. Bumped to 180s for 3x headroom.

## Math

| | Before (2 workers) | After (2 workers) | Δ |
|---|---:|---:|---:|
| Firestore writes / day | 11,520 | 2,880 | **−75%** |
| Firestore reads / day | 11,520 | ~2 (one per worker startup) | **−99.9%** |
| Total ops / day | 23,040 | 2,882 | **−87.5%** |
| API container wake-ups / day | 11,520 | 2,880 | **−75%** |

Still well under the 20k/day write quota even with room to grow to 4-6 workers.

## Test plan

- [x] \`tsc --noEmit\` passes in both \`api/\` and \`worker/\`
- [ ] CI lint / build / test pass
- [ ] After deploy: verify workers show as online on the frontend within ~2 min of starting
- [ ] After deploy: set a concurrency override via admin UI → verify worker picks it up via push (not the old heartbeat path) within a few seconds
- [ ] After deploy: restart a worker → verify it picks up any pre-existing override on its first heartbeat
- [ ] Measure: Firestore writes should drop sharply in Cloud Monitoring
- [ ] Measure: Cloud Run container idle time should finally exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)