### PR TITLE
fix(api): stop running stale-job recovery on every GET /api/jobs/[id]

### DIFF
--- a/api/app/api/jobs/[id]/route.ts
+++ b/api/app/api/jobs/[id]/route.ts
@@ -114,21 +114,17 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return badRequestResponse('Job ID is required');
     }
 
-    let job = await jobStore.getJob(id);
+    const job = await jobStore.getJob(id);
     if (!job) {
       return notFoundResponse('Job');
     }
 
-    // Attempt stale job recovery for RUNNING or stuck QUEUED jobs
-    if (job.status === 'RUNNING' || job.status === 'QUEUED') {
-      const recovered = await jobStore.recoverStaleJob(id);
-      if (recovered) {
-        job = await jobStore.getJob(id);
-        if (!job) {
-          return notFoundResponse('Job');
-        }
-      }
-    }
+    // Recovery of stuck jobs is handled out-of-band by the scheduled
+    // stale-sweeper (/api/admin/sweep-stale-jobs via Cloud Scheduler, see
+    // docs/STALE_SWEEPER.md). Keeping it out of the GET hot path: a frontend
+    // poll against a 20-sim job used to fan out to ~22 Firestore reads per
+    // call (job + active workers + every sim doc), which burned through the
+    // 50k/day Firestore free tier in minutes of watching a running job.
 
     const response = await jobToApiResponse(job, isWorker);
     return NextResponse.json(response);


### PR DESCRIPTION
## Summary

Removes the \`recoverStaleJob()\` call from the hot path of \`GET /api/jobs/[id]\`. Recovery is already handled out-of-band by the scheduled stale-sweeper introduced in TytaniumDev/MagicBracketSimulator#147.

## Why this is the biggest free-tier leak after #150

\`api/app/api/jobs/[id]/route.ts\` ran \`recoverStaleJob()\` on every GET for a RUNNING or QUEUED job. Looking at what that actually costs (\`api/lib/job-store-factory.ts:262\` → \`recoverStaleSimulations\`):

1. Re-read the job doc
2. \`getActiveWorkers(120_000)\` — query the workers collection
3. \`getSimulationStatuses(jobId)\` — **read every sim doc** in the subcollection

For a 20-simulation job, a single frontend poll fans out to ~22 Firestore reads. The job-status page polls every few seconds while the user watches a job tick. One user watching one job for an hour burns through the entire 50k/day Firestore read quota.

It also explains why \`/api/jobs/Am3ts6Iax0aO3vem881Y\` appeared **25 times in 3 minutes** in the OOM logs: each GET pulled the whole sim array into memory, sometimes concurrently under polling, and the 512 MiB container couldn't hold them.

## Why it's safe to remove

The stale-sweeper (docs/STALE_SWEEPER.md) already runs \`recoverStaleJob()\` for every active job every 15 minutes via Cloud Scheduler hitting \`/api/admin/sweep-stale-jobs\`. The GET-path recovery was a best-effort duplicate — "recover when someone asks" — which was unnecessary once a scheduled path existed.

The tradeoff: a stuck job that becomes stuck right after a user opens its page won't auto-recover in real time; it'll recover on the next 15-minute sweep. For a hobby app that's the right balance.

## Test plan

- [x] \`tsc --noEmit\` passes
- [ ] CI lint / build / test pass
- [ ] After deploy: load an active job in the UI → confirm it still shows live sim updates (those come from Firestore \`onSnapshot\`, not this endpoint)
- [ ] After deploy: watch Firestore read meter in Cloud Monitoring during a polling job-status session — should drop by 10-20x
- [ ] Sanity check: verify the stale-sweeper Cloud Scheduler job is still enabled (\`gcloud scheduler jobs list --project=magic-bracket-simulator --location=us-central1\` → \`stale-sweeper ENABLED\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)