### PR TITLE
revert: drop api memory back to 512MiB

### DIFF
--- a/api/apphosting.yaml
+++ b/api/apphosting.yaml
@@ -2,10 +2,7 @@
 runConfig:
   minInstances: 0
   maxInstances: 1
-  # Bumped from 512MiB → 1GiB: container was OOM-killing at ~520-535 MiB under
-  # normal load, causing Envoy to return 503 "upstream connect error" which
-  # surfaces in the browser as "Failed to fetch" on routes like /leaderboard.
-  memory: 1GiB
+  memory: 512MiB
   cpu: 1
   concurrency: 80
 


### PR DESCRIPTION
## Summary

Reverts the \`memory: 1GiB\` bump from TytaniumDev/MagicBracketSimulator#146. With the architectural fixes from #148–#152 landed, the container should fit comfortably in 512 MiB again.

## Context

#146 was a band-aid. The real problem was a combination of:

| PR | Fix |
|---|---|
| TytaniumDev/MagicBracketSimulator#148 | Collapsed 7 \`new Firestore({...})\` instances into a shared singleton. Each instance had its own gRPC channel + protobuf descriptor table (~10–20 MiB RSS each). |
| TytaniumDev/MagicBracketSimulator#149 | Made SQLite stores (\`job-store\`, \`worker-store\`, \`coverage-store-sqlite\`) lazy-loaded via \`await import()\` so the GCP container never parses the SQLite schema setup or loads the \`better-sqlite3\` native addon. |
| TytaniumDev/MagicBracketSimulator#150 | Slowed worker heartbeats from 15s → 60s and dropped the per-beat Firestore read. The Cloud Run container is no longer warm 24/7, so \`minInstances: 0\` actually means something now. |
| TytaniumDev/MagicBracketSimulator#151 | Stopped calling \`recoverStaleJob()\` on every \`GET /api/jobs/[id]\`. Each of those calls was fanning out to N+2 Firestore reads and loading the full sim array into memory — the direct cause of the 25 OOMs in 3 minutes on that route. |
| TytaniumDev/MagicBracketSimulator#152 | Moved the 24-hour precon sync out of \`instrumentation.ts\` and into Cloud Scheduler, eliminating a background fetch that could race with normal request handling. |

The 512 MiB ceiling was failing in #146 because every route carried the fixed cost of 7 redundant gRPC clients plus constant traffic from heartbeats and aggressive polling. Both pressures are gone now.

## Risk

Low. If the container OOMs again at 512 MiB, that's a signal the architectural work isn't complete — not that we should bump memory. The right response would be to diagnose which request is consuming memory, not to mask it.

Worst case: OOMs come back and we revert this revert. \`apphosting.yaml\` is a one-line change, trivial to roll back.

## Test plan

- [ ] CI lint / build / test pass
- [ ] After deploy: monitor Cloud Run RSS for 24 hours
- [ ] After deploy: verify no new "Memory limit of 512 MiB exceeded" log entries in Cloud Logging
- [ ] After deploy: hit \`/leaderboard\` and \`/api/jobs/\[id\]\` to confirm no 503s
- [ ] Check Cloud Run billing meters — free-tier runway should be much longer now that the container idles properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)