### PR TITLE
ci: add Firebase App Hosting rollout safety net

### DIFF
--- a/.github/workflows/rollout-safety-net.yml
+++ b/.github/workflows/rollout-safety-net.yml
@@ -1,0 +1,174 @@
+# Firebase App Hosting auto-rollout safety net.
+#
+# Problem this solves
+# -------------------
+# On 2026-04-10, two separate merges to `main` produced a successful Cloud
+# Build + healthy Cloud Run revision, but Firebase App Hosting silently did
+# NOT create a rollout resource to shift traffic. The fix was to `POST` a
+# rollout via the REST API manually. Without that, traffic sat on an old
+# revision indefinitely. The rolloutPolicy on the `api` backend is vanilla
+# (`{codebaseBranch: main}`) — there's nothing in our config that would gate
+# auto-rollouts, so this is almost certainly a transient control-plane bug
+# on the Firebase App Hosting side.
+#
+# What this workflow does
+# -----------------------
+# On every push to `main`:
+#   1. Wait up to 10 minutes for a READY build matching the pushed commit SHA
+#      to appear in `/v1/.../backends/api/builds`
+#   2. Poll `/v1/.../backends/api/rollouts` for up to 5 more minutes checking
+#      whether any rollout references that build
+#   3. If no rollout appeared, create one via
+#      `POST /v1/.../backends/api/rollouts?rolloutId=...`
+#   4. File a GitHub issue so we're aware the safety net fired
+#
+# Auth: keyless via Workload Identity Federation, using a dedicated service
+# account (`rollout-safety-net`) with `roles/firebaseapphosting.admin`.
+# No long-lived keys stored anywhere.
+#
+# Cost: $0. The workflow is a few curl calls; WIF is free.
+#
+# Security: only consumes trusted inputs (github.sha, github.repository). All
+# values are passed to shell via env: to avoid any ${{ }} interpolation inside
+# run: blocks.
+
+name: Rollout Safety Net
+
+on:
+  push:
+    branches: [main]
+
+# Never cancel an in-flight safety net — if two pushes land quickly, each
+# needs to verify its own commit's rollout.
+concurrency:
+  group: rollout-safety-net-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # WIF OIDC exchange
+  issues: write # So we can file an issue when the safety net fires
+
+jobs:
+  ensure-rollout:
+    name: Ensure App Hosting rollout exists
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: magic-bracket-simulator
+          workload_identity_provider: projects/14286370379/locations/global/workloadIdentityPools/github/providers/magic-bracket-repo
+          service_account: rollout-safety-net@magic-bracket-simulator.iam.gserviceaccount.com
+
+      - name: Poll for build, verify rollout, auto-create if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+
+          API="https://firebaseapphosting.googleapis.com/v1/projects/magic-bracket-simulator/locations/us-central1/backends/api"
+
+          get() {
+            curl -sS -H "Authorization: Bearer $(gcloud auth print-access-token)" "$@"
+          }
+
+          # ── 1. Wait for a READY build matching this commit (up to 10 min) ──
+          BUILD_NAME=""
+          BUILD_ID=""
+          echo "Polling for build matching commit ${COMMIT}..."
+          for i in $(seq 1 60); do
+            sleep 10
+            BUILD_JSON=$(get "$API/builds?pageSize=100") || BUILD_JSON='{}'
+            BUILD_NAME=$(echo "$BUILD_JSON" | jq -r --arg sha "$COMMIT" '
+              .builds // []
+              | map(select(
+                  (.source.codebase.hash // "") == $sha
+                  and .state == "READY"
+                ))
+              | sort_by(.createTime)
+              | last
+              | .name // empty
+            ')
+            if [ -n "$BUILD_NAME" ]; then
+              BUILD_ID=$(basename "$BUILD_NAME")
+              echo "Build ready: $BUILD_ID"
+              break
+            fi
+            echo "  [$i/60] No READY build yet for $COMMIT"
+          done
+
+          if [ -z "$BUILD_NAME" ]; then
+            echo "::warning::No READY Firebase App Hosting build for commit $COMMIT after 10 minutes. Either the build is still running, the build failed, or this commit doesn't trigger an App Hosting build. Exiting without action."
+            exit 0
+          fi
+
+          # ── 2. Check whether a rollout already references this build ──
+          # Healthy path: auto-rollout fires within ~60 ms of build createTime,
+          # so by the time the build is READY a rollout should almost always
+          # already exist. Poll for up to 5 more minutes as a buffer.
+          echo "Polling for rollout referencing $BUILD_ID..."
+          ROLLOUT_NAME=""
+          for i in $(seq 1 30); do
+            ROLLOUTS_JSON=$(get "$API/rollouts?pageSize=1000") || ROLLOUTS_JSON='{}'
+            ROLLOUT_NAME=$(echo "$ROLLOUTS_JSON" | jq -r --arg b "$BUILD_NAME" '
+              .rollouts // []
+              | map(select(.build == $b))
+              | sort_by(.createTime)
+              | last
+              | .name // empty
+            ')
+            if [ -n "$ROLLOUT_NAME" ]; then
+              echo "Rollout exists: $(basename "$ROLLOUT_NAME")"
+              echo "Nothing to do — auto-rollout fired normally."
+              exit 0
+            fi
+            echo "  [$i/30] No rollout yet for $BUILD_ID"
+            sleep 10
+          done
+
+          # ── 3. Auto-create the missing rollout ──
+          ROLLOUT_ID="rollout-safety-net-$(date -u +%Y%m%d-%H%M%S)-${COMMIT:0:7}"
+          echo "::warning::App Hosting auto-rollout did not fire for build $BUILD_ID (commit $COMMIT). Creating rollout $ROLLOUT_ID manually."
+
+          CREATE_BODY=$(jq -nc --arg b "$BUILD_NAME" '{build: $b}')
+          CREATE_RESULT=$(get -X POST \
+            -H "Content-Type: application/json" \
+            -d "$CREATE_BODY" \
+            "$API/rollouts?rolloutId=$ROLLOUT_ID")
+          echo "$CREATE_RESULT"
+
+          # Verify the create actually registered (the response is an Operation,
+          # not the rollout itself, so a second read is the only way to be sure)
+          sleep 5
+          VERIFY=$(get "$API/rollouts/$ROLLOUT_ID") || VERIFY=''
+          if ! echo "$VERIFY" | jq -e '.build' >/dev/null 2>&1; then
+            echo "::error::Manual rollout POST returned success but rollout resource is not visible. Check Firebase App Hosting console."
+            exit 1
+          fi
+
+          # ── 4. File a GitHub issue so we know the safety net fired ──
+          ISSUE_TITLE="Rollout safety net fired for ${COMMIT:0:7}"
+          ISSUE_BODY=$(printf '%s\n' \
+            "Firebase App Hosting's auto-rollout did not fire for a merge to \`main\`. The rollout safety net caught it and created \`${ROLLOUT_ID}\` manually." \
+            "" \
+            "- **Build:** \`${BUILD_ID}\`" \
+            "- **Commit:** \`${COMMIT}\`" \
+            "- **Merge:** ${SERVER_URL}/${REPO}/commit/${COMMIT}" \
+            "- **Created rollout:** \`${ROLLOUT_ID}\`" \
+            "" \
+            "This is almost certainly the same Firebase App Hosting control-plane glitch first seen on 2026-04-10 (two silent skips in one day). The deployed revision should be serving traffic normally now, but the pattern is worth tracking — if it keeps happening, escalate to Firebase support." \
+            "" \
+            "Upstream tracking: https://github.com/firebase/firebase-tools/issues/8866 and the Firebase status page." \
+            "" \
+            "_Filed automatically by \`.github/workflows/rollout-safety-net.yml\`._")
+
+          gh issue create \
+            --repo "$REPO" \
+            --title "$ISSUE_TITLE" \
+            --body "$ISSUE_BODY" \
+            --label "bug" || echo "::warning::Failed to file safety-net issue (non-fatal)"


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/rollout-safety-net.yml\`. On every push to \`main\`, it verifies that Firebase App Hosting actually created a rollout for the new build — and if it didn't, creates one manually and files an issue so we notice. Uses keyless auth (Workload Identity Federation) with a dedicated service account; no long-lived keys stored anywhere.

## Why

On 2026-04-10 two merges to \`main\` produced successful Cloud Builds + healthy Cloud Run revisions, but Firebase App Hosting silently did **not** create a rollout resource to shift traffic. Both times the fix was \`POST /v1/.../backends/api/rollouts\` via the REST API. Without that, traffic sat on an old revision indefinitely — tonight I caught it in ~15 minutes by watching logs, but an unattended deploy could sit stuck for hours.

A read-only forensics pass (separate subagent investigation, findings summarized in the commit) ruled out every config-side explanation:

- \`rolloutPolicy\` is vanilla \`{ codebaseBranch: main }\` — no \`disabled\`, no \`cooldownDuration\`, no rate limit
- The two affected builds are field-for-field identical to the seven healthy ones that auto-rolled out today
- Healthy auto-rollouts are created within ~60 ms of build \`createTime\`, not queued / deferred, so "cooldown after rapid deploys" doesn't fit
- No hanging long-running operations, no quota-denied log entries
- Related upstream report: TytaniumDev/MagicBracketSimulator#\( firebase/firebase-tools#8866 \) and a past Firebase status incident

It's almost certainly a transient Firebase App Hosting control-plane glitch, which means we can't fix the root cause on our side — we can only detect and recover. This workflow does exactly that.

## What the workflow does

On \`push: branches: [main]\`:

1. Authenticates to GCP via WIF (keyless, no secrets)
2. Polls \`GET .../backends/api/builds\` for up to 10 min looking for a \`READY\` build whose \`source.codebase.hash\` matches \`github.sha\`
3. Once the build is found, polls \`GET .../backends/api/rollouts\` for up to 5 min looking for a rollout that references that build
4. If no rollout appears, \`POST .../backends/api/rollouts?rolloutId=rollout-safety-net-<date>-<shortsha>\` with the build reference
5. Verifies the rollout resource exists via a follow-up GET
6. Files a GitHub issue titled \`Rollout safety net fired for <shortsha>\` with the details

Happy path (auto-rollout fires normally): the workflow finds the rollout within the first few seconds of step 3 and exits silently with zero side effects. Only fires on the pathological case.

## Auth / infrastructure

- **Service account**: \`rollout-safety-net@magic-bracket-simulator.iam.gserviceaccount.com\` (dedicated, least-privilege)
- **Role**: \`roles/firebaseapphosting.admin\` (needed for builds.list + rollouts.list + rollouts.create)
- **WIF binding**: \`roles/iam.workloadIdentityUser\` for \`principalSet://iam.googleapis.com/projects/14286370379/locations/global/workloadIdentityPools/github/attribute.repository/TytaniumDev/MagicBracketSimulator\`
- **No long-lived keys.** I briefly created a JSON key during setup while I wasn't aware of the existing WIF provider, then immediately revoked it and removed the temporary GitHub secret. All current auth is keyless.

The workflow piggy-backs on the same WIF provider (\`projects/14286370379/locations/global/workloadIdentityPools/github/providers/magic-bracket-repo\`) that the existing \`deploy.yml\` uses — no new WIF infrastructure.

## Security

Only trusted inputs are consumed: \`github.sha\`, \`github.repository\`, \`github.server_url\`. All are passed to shell via \`env:\` rather than direct \`\${{ }}\` interpolation inside \`run:\` blocks, per GitHub's workflow injection guidance. Verified clean by \`rhysd/actionlint:latest\`.

## Cost

\$0. A handful of curl calls per push, WIF is free, no running containers.

## Test plan

- [x] \`actionlint\` passes with zero warnings
- [x] Service account exists, has \`firebaseapphosting.admin\`, and WIF binding is verified via \`gcloud iam service-accounts get-iam-policy\`
- [x] jq queries verified live against commit \`f6467654a5\` (the PR #154 merge that was silently skipped earlier tonight) — the workflow correctly identifies \`build-2026-04-10-011\` and the manual rollout I had to create
- [ ] CI lint / workflow-lint pass on this PR
- [ ] **First real test**: this PR's own merge will trigger the workflow. Expected outcome: healthy path, rollout exists within ~60 ms of build creation, workflow exits silently.
- [ ] Simulated pathological path: if the Firebase glitch recurs in the future, the workflow should catch it. Hard to test proactively without Firebase SRE cooperation.

## Rollback

If something goes wrong, delete \`.github/workflows/rollout-safety-net.yml\` and the workflow stops running. The service account can be cleaned up via \`gcloud iam service-accounts delete rollout-safety-net@magic-bracket-simulator.iam.gserviceaccount.com\` if desired, but there's no cost to leaving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)