### PR TITLE
chore: architectural review cleanup and follow-ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,13 @@ agent-plans/
 /next.config.js
 /sentry.*.js
 /pages/
+
+# Playwright E2E ephemera
+frontend/test-results/
+frontend/playwright-report/
+frontend/blob-report/
+frontend/playwright/.cache/
+
+# Claude Code temp worktrees + MCP state
+.claude/worktrees/
+.playwright-mcp/

--- a/DATA_FLOW.md
+++ b/DATA_FLOW.md
@@ -38,11 +38,34 @@ parsing:
 | Step | Endpoint                                     | Data sent                                                                                                                                               |
 | ---- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1    | **PATCH** `/api/jobs/:id/simulations/:simId` | Status update: `state`, `workerId`, `workerName`, `durationMs`, `winners[]`, `winningTurns[]` (and on failure: `errorMessage`). Small JSON; no raw log. |
-| 2    | **POST** `/api/jobs/:id/logs/simulation`     | Raw log upload: `{ filename, logText }`. `logText` is the full raw log string (can be large).                                                           |
+| 2    | **POST** `/api/jobs/:id/logs/simulation`     | Raw log upload: `{ filename, logText }`. `logText` is bounded to **10 MB** (`MAX_LOG_BYTES` in `api/lib/log-store.ts`); oversize uploads are rejected with HTTP 413.                                                          |
 
 
 Order in code: status is reported first (PATCH), then raw log is uploaded
 (POST).
+
+**Log upload size cap:** `POST /api/jobs/:id/logs/simulation` enforces the
+10 MB `MAX_LOG_BYTES` cap in three places:
+
+1. **Content-Length header check** — rejects early with HTTP 413 before
+   buffering the body into memory.
+2. **Streaming byte counter** — reads the request body as a `ReadableStream`,
+   accumulates chunks, and aborts with HTTP 413 as soon as the running total
+   exceeds the cap plus JSON envelope overhead. This closes the
+   `Transfer-Encoding: chunked` bypass where the Content-Length header is
+   absent.
+3. **Library defense-in-depth** — `uploadSingleSimulationLog()` in
+   `api/lib/log-store.ts` re-checks `Buffer.byteLength(logText)` and throws
+   before writing to GCS / the local filesystem.
+
+**Worker behavior on 413:** the worker logs a warning and continues — it does
+NOT retry the upload or fail the simulation. The simulation's status update
+(step 1) has already been persisted, so the sim is reported as COMPLETED
+without its raw log. The aggregation pipeline tolerates missing per-sim logs
+(it falls back to whatever logs did upload). Operators: if you see
+`[sim_NNN] Log upload failed: HTTP 413` in the worker logs, a Forge run
+produced an unexpectedly large log — investigate the game (infinite loop?
+runaway card interaction?) rather than raising the cap.
 
 ---
 

--- a/api/app/api/admin/backfill-ratings/route.ts
+++ b/api/app/api/admin/backfill-ratings/route.ts
@@ -28,7 +28,10 @@ export async function POST(request: NextRequest) {
 
   try {
     const store = getRatingStore();
-    const jobs = await jobStore.listJobs();
+    // Backfill walks whichever jobs are in the current page cap. For full
+    // history rebuilds, call the endpoint repeatedly with `?cursor=…` once
+    // the paginated contract is exposed here (see docs/BACKFILL.md).
+    const { jobs } = await jobStore.listJobs({ limit: 200 });
 
     for (const job of jobs) {
       if (!job) continue;

--- a/api/app/api/admin/sweep-stale-jobs/route.ts
+++ b/api/app/api/admin/sweep-stale-jobs/route.ts
@@ -23,7 +23,23 @@ export async function POST(req: NextRequest) {
   }
 
   try {
+    const startedAt = Date.now();
     const result = await sweepStaleJobs();
+    const durationMs = Date.now() - startedAt;
+
+    // Structured success log. Cloud Monitoring uses this as the signal for
+    // the "sweeper liveness" alert policy (docs/SWEEPER_ALERTING.md).
+    // The alert fires if no entry with `event: 'sweep-complete'` appears
+    // for longer than the schedule period. Do NOT change the event name
+    // without updating the alert policy or the alert will go silent.
+    console.log(JSON.stringify({
+      severity: 'INFO',
+      component: 'stale-sweeper',
+      event: 'sweep-complete',
+      durationMs,
+      ...result,
+    }));
+
     return NextResponse.json(result);
   } catch (error) {
     console.error('[StaleSweeper] Error:', error);

--- a/api/app/api/decks/create/route.ts
+++ b/api/app/api/decks/create/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
         if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
           return badRequestResponse('Deck link must be a valid HTTP or HTTPS URL');
         }
-      } catch (err) {
+      } catch {
         return badRequestResponse('Deck link must be a valid URL');
       }
     }

--- a/api/app/api/health/workers/route.ts
+++ b/api/app/api/health/workers/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import * as workerStore from '@/lib/worker-store-factory';
+
+/**
+ * GET /api/health/workers — Lightweight worker-pool liveness probe.
+ *
+ * Returns HTTP 200 when at least one worker has heartbeated in the last
+ * `staleThresholdMs` (default 3 minutes) and HTTP 503 otherwise.
+ *
+ * Purpose:
+ *   - Frontend uses this to show a "no workers online" banner so users
+ *     understand why their QUEUED jobs aren't progressing.
+ *   - Cloud Monitoring can alert on sustained 503s to page an operator.
+ *
+ * Intentionally minimal: one Firestore query, no auth (same as /api/health),
+ * no other subsystem checks. The full `/api/health` endpoint remains for
+ * multi-check observability.
+ */
+export async function GET() {
+  try {
+    const workers = await workerStore.getActiveWorkers();
+    const online = workers.length;
+    const body = {
+      online,
+      workers: workers.map((w) => ({
+        workerId: w.workerId,
+        workerName: w.workerName,
+        lastHeartbeat: w.lastHeartbeat,
+        status: w.status,
+      })),
+    };
+    const status = online > 0 ? 200 : 503;
+    return NextResponse.json(body, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { online: 0, error: err instanceof Error ? err.message : 'unknown' },
+      { status: 503 }
+    );
+  }
+}

--- a/api/app/api/jobs/[id]/logs/simulation/route.ts
+++ b/api/app/api/jobs/[id]/logs/simulation/route.ts
@@ -10,12 +10,61 @@ interface RouteParams {
 // JSON envelope overhead (`{"filename":"…","logText":"…"}` plus escaping).
 // Used to cap the Content-Length rejection above the raw log payload cap.
 const ENVELOPE_OVERHEAD_BYTES = 4 * 1024;
+const MAX_REQUEST_BYTES = MAX_LOG_BYTES + ENVELOPE_OVERHEAD_BYTES;
 
 function payloadTooLargeResponse(bytes: number) {
   return NextResponse.json(
     { error: `Payload too large: ${bytes} bytes exceeds max of ${MAX_LOG_BYTES} bytes` },
     { status: 413 }
   );
+}
+
+/**
+ * Read the request body as a UTF-8 string, aborting if the accumulated
+ * byte count exceeds `MAX_REQUEST_BYTES`. This closes the
+ * `Transfer-Encoding: chunked` bypass where Content-Length is absent and
+ * `request.json()` would otherwise buffer the entire body into memory
+ * regardless of size.
+ *
+ * Returns `{ ok: true, text }` on success or `{ ok: false, bytesRead }` on
+ * overflow. The caller converts the overflow result into an HTTP 413.
+ */
+async function readBodyWithLimit(
+  request: NextRequest,
+  limit: number
+): Promise<{ ok: true; text: string } | { ok: false; bytesRead: number }> {
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return { ok: true, text: '' };
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > limit) {
+        // Best-effort cancel so the sender stops sending. Safe to ignore
+        // any error here — the connection will be torn down by the 413.
+        await reader.cancel().catch(() => { /* ignore */ });
+        return { ok: false, bytesRead: total };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  // Concatenate and decode. Total size is bounded by `limit` so this
+  // allocation is also bounded.
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.byteLength;
+  }
+  return { ok: true, text: new TextDecoder('utf-8').decode(merged) };
 }
 
 /**
@@ -29,20 +78,35 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   }
 
   // Early reject oversize uploads via Content-Length header so we never
-  // buffer multi-gigabyte bodies into memory. The library performs a
-  // second defense-in-depth check after parsing.
+  // even start reading the body. Only catches honest clients — chunked
+  // transfers are caught by the streaming reader below.
   const contentLengthHeader = request.headers.get('content-length');
   if (contentLengthHeader) {
     const contentLength = parseInt(contentLengthHeader, 10);
-    if (Number.isFinite(contentLength) && contentLength > MAX_LOG_BYTES + ENVELOPE_OVERHEAD_BYTES) {
+    if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
       return payloadTooLargeResponse(contentLength);
     }
   }
 
   try {
     const { id } = await params;
-    const body = await request.json();
-    const { filename, logText } = body;
+
+    // Streaming read with a running byte count. Rejects over-cap uploads
+    // mid-flight so we never buffer more than MAX_REQUEST_BYTES in memory,
+    // regardless of transfer encoding.
+    const bodyResult = await readBodyWithLimit(request, MAX_REQUEST_BYTES);
+    if (!bodyResult.ok) {
+      return payloadTooLargeResponse(bodyResult.bytesRead);
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse(bodyResult.text);
+    } catch {
+      return badRequestResponse('Invalid JSON body');
+    }
+
+    const { filename, logText } = body as { filename?: unknown; logText?: unknown };
 
     if (!filename || typeof filename !== 'string') {
       return badRequestResponse('filename is required');

--- a/api/app/api/jobs/[id]/logs/simulation/route.ts
+++ b/api/app/api/jobs/[id]/logs/simulation/route.ts
@@ -1,10 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { isWorkerRequest, unauthorizedResponse } from '@/lib/auth';
-import { uploadSingleSimulationLog } from '@/lib/log-store';
+import { uploadSingleSimulationLog, MAX_LOG_BYTES } from '@/lib/log-store';
 import { errorResponse, badRequestResponse } from '@/lib/api-response';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+// JSON envelope overhead (`{"filename":"…","logText":"…"}` plus escaping).
+// Used to cap the Content-Length rejection above the raw log payload cap.
+const ENVELOPE_OVERHEAD_BYTES = 4 * 1024;
+
+function payloadTooLargeResponse(bytes: number) {
+  return NextResponse.json(
+    { error: `Payload too large: ${bytes} bytes exceeds max of ${MAX_LOG_BYTES} bytes` },
+    { status: 413 }
+  );
 }
 
 /**
@@ -15,6 +26,17 @@ interface RouteParams {
 export async function POST(request: NextRequest, { params }: RouteParams) {
   if (!isWorkerRequest(request)) {
     return unauthorizedResponse('Worker authentication required');
+  }
+
+  // Early reject oversize uploads via Content-Length header so we never
+  // buffer multi-gigabyte bodies into memory. The library performs a
+  // second defense-in-depth check after parsing.
+  const contentLengthHeader = request.headers.get('content-length');
+  if (contentLengthHeader) {
+    const contentLength = parseInt(contentLengthHeader, 10);
+    if (Number.isFinite(contentLength) && contentLength > MAX_LOG_BYTES + ENVELOPE_OVERHEAD_BYTES) {
+      return payloadTooLargeResponse(contentLength);
+    }
   }
 
   try {
@@ -29,7 +51,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return badRequestResponse('logText is required');
     }
 
-    await uploadSingleSimulationLog(id, filename, logText);
+    try {
+      await uploadSingleSimulationLog(id, filename, logText);
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('Log too large')) {
+        return payloadTooLargeResponse(Buffer.byteLength(logText, 'utf-8'));
+      }
+      throw err;
+    }
 
     return NextResponse.json({ uploaded: true }, { status: 201 });
   } catch (error) {

--- a/api/app/api/jobs/route.ts
+++ b/api/app/api/jobs/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifyAuth, verifyAllowedUser, unauthorizedResponse } from '@/lib/auth';
 import * as jobStore from '@/lib/job-store-factory';
 import { resolveDeckIds } from '@/lib/deck-resolver';
+import { getDeckById } from '@/lib/deck-store-factory';
 import { publishSimulationTasks } from '@/lib/pubsub';
 import { GAMES_PER_CONTAINER } from '@/lib/types';
 import { parseBody, createJobSchema } from '@/lib/validation';
@@ -70,7 +71,9 @@ function jobToSummary(job: Awaited<ReturnType<typeof jobStore.getJob>>, gamesCom
 }
 
 /**
- * GET /api/jobs - List jobs
+ * GET /api/jobs - List jobs (paginated)
+ * Query params: ?limit=N (default 100, max 200), ?cursor=<opaque>
+ * Returns: { jobs: JobSummary[], nextCursor: string | null }
  */
 export async function GET(request: NextRequest) {
   try {
@@ -80,7 +83,19 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const jobs = await jobStore.listJobs();
+    const url = new URL(request.url);
+    const limitParam = url.searchParams.get('limit');
+    const cursorParam = url.searchParams.get('cursor');
+    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+    if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0)) {
+      return badRequestResponse('limit must be a positive integer');
+    }
+
+    const { jobs, nextCursor } = await jobStore.listJobs({
+      limit,
+      cursor: cursorParam ?? undefined,
+    });
+
     // Derive gamesCompleted from atomic counters (O(1) — no subcollection reads)
     const summaries = jobs
       .filter((j): j is NonNullable<typeof j> => j !== null)
@@ -92,7 +107,7 @@ export async function GET(request: NextRequest) {
       })
       .filter((s): s is NonNullable<typeof s> => s !== null);
 
-    return NextResponse.json({ jobs: summaries });
+    return NextResponse.json({ jobs: summaries, nextCursor });
   } catch (error) {
     console.error('GET /api/jobs error:', error);
     return errorResponse(error instanceof Error ? error.message : 'Failed to list jobs', 500);
@@ -133,11 +148,39 @@ export async function POST(request: NextRequest) {
       return badRequestResponse(`Invalid deck IDs: ${errors.join(', ')}`);
     }
 
+    // Denormalize deck metadata into the job doc at creation time so every
+    // downstream job view (Browse list, detail page, leaderboard) doesn't
+    // have to re-fetch 4 deck docs per job. In GCP mode this is a ~4x
+    // Firestore read reduction on the hot path. LOCAL mode is unaffected:
+    // the job-store factory only passes these fields to Firestore.
+    const deckLinks: Record<string, string | null> = {};
+    const colorIdentity: Record<string, string[]> = {};
+    if (isGcpMode()) {
+      const resolved = await Promise.all(
+        deckIds.map(async (id, i) => {
+          try {
+            const deck = await getDeckById(id);
+            return { name: decks[i].name, deck };
+          } catch {
+            return { name: decks[i].name, deck: null };
+          }
+        }),
+      );
+      for (const { name, deck } of resolved) {
+        deckLinks[name] = deck?.link ?? null;
+        if (deck?.colorIdentity && deck.colorIdentity.length > 0) {
+          colorIdentity[name] = deck.colorIdentity;
+        }
+      }
+    }
+
     const job = await jobStore.createJob(decks, simulations, {
       idempotencyKey,
       parallelism,
       createdBy: user.uid,
       deckIds,
+      ...(Object.keys(deckLinks).length > 0 && { deckLinks }),
+      ...(Object.keys(colorIdentity).length > 0 && { colorIdentity }),
     });
 
     // Each container runs GAMES_PER_CONTAINER games, so we need fewer containers

--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -1,0 +1,50 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  {
+    ignores: [
+      '.next/**',
+      'node_modules/**',
+      'dist/**',
+      'out/**',
+      'data/**',
+      'logs-data/**',
+      'next-env.d.ts',
+    ],
+  },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        ...globals.es2022,
+      },
+    },
+    rules: {
+      // Unused vars: allow underscore-prefixed as intentional
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      // Several factory files lazy-load SQLite via require() to keep native
+      // bindings out of the GCP bundle; that pattern is deliberate.
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+  {
+    // Relax rules for test files
+    files: ['**/*.test.ts', 'test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+)

--- a/api/lib/archidekt-sync.ts
+++ b/api/lib/archidekt-sync.ts
@@ -207,7 +207,7 @@ export async function syncPrecons(): Promise<SyncResult> {
 
     // Extract synchronous state changes (like ID generation) before async ops
     for (const adeck of batch) {
-      let existing = existingByArchidektId.get(adeck.id);
+      const existing = existingByArchidektId.get(adeck.id);
 
       // If we haven't seen this archidektId in the initial load but another
       // concurrent sync may have inserted it, do a fresh lookup.

--- a/api/lib/auth.ts
+++ b/api/lib/auth.ts
@@ -123,7 +123,10 @@ export async function verifyTokenString(token: string): Promise<AuthUser> {
     if (error instanceof Error && error.message.includes('email')) {
       throw error;
     }
-    throw new Error(`Invalid token: ${error instanceof Error ? error.message : 'unknown'}`);
+    throw new Error(
+      `Invalid token: ${error instanceof Error ? error.message : 'unknown'}`,
+      { cause: error }
+    );
   }
 }
 
@@ -175,9 +178,9 @@ export async function verifyAllowedUser(req: NextRequest): Promise<AuthUser> {
       if (error.message.includes('allowlist') || error.message.includes('email')) {
         throw error;
       }
-      throw new Error(`Invalid token: ${error.message}`);
+      throw new Error(`Invalid token: ${error.message}`, { cause: error });
     }
-    throw new Error('Token verification failed');
+    throw new Error('Token verification failed', { cause: error });
   }
 }
 
@@ -264,7 +267,8 @@ async function verifyAppCheck(req: NextRequest): Promise<void> {
     await getAppCheck().verifyToken(appCheckToken);
   } catch (error) {
     throw new Error(
-      `App Check verification failed: ${error instanceof Error ? error.message : 'unknown'}`
+      `App Check verification failed: ${error instanceof Error ? error.message : 'unknown'}`,
+      { cause: error }
     );
   }
 }

--- a/api/lib/condenser/derive-job-status.test.ts
+++ b/api/lib/condenser/derive-job-status.test.ts
@@ -35,10 +35,6 @@ async function test(name: string, fn: () => void | Promise<void>) {
   }
 }
 
-function assert(condition: boolean, message: string) {
-  if (!condition) throw new Error(message);
-}
-
 function assertEqual<T>(actual: T, expected: T, message: string) {
   if (actual !== expected) {
     throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);

--- a/api/lib/condenser/index.ts
+++ b/api/lib/condenser/index.ts
@@ -75,7 +75,6 @@ import {
   calculateCardsDrawnPerTurn,
   calculatePerDeckTurns,
   extractWinner,
-  extractWinningTurn,
 } from './turns';
 import { buildStructuredGame } from './structured';
 import { matchesDeckName } from './deck-match';

--- a/api/lib/condenser/structured.ts
+++ b/api/lib/condenser/structured.ts
@@ -30,9 +30,8 @@
  */
 
 import type { StructuredGame, DeckHistory, DeckTurnActions, DeckAction, EventType } from '../types';
-import { extractTurnRanges, sliceByTurn, getMaxRound, getNumPlayers, segmentToRound, calculateLifePerTurn, calculatePerDeckTurns, extractWinner, type TurnRange } from './turns';
+import { extractTurnRanges, sliceByTurn, getMaxRound, getNumPlayers, segmentToRound, calculateLifePerTurn, calculatePerDeckTurns, extractWinner } from './turns';
 import { classifyLine } from './classify';
-import { shouldIgnoreLine } from './filter';
 import { matchesDeckName } from './deck-match';
 
 // -----------------------------------------------------------------------------

--- a/api/lib/condenser/win-tally.test.ts
+++ b/api/lib/condenser/win-tally.test.ts
@@ -41,10 +41,6 @@ async function test(name: string, fn: () => void | Promise<void>) {
   }
 }
 
-function assert(condition: boolean, message: string) {
-  if (!condition) throw new Error(message);
-}
-
 function assertEqual<T>(actual: T, expected: T, message: string) {
   if (actual !== expected) {
     throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);

--- a/api/lib/coverage-service.ts
+++ b/api/lib/coverage-service.ts
@@ -54,20 +54,18 @@ export async function computePairCoverage(): Promise<PairCoverageMap> {
     return coverageCache.data;
   }
 
-  const [allDecks, matchResults] = await Promise.all([
-    listAllDecks(),
-    getAllMatchResults(),
-  ]);
-
+  const allDecks = await listAllDecks();
   const allDeckIds = allDecks.map((d) => d.id);
   const counts = new Map<string, number>();
 
-  for (const result of matchResults) {
-    const pairs = extractPairs(result.deckIds);
-    for (const pair of pairs) {
+  const incrementPairs = (deckIds: string[]): void => {
+    if (!Array.isArray(deckIds)) return;
+    for (const pair of extractPairs(deckIds)) {
       counts.set(pair, (counts.get(pair) ?? 0) + 1);
     }
-  }
+  };
+
+  await forEachMatchResult(incrementPairs);
 
   const data = { counts, allDeckIds };
   coverageCache = { data, ts: Date.now() };
@@ -202,14 +200,32 @@ export async function hasActiveCoverageJob(): Promise<boolean> {
 }
 
 /**
- * Get all match results (deck_ids arrays) from the database.
+ * Page size for Firestore match_results scans. Keeps per-RPC memory bounded
+ * so the coverage computation never loads the entire collection at once.
  */
-async function getAllMatchResults(): Promise<{ deckIds: string[] }[]> {
+const MATCH_RESULTS_PAGE_SIZE = 1000;
+
+/**
+ * Stream every match_results document through `visit`. In GCP mode this
+ * uses cursor-based pagination so the in-memory working set is at most
+ * MATCH_RESULTS_PAGE_SIZE docs; in LOCAL mode the SQLite row count is
+ * small enough that we load all rows eagerly.
+ */
+async function forEachMatchResult(visit: (deckIds: string[]) => void): Promise<void> {
   if (USE_FIRESTORE) {
-    const snapshot = await getFirestoreClient().collection('matchResults').select('deckIds').get();
-    return snapshot.docs.map((doc) => ({
-      deckIds: doc.data().deckIds as string[],
-    }));
+    const ref = getFirestoreClient().collection('matchResults');
+    let lastDoc: FirebaseFirestore.QueryDocumentSnapshot | null = null;
+    while (true) {
+      let query = ref.select('deckIds').orderBy('__name__').limit(MATCH_RESULTS_PAGE_SIZE);
+      if (lastDoc) query = query.startAfter(lastDoc);
+      const snapshot = await query.get();
+      if (snapshot.empty) return;
+      for (const doc of snapshot.docs) {
+        visit(doc.data().deckIds as string[]);
+      }
+      if (snapshot.size < MATCH_RESULTS_PAGE_SIZE) return;
+      lastDoc = snapshot.docs[snapshot.docs.length - 1];
+    }
   }
 
   const { getDb } = require('./db') as { getDb: () => import('better-sqlite3').Database };
@@ -217,7 +233,7 @@ async function getAllMatchResults(): Promise<{ deckIds: string[] }[]> {
   const rows = db
     .prepare('SELECT deck_ids FROM match_results')
     .all() as { deck_ids: string }[];
-  return rows.map((r) => ({
-    deckIds: JSON.parse(r.deck_ids) as string[],
-  }));
+  for (const row of rows) {
+    visit(JSON.parse(row.deck_ids) as string[]);
+  }
 }

--- a/api/lib/deck-store-factory.ts
+++ b/api/lib/deck-store-factory.ts
@@ -6,6 +6,7 @@ import { listSavedDecks, readSavedDeckContent, saveDeck, deleteSavedDeck } from 
 import { slugify } from './saved-decks';
 import { getColorIdentityByKey } from './deck-metadata';
 import * as firestoreDecks from './firestore-decks';
+import { lruTouch, lruEvictIfFull } from './lru';
 
 const USE_FIRESTORE =
   typeof process.env.GOOGLE_CLOUD_PROJECT === 'string' && process.env.GOOGLE_CLOUD_PROJECT.length > 0;
@@ -183,7 +184,7 @@ const DECK_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const DECK_CACHE_MAX_SIZE = 500;
 
 export async function getDeckById(id: string): Promise<DeckListItem | null> {
-  const cached = deckByIdCache.get(id);
+  const cached = lruTouch(deckByIdCache, id);
   if (cached && Date.now() - cached.ts < DECK_CACHE_TTL_MS) {
     return cached.item;
   }
@@ -225,11 +226,10 @@ export async function getDeckById(id: string): Promise<DeckListItem | null> {
     return item;
   }
 
-  // Evict oldest entry if at capacity (Map iteration order = insertion order)
-  if (deckByIdCache.size >= DECK_CACHE_MAX_SIZE) {
-    const oldest = deckByIdCache.keys().next().value;
-    if (oldest !== undefined) deckByIdCache.delete(oldest);
-  }
+  // Evict least-recently-used entries if at capacity. lruTouch above
+  // ensures that frequently-read decks bubble to the end and are not
+  // evicted before never-read entries.
+  lruEvictIfFull(deckByIdCache, DECK_CACHE_MAX_SIZE);
   deckByIdCache.set(id, { item, ts: Date.now() });
   return item;
 }

--- a/api/lib/firestore-decks.ts
+++ b/api/lib/firestore-decks.ts
@@ -74,23 +74,6 @@ function docToDeck(doc: FirebaseFirestore.DocumentSnapshot): DeckDoc | null {
   };
 }
 
-function deckToListItem(doc: DeckDoc): DeckListItem {
-  return {
-    id: doc.id,
-    name: doc.name,
-    filename: doc.filename,
-    primaryCommander: doc.primaryCommander ?? null,
-    colorIdentity: doc.colorIdentity,
-    isPrecon: doc.isPrecon,
-    link: doc.link,
-    ownerId: doc.ownerId,
-    ownerEmail: doc.ownerEmail,
-    createdAt: doc.createdAt?.toDate?.()?.toISOString() ?? new Date().toISOString(),
-    setName: doc.setName ?? null,
-    archidektId: doc.archidektId ?? null,
-  };
-}
-
 /**
  * List all decks (precons + every user's submissions)
  */

--- a/api/lib/firestore-job-store.ts
+++ b/api/lib/firestore-job-store.ts
@@ -1,4 +1,4 @@
-import { Timestamp, FieldValue } from '@google-cloud/firestore';
+import { Timestamp, FieldValue, FieldPath } from '@google-cloud/firestore';
 import { Job, JobStatus, JobResults, DeckSlot, SimulationStatus, SimulationState, JobSource } from './types';
 import { getFirestore } from './firestore-client';
 
@@ -286,28 +286,72 @@ const DEFAULT_LIST_LIMIT = 100;
 const MAX_LIST_LIMIT = 200;
 
 /**
+ * Composite pagination cursor: ISO createdAt + document id. The id is
+ * the tie-breaker for the rare case where two jobs share the exact same
+ * `createdAt` millisecond (e.g. batch imports), ensuring no job is ever
+ * skipped or duplicated across page boundaries. Wire format is
+ * base64(JSON({ts, id})). Legacy timestamp-only cursors (from the first
+ * cut of this endpoint) are still accepted for backward compat.
+ */
+interface ListJobsCursor {
+  ts: string;
+  id: string;
+}
+
+function encodeCursor(cursor: ListJobsCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf-8').toString('base64');
+}
+
+function decodeCursor(raw: string): ListJobsCursor | null {
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf-8');
+    if (decoded.startsWith('{')) {
+      const parsed = JSON.parse(decoded) as Partial<ListJobsCursor>;
+      if (parsed && typeof parsed.ts === 'string' && typeof parsed.id === 'string') {
+        if (isNaN(new Date(parsed.ts).getTime())) return null;
+        return { ts: parsed.ts, id: parsed.id };
+      }
+      return null;
+    }
+    // Legacy timestamp-only cursor
+    if (!isNaN(new Date(decoded).getTime())) {
+      return { ts: decoded, id: '' };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * List jobs, optionally filtered by user. Results are cursor-paginated in
- * descending createdAt order. Pass `options.cursor` from a previous result's
- * `nextCursor` to fetch the next page; `nextCursor === null` means no more.
+ * descending (createdAt, id) order. Pass `options.cursor` from a previous
+ * result's `nextCursor` to fetch the next page; `nextCursor === null`
+ * means no more results.
  */
 export async function listJobs(options: ListJobsOptions = {}): Promise<ListJobsResult> {
   const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT));
 
-  let query: FirebaseFirestore.Query = jobsCollection.orderBy('createdAt', 'desc');
+  // Order by (createdAt DESC, __name__ DESC) so document id is a stable
+  // tie-breaker within the same millisecond.
+  let query: FirebaseFirestore.Query = jobsCollection
+    .orderBy('createdAt', 'desc')
+    .orderBy(FieldPath.documentId(), 'desc');
 
   if (options.userId) {
     query = query.where('createdBy', '==', options.userId);
   }
 
   if (options.cursor) {
-    try {
-      const iso = Buffer.from(options.cursor, 'base64').toString('utf-8');
-      const ts = new Date(iso);
-      if (!isNaN(ts.getTime())) {
+    const parsed = decodeCursor(options.cursor);
+    if (parsed) {
+      const ts = Timestamp.fromDate(new Date(parsed.ts));
+      if (parsed.id) {
+        query = query.startAfter(ts, parsed.id);
+      } else {
+        // Legacy cursor — best-effort, may lose ties on the boundary
         query = query.startAfter(ts);
       }
-    } catch {
-      // Ignore malformed cursors — start from the beginning
     }
   }
 
@@ -319,7 +363,10 @@ export async function listJobs(options: ListJobsOptions = {}): Promise<ListJobsR
   const hasMore = rawJobs.length > limit;
   const jobs = hasMore ? rawJobs.slice(0, limit) : rawJobs;
   const nextCursor = hasMore && jobs.length > 0
-    ? Buffer.from(jobs[jobs.length - 1].createdAt.toISOString(), 'utf-8').toString('base64')
+    ? encodeCursor({
+        ts: jobs[jobs.length - 1].createdAt.toISOString(),
+        id: jobs[jobs.length - 1].id,
+      })
     : null;
 
   return { jobs, nextCursor };

--- a/api/lib/firestore-job-store.ts
+++ b/api/lib/firestore-job-store.ts
@@ -47,6 +47,14 @@ export interface CreateJobData {
   createdBy: string;
   deckIds?: string[];
   source?: JobSource;
+  /**
+   * Denormalized deck metadata, keyed by deck NAME (matches deckNames[]).
+   * Writing these into the job doc at creation time eliminates 4 Firestore
+   * deck reads per job view (Browse + detail pages) and massively reduces
+   * the leaderboard's read fan-out.
+   */
+  deckLinks?: Record<string, string | null>;
+  colorIdentity?: Record<string, string[]>;
 }
 
 /**
@@ -67,6 +75,8 @@ export async function createJob(data: CreateJobData): Promise<Job> {
   const jobData = {
     decks: data.decks,
     ...(data.deckIds != null && data.deckIds.length === 4 && { deckIds: data.deckIds }),
+    ...(data.deckLinks && Object.keys(data.deckLinks).length > 0 && { deckLinks: data.deckLinks }),
+    ...(data.colorIdentity && Object.keys(data.colorIdentity).length > 0 && { colorIdentity: data.colorIdentity }),
     status: 'QUEUED' as JobStatus,
     simulations: data.simulations,
     parallelism: data.parallelism || 4,
@@ -260,18 +270,59 @@ export async function getNextQueuedJob(): Promise<Job | null> {
   return docToJob(snapshot.docs[0]);
 }
 
+export interface ListJobsOptions {
+  userId?: string;
+  limit?: number;
+  /** Opaque cursor returned from a previous call's `nextCursor`. */
+  cursor?: string;
+}
+
+export interface ListJobsResult {
+  jobs: Job[];
+  nextCursor: string | null;
+}
+
+const DEFAULT_LIST_LIMIT = 100;
+const MAX_LIST_LIMIT = 200;
+
 /**
- * List jobs, optionally filtered by user
+ * List jobs, optionally filtered by user. Results are cursor-paginated in
+ * descending createdAt order. Pass `options.cursor` from a previous result's
+ * `nextCursor` to fetch the next page; `nextCursor === null` means no more.
  */
-export async function listJobs(userId?: string): Promise<Job[]> {
+export async function listJobs(options: ListJobsOptions = {}): Promise<ListJobsResult> {
+  const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT));
+
   let query: FirebaseFirestore.Query = jobsCollection.orderBy('createdAt', 'desc');
-  
-  if (userId) {
-    query = query.where('createdBy', '==', userId);
+
+  if (options.userId) {
+    query = query.where('createdBy', '==', options.userId);
   }
 
-  const snapshot = await query.limit(100).get();
-  return snapshot.docs.map(doc => docToJob(doc)).filter((job): job is Job => job !== null);
+  if (options.cursor) {
+    try {
+      const iso = Buffer.from(options.cursor, 'base64').toString('utf-8');
+      const ts = new Date(iso);
+      if (!isNaN(ts.getTime())) {
+        query = query.startAfter(ts);
+      }
+    } catch {
+      // Ignore malformed cursors — start from the beginning
+    }
+  }
+
+  const snapshot = await query.limit(limit + 1).get();
+  const rawJobs = snapshot.docs
+    .map(doc => docToJob(doc))
+    .filter((job): job is Job => job !== null);
+
+  const hasMore = rawJobs.length > limit;
+  const jobs = hasMore ? rawJobs.slice(0, limit) : rawJobs;
+  const nextCursor = hasMore && jobs.length > 0
+    ? Buffer.from(jobs[jobs.length - 1].createdAt.toISOString(), 'utf-8').toString('base64')
+    : null;
+
+  return { jobs, nextCursor };
 }
 
 export async function listActiveJobs(): Promise<Job[]> {

--- a/api/lib/ingestion/manapool.ts
+++ b/api/lib/ingestion/manapool.ts
@@ -68,7 +68,8 @@ export async function fetchDeckFromManaPoolUrl(url: string): Promise<ParsedDeck>
     });
   } catch (err) {
     throw new Error(
-      `Could not reach ManaPool (network error). Please check the URL and try again.`
+      `Could not reach ManaPool (network error). Please check the URL and try again.`,
+      { cause: err }
     );
   }
 

--- a/api/lib/ingestion/text-parser.ts
+++ b/api/lib/ingestion/text-parser.ts
@@ -154,7 +154,7 @@ function parseCardLine(line: string): DeckCard | null {
   if (!line) return null;
   
   // Remove set codes in parentheses or brackets at the end
-  line = line.replace(/\s*[\(\[][\w\d]+[\)\]]\s*$/, '');
+  line = line.replace(/\s*[([][\w\d]+[)\]]\s*$/, '');
   
   // Try to parse quantity
   // Pattern: "N CardName" or "Nx CardName" where N is a number

--- a/api/lib/ingestion/to-dck.ts
+++ b/api/lib/ingestion/to-dck.ts
@@ -58,6 +58,7 @@ function formatCardEntry(card: DeckCard): string {
  */
 function cleanDeckName(name: string): string {
   // Replace newlines and control characters with a space
+  // eslint-disable-next-line no-control-regex -- deliberate: sanitizing raw input
   return name.replace(/[\r\n\x00-\x1F\x7F]+/g, ' ').trim();
 }
 
@@ -75,6 +76,7 @@ function cleanCardName(name: string): string {
   }
 
   // Replace newlines and control characters with a space to prevent injection
+  // eslint-disable-next-line no-control-regex -- deliberate: sanitizing raw input
   name = name.replace(/[\r\n\x00-\x1F\x7F]+/g, ' ');
 
   // Trim whitespace

--- a/api/lib/job-store-factory.ts
+++ b/api/lib/job-store-factory.ts
@@ -61,7 +61,16 @@ export async function getJobByIdempotencyKey(key: string): Promise<Job | null> {
 export async function createJob(
   decks: DeckSlot[],
   simulations: number,
-  options?: { idempotencyKey?: string; parallelism?: number; createdBy?: string; deckIds?: string[]; source?: JobSource }
+  options?: {
+    idempotencyKey?: string;
+    parallelism?: number;
+    createdBy?: string;
+    deckIds?: string[];
+    source?: JobSource;
+    /** Denormalized deck metadata, Firestore-only. See CreateJobData. */
+    deckLinks?: Record<string, string | null>;
+    colorIdentity?: Record<string, string[]>;
+  }
 ): Promise<Job> {
   if (USE_FIRESTORE) {
     return firestoreStore.createJob({
@@ -72,6 +81,8 @@ export async function createJob(
       createdBy: options?.createdBy ?? 'unknown',
       deckIds: options?.deckIds,
       source: options?.source,
+      deckLinks: options?.deckLinks,
+      colorIdentity: options?.colorIdentity,
     });
   }
   return (await sqliteStore()).createJob(
@@ -84,11 +95,23 @@ export async function createJob(
   );
 }
 
-export async function listJobs(userId?: string): Promise<Job[]> {
+export interface ListJobsOptions {
+  userId?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListJobsResult {
+  jobs: Job[];
+  nextCursor: string | null;
+}
+
+export async function listJobs(options: ListJobsOptions = {}): Promise<ListJobsResult> {
   if (USE_FIRESTORE) {
-    return firestoreStore.listJobs(userId);
+    return firestoreStore.listJobs(options);
   }
-  return (await sqliteStore()).listJobs();
+  const { userId: _userId, ...rest } = options;
+  return (await sqliteStore()).listJobs(rest);
 }
 
 export async function listActiveJobs(): Promise<Job[]> {
@@ -313,7 +336,9 @@ async function recoverStaleSimulations(
   job: Job,
   activeWorkers: WorkerInfo[],
 ): Promise<boolean> {
-  if (!USE_FIRESTORE) return false; // Only applies in GCP mode with Pub/Sub
+  if (!USE_FIRESTORE) {
+    return recoverStaleSimulationsLocal(jobId, job, activeWorkers);
+  }
 
   const sims = await getSimulationStatuses(jobId);
   if (sims.length === 0) return false;
@@ -423,6 +448,82 @@ async function recoverStaleSimulations(
 }
 
 /**
+ * LOCAL-mode recovery. The architecture is different from GCP:
+ *   - Workers claim entire jobs (atomic QUEUED → RUNNING in claimNextJob).
+ *   - There is no Pub/Sub to republish individual sims to.
+ *   - If the worker holding a RUNNING job dies, the job stays RUNNING with
+ *     a stale workerId and the remaining PENDING sims never progress.
+ *
+ * Strategy:
+ *   1. If the job is RUNNING but its worker is not in the active-workers
+ *      list (and at least one other worker IS active), reset the job back
+ *      to QUEUED and reset any RUNNING/FAILED sims to PENDING. The next
+ *      call to claimNextJob() will pick it up; the worker will then resume
+ *      by processing only PENDING sims.
+ *   2. If all sims are already terminal (COMPLETED/CANCELLED) but the job
+ *      status is still RUNNING, trigger aggregation to finalize it — this
+ *      matches the GCP path and is what the stale-sweeper relies on.
+ *   3. If no active workers exist, do nothing — resetting would just thrash.
+ */
+async function recoverStaleSimulationsLocal(
+  jobId: string,
+  job: Job,
+  activeWorkers: WorkerInfo[],
+): Promise<boolean> {
+  const sims = await getSimulationStatuses(jobId);
+  if (sims.length === 0) return false;
+
+  const allTerminal = sims.every(
+    (s) => s.state === 'COMPLETED' || s.state === 'CANCELLED'
+  );
+
+  // Fast path: all sims terminal but job still RUNNING → aggregate to finalize.
+  if (allTerminal) {
+    const needsRetrigger = job.status === 'RUNNING' || job.needsAggregation === true;
+    if (needsRetrigger) {
+      recoveryLog.info('LOCAL: all sims terminal, retriggering aggregation', { jobId });
+      aggregateJobResults(jobId).catch((err) => {
+        recoveryLog.error('LOCAL aggregation failed', { jobId, error: err instanceof Error ? err.message : String(err) });
+        Sentry.captureException(err, { tags: { component: 'recovery-aggregation-local', jobId } });
+      });
+      return true;
+    }
+    return false;
+  }
+
+  // Only attempt re-claim if there's another worker to take over.
+  if (activeWorkers.length === 0) return false;
+
+  const activeWorkerIds = new Set(activeWorkers.map((w) => w.workerId));
+  const workerStillAlive = job.workerId != null && activeWorkerIds.has(job.workerId);
+  if (workerStillAlive) return false;
+
+  // Worker is dead. Reset in-flight sims so the re-claim has clean state.
+  let resetCount = 0;
+  for (const sim of sims) {
+    if (sim.state === 'RUNNING' || sim.state === 'FAILED') {
+      const updated = await conditionalUpdateSimulationStatus(
+        jobId,
+        sim.simId,
+        [sim.state],
+        { state: 'PENDING' }
+      );
+      if (updated) resetCount++;
+    }
+  }
+
+  const jobReset = await resetJobForRetry(jobId);
+  recoveryLog.info('LOCAL: reset stuck RUNNING job for re-claim', {
+    jobId,
+    deadWorkerId: job.workerId,
+    resetSims: resetCount,
+    jobReset,
+  });
+
+  return jobReset || resetCount > 0;
+}
+
+/**
  * Re-publish a QUEUED job that may have lost its Pub/Sub message.
  *
  * If the job has been QUEUED for >2 minutes, re-publish to Pub/Sub so
@@ -461,8 +562,8 @@ async function recoverStaleQueuedJob(jobId: string, job: Job): Promise<boolean> 
       // Re-publish only for PENDING sims
       const pendingSims = sims.filter(s => s.state === 'PENDING');
       if (pendingSims.length > 0) {
-        const { publishSimulationTasks: publish } = await import('./pubsub');
-        const topic = (await import('./pubsub')).pubsub.topic((await import('./pubsub')).TOPIC_NAME);
+        const { pubsub, TOPIC_NAME } = await import('./pubsub');
+        const topic = pubsub.topic(TOPIC_NAME);
         const promises = pendingSims.map(s => {
           const msg = {
             type: 'simulation' as const,

--- a/api/lib/job-store-factory.ts
+++ b/api/lib/job-store-factory.ts
@@ -482,10 +482,16 @@ async function recoverStaleSimulationsLocal(
     const needsRetrigger = job.status === 'RUNNING' || job.needsAggregation === true;
     if (needsRetrigger) {
       recoveryLog.info('LOCAL: all sims terminal, retriggering aggregation', { jobId });
-      aggregateJobResults(jobId).catch((err) => {
+      // Awaited (not fire-and-forget) so the caller — typically the
+      // stale-sweeper HTTP handler — doesn't return before the aggregation
+      // finishes. On serverless runtimes (Cloud Run), unawaited background
+      // work can be throttled or killed the moment the response is sent.
+      try {
+        await aggregateJobResults(jobId);
+      } catch (err) {
         recoveryLog.error('LOCAL aggregation failed', { jobId, error: err instanceof Error ? err.message : String(err) });
         Sentry.captureException(err, { tags: { component: 'recovery-aggregation-local', jobId } });
-      });
+      }
       return true;
     }
     return false;

--- a/api/lib/job-store.ts
+++ b/api/lib/job-store.ts
@@ -274,34 +274,84 @@ export interface ListJobsResult {
 const DEFAULT_LIST_LIMIT = 100;
 const MAX_LIST_LIMIT = 200;
 
+/**
+ * Composite cursor (matches firestore-job-store.ts). Timestamp + job id,
+ * encoded as base64(JSON). Legacy timestamp-only cursors still accepted.
+ */
+interface ListJobsCursor {
+  ts: string;
+  id: string;
+}
+
+function encodeCursor(cursor: ListJobsCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf-8').toString('base64');
+}
+
+function decodeCursor(raw: string): ListJobsCursor | null {
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf-8');
+    if (decoded.startsWith('{')) {
+      const parsed = JSON.parse(decoded) as Partial<ListJobsCursor>;
+      if (parsed && typeof parsed.ts === 'string' && typeof parsed.id === 'string') {
+        if (isNaN(new Date(parsed.ts).getTime())) return null;
+        return { ts: parsed.ts, id: parsed.id };
+      }
+      return null;
+    }
+    if (!isNaN(new Date(decoded).getTime())) {
+      return { ts: decoded, id: '' };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function listJobs(options: ListJobsOptions = {}): ListJobsResult {
   const db = getDb();
   const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT));
 
-  let cursorTs: string | null = null;
-  if (options.cursor) {
-    try {
-      cursorTs = Buffer.from(options.cursor, 'base64').toString('utf-8');
-      if (isNaN(new Date(cursorTs).getTime())) cursorTs = null;
-    } catch {
-      cursorTs = null;
-    }
-  }
+  const parsedCursor = options.cursor ? decodeCursor(options.cursor) : null;
 
-  // Fetch limit+1 to detect a next page
-  const rows = cursorTs
-    ? (db
-        .prepare('SELECT * FROM jobs WHERE created_at < ? ORDER BY created_at DESC LIMIT ?')
-        .all(cursorTs, limit + 1) as Row[])
-    : (db
-        .prepare('SELECT * FROM jobs ORDER BY created_at DESC LIMIT ?')
-        .all(limit + 1) as Row[]);
+  // Fetch limit+1 to detect a next page. Tie-break on id DESC so two
+  // jobs at the same millisecond are never skipped or duplicated across
+  // page boundaries.
+  let rows: Row[];
+  if (parsedCursor && parsedCursor.id) {
+    rows = db
+      .prepare(
+        `SELECT * FROM jobs
+         WHERE created_at < ? OR (created_at = ? AND id < ?)
+         ORDER BY created_at DESC, id DESC
+         LIMIT ?`
+      )
+      .all(parsedCursor.ts, parsedCursor.ts, parsedCursor.id, limit + 1) as Row[];
+  } else if (parsedCursor) {
+    // Legacy timestamp-only cursor — best-effort, may lose ties
+    rows = db
+      .prepare(
+        `SELECT * FROM jobs
+         WHERE created_at < ?
+         ORDER BY created_at DESC, id DESC
+         LIMIT ?`
+      )
+      .all(parsedCursor.ts, limit + 1) as Row[];
+  } else {
+    rows = db
+      .prepare(
+        `SELECT * FROM jobs
+         ORDER BY created_at DESC, id DESC
+         LIMIT ?`
+      )
+      .all(limit + 1) as Row[];
+  }
 
   const allJobs = rows.map(rowToJob);
   const hasMore = allJobs.length > limit;
   const jobs = hasMore ? allJobs.slice(0, limit) : allJobs;
-  const nextCursor = hasMore && jobs.length > 0
-    ? Buffer.from(jobs[jobs.length - 1].createdAt.toISOString(), 'utf-8').toString('base64')
+  const last = jobs[jobs.length - 1];
+  const nextCursor = hasMore && last
+    ? encodeCursor({ ts: last.createdAt.toISOString(), id: last.id })
     : null;
 
   return { jobs, nextCursor };
@@ -318,15 +368,6 @@ export function listActiveJobs(): Job[] {
 export function clearJobs(): void {
   const db = getDb();
   db.prepare('DELETE FROM jobs').run();
-}
-
-export function getJobsMap(): Map<string, Job> {
-  const { jobs } = listJobs({ limit: MAX_LIST_LIMIT });
-  const map = new Map<string, Job>();
-  for (const job of jobs) {
-    map.set(job.id, job);
-  }
-  return map;
 }
 
 // ─── Per-Simulation Tracking ─────────────────────────────────────────────────

--- a/api/lib/job-store.ts
+++ b/api/lib/job-store.ts
@@ -261,10 +261,50 @@ export function claimNextJob(workerId?: string, workerName?: string): Job | unde
   return row ? rowToJob(row) : undefined;
 }
 
-export function listJobs(): Job[] {
+export interface ListJobsOptions {
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListJobsResult {
+  jobs: Job[];
+  nextCursor: string | null;
+}
+
+const DEFAULT_LIST_LIMIT = 100;
+const MAX_LIST_LIMIT = 200;
+
+export function listJobs(options: ListJobsOptions = {}): ListJobsResult {
   const db = getDb();
-  const rows = db.prepare('SELECT * FROM jobs ORDER BY created_at DESC').all() as Row[];
-  return rows.map(rowToJob);
+  const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT));
+
+  let cursorTs: string | null = null;
+  if (options.cursor) {
+    try {
+      cursorTs = Buffer.from(options.cursor, 'base64').toString('utf-8');
+      if (isNaN(new Date(cursorTs).getTime())) cursorTs = null;
+    } catch {
+      cursorTs = null;
+    }
+  }
+
+  // Fetch limit+1 to detect a next page
+  const rows = cursorTs
+    ? (db
+        .prepare('SELECT * FROM jobs WHERE created_at < ? ORDER BY created_at DESC LIMIT ?')
+        .all(cursorTs, limit + 1) as Row[])
+    : (db
+        .prepare('SELECT * FROM jobs ORDER BY created_at DESC LIMIT ?')
+        .all(limit + 1) as Row[]);
+
+  const allJobs = rows.map(rowToJob);
+  const hasMore = allJobs.length > limit;
+  const jobs = hasMore ? allJobs.slice(0, limit) : allJobs;
+  const nextCursor = hasMore && jobs.length > 0
+    ? Buffer.from(jobs[jobs.length - 1].createdAt.toISOString(), 'utf-8').toString('base64')
+    : null;
+
+  return { jobs, nextCursor };
 }
 
 export function listActiveJobs(): Job[] {
@@ -281,7 +321,7 @@ export function clearJobs(): void {
 }
 
 export function getJobsMap(): Map<string, Job> {
-  const jobs = listJobs();
+  const { jobs } = listJobs({ limit: MAX_LIST_LIMIT });
   const map = new Map<string, Job>();
   for (const job of jobs) {
     map.set(job.id, job);

--- a/api/lib/log-store.test.ts
+++ b/api/lib/log-store.test.ts
@@ -106,6 +106,33 @@ async function runTests() {
       assert(fs.existsSync(filePath), 'Should be stored as-is');
     });
 
+    await test('uploadSingleSimulationLog: rejects log text over MAX_LOG_BYTES', async () => {
+      const maxBytes = logStore.MAX_LOG_BYTES;
+      assert(typeof maxBytes === 'number' && maxBytes > 0, 'MAX_LOG_BYTES must be exported');
+      const oversize = 'a'.repeat(maxBytes + 1);
+      let thrown: Error | null = null;
+      try {
+        await logStore.uploadSingleSimulationLog('job-upload-oversize', 'raw/game_001.txt', oversize);
+      } catch (err) {
+        thrown = err as Error;
+      }
+      assert(thrown !== null, 'should throw for oversize log');
+      assert(
+        /too large|exceeds|max/i.test(thrown!.message),
+        `error message should indicate size; got: ${thrown!.message}`
+      );
+      const filePath = path.join(tempDir, 'job-upload-oversize', 'game_001.txt');
+      assert(!fs.existsSync(filePath), 'oversize log must not be written to disk');
+    });
+
+    await test('uploadSingleSimulationLog: accepts log text exactly at MAX_LOG_BYTES', async () => {
+      const exact = 'a'.repeat(logStore.MAX_LOG_BYTES);
+      await logStore.uploadSingleSimulationLog('job-upload-exact', 'raw/game_001.txt', exact);
+      const filePath = path.join(tempDir, 'job-upload-exact', 'game_001.txt');
+      assert(fs.existsSync(filePath), 'at-limit log should be written');
+      assertEqual(fs.statSync(filePath).size, logStore.MAX_LOG_BYTES, 'file size should equal MAX_LOG_BYTES');
+    });
+
     // =========================================================================
     // getRawLogs
     // =========================================================================

--- a/api/lib/log-store.ts
+++ b/api/lib/log-store.ts
@@ -15,6 +15,13 @@ import type { CondensedGame, StructuredGame } from './types';
 // Local filesystem storage directory
 const LOGS_DATA_DIR = process.env.LOGS_DATA_DIR ?? path.join(process.cwd(), 'logs-data');
 
+/**
+ * Max bytes for a single simulation log upload. Forge logs for a full game
+ * are typically <500 KB; 10 MB gives ~20x headroom and caps runaway / malicious
+ * uploads before they can OOM the API or balloon GCS costs.
+ */
+export const MAX_LOG_BYTES = 10 * 1024 * 1024;
+
 // Ensure local data directory exists in LOCAL mode
 if (!isGcpMode() && !fs.existsSync(LOGS_DATA_DIR)) {
   fs.mkdirSync(LOGS_DATA_DIR, { recursive: true });
@@ -101,6 +108,13 @@ export async function uploadSingleSimulationLog(
   filename: string,
   logText: string
 ): Promise<void> {
+  const byteLength = Buffer.byteLength(logText, 'utf-8');
+  if (byteLength > MAX_LOG_BYTES) {
+    throw new Error(
+      `Log too large: ${byteLength} bytes exceeds max of ${MAX_LOG_BYTES} bytes`
+    );
+  }
+
   if (isGcpMode()) {
     await gcs.uploadJobArtifact(jobId, filename, logText);
   } else {

--- a/api/lib/lru.test.ts
+++ b/api/lib/lru.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for lru.ts helpers.
+ *
+ * Run with: npx tsx lib/lru.test.ts
+ */
+
+import { lruTouch, lruEvictIfFull } from './lru';
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+const results: TestResult[] = [];
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    results.push({ name, passed: true });
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    results.push({ name, passed: false, error: message });
+    console.log(`✗ ${name}`);
+    console.log(`  Error: ${message}`);
+  }
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual<T>(actual: T, expected: T, message: string) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// lruTouch
+// ---------------------------------------------------------------------------
+
+test('lruTouch: returns undefined for missing key', () => {
+  const m = new Map<string, number>();
+  assertEqual(lruTouch(m, 'x'), undefined, 'missing key');
+});
+
+test('lruTouch: returns value for existing key', () => {
+  const m = new Map<string, number>([['a', 1]]);
+  assertEqual(lruTouch(m, 'a'), 1, 'existing key value');
+});
+
+test('lruTouch: moves touched entry to end of insertion order', () => {
+  const m = new Map<string, number>([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+  ]);
+  lruTouch(m, 'a');
+  const keys = [...m.keys()];
+  assertEqual(keys[0], 'b', 'b should become first');
+  assertEqual(keys[1], 'c', 'c should become second');
+  assertEqual(keys[2], 'a', 'a should be last');
+});
+
+test('lruTouch: touching last entry is a no-op for order', () => {
+  const m = new Map<string, number>([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+  ]);
+  lruTouch(m, 'c');
+  assertEqual([...m.keys()].join(','), 'a,b,c', 'order unchanged');
+});
+
+test('lruTouch: does not modify map for missing key', () => {
+  const m = new Map<string, number>([['a', 1]]);
+  lruTouch(m, 'missing');
+  assertEqual(m.size, 1, 'size unchanged');
+  assertEqual(m.get('a'), 1, 'value unchanged');
+});
+
+// ---------------------------------------------------------------------------
+// lruEvictIfFull
+// ---------------------------------------------------------------------------
+
+test('lruEvictIfFull: no eviction when under capacity', () => {
+  const m = new Map<string, number>([['a', 1], ['b', 2]]);
+  lruEvictIfFull(m, 5);
+  assertEqual(m.size, 2, 'size unchanged');
+});
+
+test('lruEvictIfFull: evicts oldest entry when at capacity', () => {
+  const m = new Map<string, number>([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+  ]);
+  lruEvictIfFull(m, 3);
+  assertEqual(m.size, 2, 'one evicted');
+  assert(!m.has('a'), 'a should be evicted');
+  assert(m.has('b'), 'b remains');
+  assert(m.has('c'), 'c remains');
+});
+
+test('lruEvictIfFull: respects recency updates from lruTouch', () => {
+  const m = new Map<string, number>([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+  ]);
+  lruTouch(m, 'a'); // a becomes most-recent
+  lruEvictIfFull(m, 3);
+  assert(!m.has('b'), 'b (oldest after touch) should be evicted');
+  assert(m.has('a'), 'a should remain (just touched)');
+  assert(m.has('c'), 'c remains');
+});
+
+test('lruEvictIfFull: evicts multiple entries when over capacity', () => {
+  const m = new Map<string, number>([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+    ['d', 4],
+  ]);
+  lruEvictIfFull(m, 2);
+  assertEqual(m.size, 1, 'should evict down to size < maxSize');
+  assert(m.has('d'), 'newest remains');
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+const passed = results.filter((r) => r.passed).length;
+const failed = results.filter((r) => !r.passed).length;
+console.log('\n--- Test Summary ---');
+console.log(`Passed: ${passed}/${results.length}`);
+console.log(`Failed: ${failed}/${results.length}`);
+
+if (failed > 0) {
+  console.log('\nFailed tests:');
+  results
+    .filter((r) => !r.passed)
+    .forEach((r) => {
+      console.log(`  - ${r.name}: ${r.error}`);
+    });
+  process.exit(1);
+}

--- a/api/lib/lru.ts
+++ b/api/lib/lru.ts
@@ -1,0 +1,33 @@
+/**
+ * Tiny LRU helpers for Map-backed in-memory caches.
+ *
+ * ECMAScript Maps iterate in insertion order, so we get LRU semantics by
+ * (a) re-inserting on access so the touched entry moves to the end, and
+ * (b) evicting the first key (least-recently-used) when full.
+ *
+ * No dependencies, no class, no allocation on cache hits beyond the reinsert.
+ */
+
+/**
+ * Mark `key` as most-recently-used and return its value (or undefined if
+ * absent). Safe to call on a missing key — it's a no-op.
+ */
+export function lruTouch<K, V>(map: Map<K, V>, key: K): V | undefined {
+  if (!map.has(key)) return undefined;
+  const value = map.get(key) as V;
+  map.delete(key);
+  map.set(key, value);
+  return value;
+}
+
+/**
+ * Evict least-recently-used entries until `map.size < maxSize`. Call this
+ * before inserting a new entry if the cache has grown to capacity.
+ */
+export function lruEvictIfFull<K, V>(map: Map<K, V>, maxSize: number): void {
+  while (map.size >= maxSize) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}

--- a/api/lib/rate-limiter.ts
+++ b/api/lib/rate-limiter.ts
@@ -21,10 +21,13 @@ export async function checkRateLimit(
     const { getFirestore } = await import('./firestore-client');
     const jobsRef = getFirestore().collection('jobs');
 
-    // Check active jobs (QUEUED + RUNNING)
+    // Check active jobs (QUEUED + RUNNING). Limit caps the query at one
+    // over the threshold so a pathologically high-volume user can't cause
+    // the query to load thousands of docs into memory.
     const activeSnap = await jobsRef
       .where('createdBy', '==', userId)
       .where('status', 'in', ['QUEUED', 'RUNNING'])
+      .limit(MAX_ACTIVE_JOBS + 1)
       .get();
 
     if (activeSnap.size >= MAX_ACTIVE_JOBS) {
@@ -34,13 +37,16 @@ export async function checkRateLimit(
       };
     }
 
-    // Check daily limits
+    // Check daily limits. Limit caps at (MAX_JOBS_PER_DAY + 1) — if there
+    // are more than MAX_JOBS_PER_DAY we reject immediately, so we never
+    // need to sum simulations from more than MAX_JOBS_PER_DAY docs.
     const startOfDay = new Date();
     startOfDay.setHours(0, 0, 0, 0);
 
     const dailySnap = await jobsRef
       .where('createdBy', '==', userId)
       .where('createdAt', '>=', startOfDay)
+      .limit(MAX_JOBS_PER_DAY + 1)
       .get();
 
     if (dailySnap.size >= MAX_JOBS_PER_DAY) {

--- a/api/lib/saved-decks.ts
+++ b/api/lib/saved-decks.ts
@@ -240,6 +240,6 @@ export function deleteSavedDeck(filename: string): boolean {
     return true;
   } catch (err) {
     console.error(`Failed to delete deck ${filename}:`, err);
-    throw new Error('Failed to delete deck');
+    throw new Error('Failed to delete deck', { cause: err });
   }
 }

--- a/api/lib/stale-sweeper.test.ts
+++ b/api/lib/stale-sweeper.test.ts
@@ -244,7 +244,6 @@ async function runTests() {
       const result = await sweep(farFuture);
 
       assert(result.simsCancelled === 1, `one sim should be cancelled, got ${result.simsCancelled}`);
-      assert(result.aggregationsTriggered === 1, `aggregation should fire, got ${result.aggregationsTriggered}`);
 
       const sims = jobStoreSqlite.getSimulationStatuses(jobId);
       const stuckSim = sims.find((s) => s.simId === 'sim_001');
@@ -252,7 +251,12 @@ async function runTests() {
 
       const finalJob = jobStoreSqlite.getJob(jobId);
       // After aggregateJobResults on an all-terminal job, status should
-      // transition to COMPLETED (in local mode the aggregation runs inline).
+      // transition to COMPLETED (in local mode the aggregation runs inline
+      // inside recoverStaleSimulationsLocal since the gemini review fix).
+      // The observable outcome is what matters — `aggregationsTriggered`
+      // is implementation detail that depends on which internal code path
+      // fired the trigger (recovery vs sweeper catch-up), so we don't
+      // assert on the counter here.
       assert(finalJob!.status === 'COMPLETED', `job should be COMPLETED, got ${finalJob!.status}`);
     } finally {
       cleanupJob(jobId);

--- a/api/lib/store-guards.test.ts
+++ b/api/lib/store-guards.test.ts
@@ -42,10 +42,6 @@ async function test(name: string, fn: () => void | Promise<void>) {
   }
 }
 
-function assert(condition: boolean, message: string) {
-  if (!condition) throw new Error(message);
-}
-
 function assertEqual<T>(actual: T, expected: T, message: string) {
   if (actual !== expected) {
     throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);

--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -21,10 +21,6 @@ async function test(name: string, fn: () => void | Promise<void>) {
   }
 }
 
-function assert(condition: boolean, message: string) {
-  if (!condition) throw new Error(message);
-}
-
 function assertEqual<T>(actual: T, expected: T, message: string) {
   if (actual !== expected) {
     throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/nextjs": "^10.40.0",
         "@tailwindcss/postcss": "^4.1.18",
         "autoprefixer": "^10.4.21",
-        "better-sqlite3": "^11.6.0",
+        "better-sqlite3": "^12.8.0",
         "firebase-admin": "^13.6.0",
         "next": "15.5.7",
         "postcss": "^8.5.3",
@@ -27,13 +27,17 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^22.15.29",
         "@types/react": "^19.1.6",
         "@types/react-dom": "^19.1.5",
         "@types/uuid": "^10.0.0",
+        "eslint": "^10.2.0",
+        "globals": "^17.4.0",
         "tsx": "^4.19.4",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "typescript-eslint": "^8.58.1"
       },
       "optionalDependencies": {
         "@tailwindcss/oxide-linux-x64-gnu": "^4.1.8",
@@ -772,6 +776,173 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@fastify/busboy": {
       "version": "3.2.0",
       "license": "MIT"
@@ -1302,6 +1473,58 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/colour": {
@@ -4061,6 +4284,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4071,8 +4301,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
@@ -4169,6 +4398,275 @@
       "version": "10.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -4389,6 +4887,16 @@
         "acorn": "^8.14.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "license": "MIT",
@@ -4546,12 +5054,17 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bignumber.js": {
@@ -4876,6 +5389,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
@@ -5054,6 +5574,75 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.4",
+        "@eslint/config-helpers": "^0.5.4",
+        "@eslint/core": "^1.2.0",
+        "@eslint/plugin-kit": "^0.7.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -5068,12 +5657,157 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -5086,7 +5820,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -5106,6 +5839,16 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -5144,6 +5887,20 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -5225,6 +5982,19 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -5392,6 +6162,27 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -5626,12 +6417,38 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause",
       "peer": true
+    },
+    "node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/google-auth-library": {
       "version": "10.5.0",
@@ -5939,6 +6756,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-in-the-middle": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
@@ -5951,6 +6778,16 @@
         "module-details-from-path": "^1.0.4"
       }
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -5959,11 +6796,34 @@
       "version": "1.3.8",
       "license": "ISC"
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-reference": {
@@ -6060,6 +6920,13 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -6073,6 +6940,13 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6135,6 +7009,30 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -6613,6 +7511,13 @@
       "version": "2.0.0",
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -6766,6 +7671,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-defer": {
       "version": "3.0.0",
       "license": "MIT",
@@ -6875,9 +7798,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6979,6 +7902,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -7032,6 +7965,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/randombytes": {
@@ -7708,9 +8651,39 @@
         }
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -7744,6 +8717,19 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
@@ -7765,6 +8751,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {
@@ -7797,6 +8807,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -7936,6 +8956,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/api/package.json
+++ b/api/package.json
@@ -6,9 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start -p ${PORT:-3000}",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && eslint . --report-unused-disable-directives --max-warnings 0",
     "test:integration": "tsx test/integration.test.ts",
-    "test:unit": "tsx test/state-machine.test.ts && tsx test/game-logs.test.ts && tsx lib/condenser/condenser.test.ts && tsx lib/condenser/structured.test.ts && tsx lib/condenser/derive-job-status.test.ts && tsx lib/condenser/win-tally.test.ts && tsx lib/condenser/pipeline.test.ts && tsx lib/log-store.test.ts && tsx lib/store-guards.test.ts && tsx lib/job-store-aggregation.test.ts && tsx lib/validation.test.ts && tsx lib/stale-sweeper.test.ts && tsx test/cors.test.ts && tsx test/cors-wildcard.test.ts && tsx test/job-store-contract.test.ts && tsx test/cancel-recover.test.ts",
+    "test:unit": "tsx test/state-machine.test.ts && tsx test/game-logs.test.ts && tsx lib/condenser/condenser.test.ts && tsx lib/condenser/structured.test.ts && tsx lib/condenser/derive-job-status.test.ts && tsx lib/condenser/win-tally.test.ts && tsx lib/condenser/pipeline.test.ts && tsx lib/log-store.test.ts && tsx lib/lru.test.ts && tsx lib/store-guards.test.ts && tsx lib/job-store-aggregation.test.ts && tsx lib/validation.test.ts && tsx lib/stale-sweeper.test.ts && tsx test/cors.test.ts && tsx test/cors-wildcard.test.ts && tsx test/job-store-contract.test.ts && tsx test/cancel-recover.test.ts && tsx test/condenser-contract.test.ts",
     "test:cors": "tsx test/cors.test.ts && tsx test/cors-wildcard.test.ts",
     "test:ingestion": "tsx test/ingestion.test.ts",
     "test:condenser": "tsx lib/condenser/condenser.test.ts",
@@ -34,7 +34,7 @@
     "@sentry/nextjs": "^10.40.0",
     "@tailwindcss/postcss": "^4.1.18",
     "autoprefixer": "^10.4.21",
-    "better-sqlite3": "^11.6.0",
+    "better-sqlite3": "^12.8.0",
     "firebase-admin": "^13.6.0",
     "next": "15.5.7",
     "postcss": "^8.5.3",
@@ -45,13 +45,17 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^22.15.29",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
     "@types/uuid": "^10.0.0",
+    "eslint": "^10.2.0",
+    "globals": "^17.4.0",
     "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.58.1"
   },
   "optionalDependencies": {
     "@tailwindcss/oxide-linux-x64-gnu": "^4.1.8",

--- a/api/test/condenser-contract.test.ts
+++ b/api/test/condenser-contract.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Contract test: worker condenser vs API condenser.
+ *
+ * DATA_FLOW.md calls the worker's condenser "lightweight parsing" — it
+ * runs inside the worker immediately after a container exits to build
+ * a quick status update (winners[], winningTurns[]). The API re-runs
+ * the full authoritative condense/structure pipeline later during
+ * aggregation, and its results are what leaderboards and rating math
+ * consume.
+ *
+ * What MUST agree between the two implementations:
+ *   1. splitConcatenatedGames must produce the same NUMBER of games on
+ *      both sides. If it doesn't, the status update's winners[] array
+ *      has a different length than the API's aggregation expects,
+ *      breaking per-game attribution.
+ *   2. extractWinner must produce the same WINNER for each game index.
+ *      If it doesn't, the worker reports one player as the winner and
+ *      the API re-aggregates with a different one, and the UI flickers
+ *      or the rating math is wrong.
+ *
+ * What does NOT need to agree (intentional divergence):
+ *   - Byte-for-byte game boundaries. Both implementations agree on the
+ *     game count and on the line containing the winner, but they may
+ *     include slightly different surrounding noise in each chunk.
+ *   - extractWinningTurn. The worker's turn count is a preliminary
+ *     preview; the API's aggregation uses per-deck turn tracking which
+ *     is authoritative and overwrites it.
+ *
+ * If a future change makes the worker's turn extraction authoritative,
+ * add the stricter assertion here so drift is caught at test time.
+ *
+ * Run with: npx tsx test/condenser-contract.test.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  splitConcatenatedGames as apiSplit,
+  extractWinner as apiExtractWinner,
+  extractWinningTurn as apiExtractWinningTurn,
+} from '../lib/condenser/index';
+import {
+  splitConcatenatedGames as workerSplit,
+  extractWinner as workerExtractWinner,
+  extractWinningTurn as workerExtractWinningTurn,
+} from '../../worker/src/condenser';
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+const results: TestResult[] = [];
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    results.push({ name, passed: true });
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    results.push({ name, passed: false, error: message });
+    console.log(`✗ ${name}`);
+    console.log(`  Error: ${message}`);
+  }
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual<T>(actual: T, expected: T, message: string) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const FIXTURE_PATH = path.join(__dirname, '..', 'lib', 'condenser', 'fixtures', 'real-4game-log.txt');
+const RAW_LOG = fs.readFileSync(FIXTURE_PATH, 'utf-8');
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * The worker condenser returns `string` (empty for no winner) while the API
+ * condenser returns `string | undefined`. Normalize both to `undefined` so
+ * the contract check is an apples-to-apples comparison.
+ */
+function normWinner(w: string | undefined): string | undefined {
+  if (w === undefined || w === '' || w === null) return undefined;
+  return w;
+}
+
+/** Same normalization for winning turns: 0 or undefined means "no winner". */
+function normTurn(t: number | undefined): number | undefined {
+  if (t === undefined || t === 0) return undefined;
+  return t;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('splitConcatenatedGames: both implementations produce the same game count', () => {
+  const apiGames = apiSplit(RAW_LOG);
+  const workerGames = workerSplit(RAW_LOG);
+  assertEqual(workerGames.length, apiGames.length, 'game count');
+  assert(apiGames.length > 0, 'fixture must contain at least one game');
+});
+
+test('extractWinner: worker and API agree for every split game', () => {
+  // Each implementation extracts the winner from its own split output;
+  // that's the real flow — the worker reports winners[] to the API and
+  // the API re-derives winners during aggregation. Both sides must
+  // independently arrive at the same winner per game index.
+  const apiGames = apiSplit(RAW_LOG);
+  const workerGames = workerSplit(RAW_LOG);
+  for (let i = 0; i < apiGames.length; i++) {
+    const apiW = normWinner(apiExtractWinner(apiGames[i]));
+    const workerW = normWinner(workerExtractWinner(workerGames[i]));
+    assertEqual(workerW, apiW, `game ${i} winner`);
+  }
+});
+
+test('extractWinner: both sides find at least one winner in the fixture', () => {
+  // Guardrail: the fixture log is a 4-game real match; if a parser
+  // refactor accidentally produces "no winner" for every game, the
+  // previous test could pass trivially (undefined === undefined).
+  const apiGames = apiSplit(RAW_LOG);
+  const found = apiGames.filter((g) => normWinner(apiExtractWinner(g))).length;
+  assert(found > 0, 'fixture must contain at least one extractable winner');
+});
+
+test('extractWinner: empty log returns no winner on both sides', () => {
+  const apiW = normWinner(apiExtractWinner(''));
+  const workerW = normWinner(workerExtractWinner(''));
+  assertEqual(apiW, undefined, 'api empty');
+  assertEqual(workerW, undefined, 'worker empty');
+});
+
+test('extractWinningTurn: empty log returns no turn on both sides', () => {
+  const apiT = normTurn(apiExtractWinningTurn(''));
+  const workerT = normTurn(workerExtractWinningTurn(''));
+  assertEqual(apiT, undefined, 'api empty');
+  assertEqual(workerT, undefined, 'worker empty');
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log('\n--- Condenser Contract Test Summary ---');
+const passed = results.filter((r) => r.passed).length;
+const failed = results.filter((r) => !r.passed).length;
+console.log(`Passed: ${passed}/${results.length}`);
+console.log(`Failed: ${failed}/${results.length}`);
+
+if (failed > 0) {
+  console.log('\nFailed tests:');
+  results.filter((r) => !r.passed).forEach((r) => {
+    console.log(`  - ${r.name}: ${r.error}`);
+  });
+  process.exit(1);
+}

--- a/api/test/cors-wildcard.test.ts
+++ b/api/test/cors-wildcard.test.ts
@@ -2,14 +2,12 @@ import { NextRequest } from 'next/server';
 
 process.env.CORS_ALLOWED_ORIGINS = '*';
 
-let passed = 0;
 let failed = 0;
 
 async function test(name: string, fn: () => void | Promise<void>) {
   try {
     await fn();
     console.log(`✓ ${name}`);
-    passed++;
   } catch (error) {
     console.error(`✗ ${name}`);
     console.error(error);

--- a/api/test/ingestion.test.ts
+++ b/api/test/ingestion.test.ts
@@ -228,6 +228,7 @@ async function runTests() {
     const hackedCardLine = lines.find(l => l.includes('100 Black Lotus') && !l.includes('Commander'));
 
     assert(!hackedNameLine, "VULNERABILITY: Deck name injection successful (found independent Name=Hacked line)");
+    assert(!hackedCardLine, "VULNERABILITY: Card injection successful (found 100 Black Lotus outside commander line)");
     // The injected card would appear as "100 Black Lotus" if injection worked
     // If sanitized, it would be part of the commander line
 

--- a/api/test/job-store-contract.test.ts
+++ b/api/test/job-store-contract.test.ts
@@ -13,7 +13,7 @@
  */
 
 import * as jobStore from '../lib/job-store-factory';
-import type { DeckSlot, Job, SimulationStatus } from '../lib/types';
+import type { DeckSlot, SimulationStatus } from '../lib/types';
 
 // ---------------------------------------------------------------------------
 // Test Utilities

--- a/docs/SWEEPER_ALERTING.md
+++ b/docs/SWEEPER_ALERTING.md
@@ -1,0 +1,85 @@
+# Sweeper liveness alerting
+
+The stale-job sweeper (see [STALE_SWEEPER.md](./STALE_SWEEPER.md)) is the
+only recovery path for stuck jobs after PR #151 removed per-GET recovery.
+If Cloud Scheduler silently stops invoking `POST /api/admin/sweep-stale-jobs`
+— paused job, expired OIDC token, IAM regression — jobs can accumulate in
+a stuck state for hours before anyone notices.
+
+This document sets up a Cloud Monitoring alert that fires when the
+sweeper hasn't completed a successful run in the last 30 minutes.
+
+## How it works
+
+On every successful sweep, the route handler
+(`api/app/api/admin/sweep-stale-jobs/route.ts`) writes a structured log
+line with `event: "sweep-complete"` and the sweep's result counts.
+
+Cloud Monitoring builds a **log-based metric** that counts these entries,
+and an **alert policy** fires on the metric's absence (i.e., count == 0)
+over a 30-minute rolling window. That's longer than the 15-minute schedule
+interval so a single missed invocation doesn't page.
+
+## Deployment
+
+Prerequisites:
+- `gcloud` CLI authenticated against the `magic-bracket-simulator` project
+- A notification channel already exists (email, Slack, PagerDuty, etc.)
+
+### 1. Create the log-based metric
+
+```bash
+gcloud logging metrics create sweeper_completions \
+  --project=magic-bracket-simulator \
+  --description="Count of successful stale-sweeper runs" \
+  --log-filter='jsonPayload.component="stale-sweeper" AND jsonPayload.event="sweep-complete"'
+```
+
+### 2. Create the alert policy
+
+Save [`sweeper-alert-policy.yaml`](./sweeper-alert-policy.yaml) and apply
+it — update the notification channel ID first:
+
+```bash
+# Find your notification channel ID
+gcloud alpha monitoring channels list --project=magic-bracket-simulator
+
+# Edit docs/sweeper-alert-policy.yaml and replace the notificationChannels
+# entry with the ID from above, then apply:
+gcloud alpha monitoring policies create \
+  --project=magic-bracket-simulator \
+  --policy-from-file=docs/sweeper-alert-policy.yaml
+```
+
+### 3. Verify
+
+Wait 15 minutes for the next scheduled sweeper run, then run:
+
+```bash
+gcloud logging read \
+  'jsonPayload.component="stale-sweeper" AND jsonPayload.event="sweep-complete"' \
+  --project=magic-bracket-simulator \
+  --limit=5 \
+  --format='value(timestamp,jsonPayload.durationMs,jsonPayload.scanned)'
+```
+
+You should see one entry per scheduler run. If you see nothing, the
+sweeper is not running — which is exactly the condition the alert is
+designed to catch.
+
+## Testing the alert
+
+To force a fire without actually breaking the sweeper, temporarily edit
+the log-based metric filter to something that never matches (e.g.
+`jsonPayload.event="intentionally-nonexistent"`), wait 30 minutes, and
+confirm the alert opens. Revert the filter to restore normal operation.
+
+## Known limitations
+
+- **Cold start**: the very first sweep after an API deploy may take
+  longer than 30 minutes if Cloud Run scales to zero and the scheduler
+  invocation coincides with a deploy window. If this becomes noisy,
+  widen the alert's `duration` field in `sweeper-alert-policy.yaml`.
+- **One signal**: the alert only checks liveness, not correctness. A
+  sweeper that runs but always throws would still emit error logs and
+  fire Sentry alerts; those are tracked separately.

--- a/docs/sweeper-alert-policy.yaml
+++ b/docs/sweeper-alert-policy.yaml
@@ -1,0 +1,69 @@
+# Cloud Monitoring alert policy: sweeper liveness
+#
+# Fires if the stale-job sweeper has not emitted a successful completion
+# log line in the last 30 minutes. See docs/SWEEPER_ALERTING.md for full
+# deployment instructions.
+#
+# Prerequisites (run once before applying this file):
+#
+#   gcloud logging metrics create sweeper_completions \
+#     --project=magic-bracket-simulator \
+#     --description="Count of successful stale-sweeper runs" \
+#     --log-filter='jsonPayload.component="stale-sweeper" AND jsonPayload.event="sweep-complete"'
+#
+# Apply this policy:
+#
+#   gcloud alpha monitoring policies create \
+#     --project=magic-bracket-simulator \
+#     --policy-from-file=docs/sweeper-alert-policy.yaml
+#
+# REQUIRED: replace `REPLACE_WITH_CHANNEL_ID` below with a real
+# notification channel ID from:
+#   gcloud alpha monitoring channels list --project=magic-bracket-simulator
+
+displayName: "stale-sweeper has not completed a run in 30 minutes"
+documentation:
+  content: |
+    The stale-job sweeper is the only recovery path for stuck jobs
+    post-#151. This alert fires if no successful sweep has been logged
+    for 30 minutes (normal schedule is every 15 minutes, so missing one
+    invocation is tolerated but missing two is not).
+
+    Runbook:
+      1. Check Cloud Scheduler:
+         gcloud scheduler jobs list --project=magic-bracket-simulator
+         If the sweeper job is PAUSED, resume it.
+      2. Check the API's recent log entries for the sweeper component:
+         gcloud logging read 'jsonPayload.component="stale-sweeper"' \
+           --project=magic-bracket-simulator --limit=20
+      3. Check the API's authentication for WORKER_SECRET — expired
+         secrets cause the sweeper endpoint to return 401.
+      4. Worst case: run the sweeper manually to catch up:
+         curl -X POST https://api--magic-bracket-simulator.us-central1.hosted.app/api/admin/sweep-stale-jobs \
+           -H "X-Worker-Secret: $(gcloud secrets versions access latest --secret=worker-secret)"
+  mimeType: "text/markdown"
+
+conditions:
+  - displayName: "No sweep completions in 30 minutes"
+    conditionThreshold:
+      filter: >-
+        metric.type="logging.googleapis.com/user/sweeper_completions"
+        resource.type="cloud_run_revision"
+      comparison: COMPARISON_LT
+      thresholdValue: 1
+      duration: 1800s  # 30 minutes
+      aggregations:
+        - alignmentPeriod: 300s  # 5 minute buckets
+          perSeriesAligner: ALIGN_SUM
+      trigger:
+        count: 1
+
+combiner: OR
+enabled: true
+notificationChannels:
+  # Email channel created 2026-04-10 (tywholland@gmail.com). Replace or
+  # add additional channels (PagerDuty, Slack, etc.) as needed — list
+  # with: gcloud beta monitoring channels list
+  - projects/magic-bracket-simulator/notificationChannels/17583582606854007548
+alertStrategy:
+  autoClose: 86400s  # Auto-close after 24 hours if resolved

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,12 +2,17 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'tests', 'playwright-report', 'test-results'] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      jsxA11y.flatConfigs.recommended,
+    ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.1.8",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -26,6 +27,7 @@
         "@types/react-dom": "^19.1.5",
         "@vitejs/plugin-react": "^4.3.4",
         "eslint": "^9.17.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
@@ -1858,6 +1860,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -3352,6 +3370,106 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3360,6 +3478,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/balanced-match": {
@@ -3432,6 +3603,56 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3630,6 +3851,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -3642,6 +3870,60 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/debug": {
@@ -3676,6 +3958,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3703,6 +4021,21 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.283",
@@ -3743,12 +4076,161 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -3873,6 +4355,53 @@
           "optional": true
         }
       }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.2.0",
@@ -4147,6 +4676,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4160,6 +4705,57 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -4178,6 +4774,63 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob-parent": {
@@ -4206,12 +4859,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4221,6 +4917,77 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -4321,12 +5088,146 @@
         "node": ">=8"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -4339,12 +5240,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -4360,10 +5297,205 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4492,6 +5624,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4500,6 +5648,26 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/levn": {
@@ -4841,6 +6009,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -4911,6 +6089,88 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -4938,6 +6198,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -5043,6 +6321,63 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -5238,6 +6573,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5311,6 +6690,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5329,6 +6728,41 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -5365,6 +6799,55 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5386,6 +6869,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -5419,6 +6978,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -5430,6 +7003,80 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -5631,6 +7278,84 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -5667,6 +7392,25 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/undici": {
@@ -5966,6 +7710,95 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@sentry/react": "^10.40.0",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.1.8",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -29,6 +32,7 @@
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.17.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for Magic Bracket Simulator smoke tests.
+ *
+ * Runs against the Vite dev server. Auth-backed flows require a test user
+ * via Firebase Emulator or a stubbed auth provider (not yet configured) —
+ * see tests/smoke.spec.ts for what's currently covered.
+ *
+ * Run locally:
+ *   npm run test:e2e         # headless
+ *   npm run test:e2e:ui      # with Playwright UI
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'list',
+
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  // Start the Vite dev server automatically unless PLAYWRIGHT_BASE_URL is set
+  // (in which case we assume the user is running against a deployed instance).
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:5173',
+        reuseExistingServer: !process.env.CI,
+        // Vite's first-run is slow (esbuild prebundle on cold cache can take
+        // 90+ seconds on a fresh clone). Give it plenty of headroom; on
+        // subsequent runs this is essentially instant.
+        timeout: 180_000,
+      },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/src/hooks/useJobStream.test.ts
+++ b/frontend/src/hooks/useJobStream.test.ts
@@ -246,6 +246,7 @@ describe('mergeFirestoreJobUpdate', () => {
     parallelism: 4,
     createdAt: '2026-04-10T12:00:00.000Z',
     startedAt: '2026-04-10T12:00:05.000Z',
+    durationMs: null,
     retryCount: 0,
     results: null,
   };

--- a/frontend/src/hooks/useJobStream.test.ts
+++ b/frontend/src/hooks/useJobStream.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement, type ReactNode } from 'react';
-import { useJobStream } from './useJobStream';
+import { useJobStream, mergeFirestoreJobUpdate } from './useJobStream';
 import { fetchWithAuth } from '../api';
+import type { JobResponse } from '@shared/types/job';
 
 vi.mock('../firebase');
 vi.mock('../api', () => ({
@@ -220,5 +221,125 @@ describe('useJobStream', () => {
     });
 
     expect(result.current.simulations).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeFirestoreJobUpdate: ordering race contract
+//
+// The hook merges REST fetch results with onSnapshot updates into the same
+// React Query cache entry. These tests lock in the invariant that once a
+// job has transitioned to a terminal state, a subsequent stale onSnapshot
+// cannot regress it back to RUNNING (which would cause the UI to flicker
+// and, worse, retrigger polling).
+// ---------------------------------------------------------------------------
+
+describe('mergeFirestoreJobUpdate', () => {
+  const RUNNING_JOB: JobResponse = {
+    id: 'job-1',
+    name: 'A vs B vs C vs D',
+    deckNames: ['A', 'B', 'C', 'D'],
+    deckIds: ['d1', 'd2', 'd3', 'd4'],
+    status: 'RUNNING',
+    simulations: 20,
+    gamesCompleted: 4,
+    parallelism: 4,
+    createdAt: '2026-04-10T12:00:00.000Z',
+    startedAt: '2026-04-10T12:00:05.000Z',
+    retryCount: 0,
+    results: null,
+  };
+
+  const COMPLETED_JOB: JobResponse = {
+    ...RUNNING_JOB,
+    status: 'COMPLETED',
+    gamesCompleted: 20,
+    completedAt: '2026-04-10T12:10:00.000Z',
+    durationMs: 10 * 60 * 1000,
+    results: { winnerCounts: {}, totalGames: 20 } as unknown as JobResponse['results'],
+  };
+
+  it('returns undefined prev unchanged (no prior REST fetch)', () => {
+    const result = mergeFirestoreJobUpdate(undefined, { status: 'COMPLETED' });
+    expect(result).toBeUndefined();
+  });
+
+  it('applies Firestore update to in-progress job', () => {
+    const result = mergeFirestoreJobUpdate(RUNNING_JOB, {
+      status: 'RUNNING',
+      gamesCompleted: 12,
+    });
+    expect(result?.status).toBe('RUNNING');
+    expect(result?.gamesCompleted).toBe(12);
+  });
+
+  it('transitions RUNNING → COMPLETED when Firestore reports terminal state', () => {
+    const result = mergeFirestoreJobUpdate(RUNNING_JOB, {
+      status: 'COMPLETED',
+      gamesCompleted: 20,
+      completedAt: '2026-04-10T12:10:00.000Z',
+    });
+    expect(result?.status).toBe('COMPLETED');
+    expect(result?.gamesCompleted).toBe(20);
+    expect(result?.durationMs).toBe(10 * 60 * 1000 - 5000); // started - completed
+  });
+
+  it('REGRESSION GUARD: stale RUNNING onSnapshot cannot revert a terminal job', () => {
+    // Scenario: REST fetch arrives first and sets the cache to COMPLETED.
+    // Then a stale onSnapshot message (produced before the worker finalized)
+    // arrives with status=RUNNING, gamesCompleted=12. The merge must refuse
+    // to touch the job so the UI does not flicker and polling does not
+    // re-enable itself.
+    const staleUpdate = {
+      status: 'RUNNING',
+      gamesCompleted: 12,
+      completedSimCount: 3,
+    };
+    const result = mergeFirestoreJobUpdate(COMPLETED_JOB, staleUpdate);
+    // Should be identical (===) to the terminal prev — no merge applied
+    expect(result).toBe(COMPLETED_JOB);
+    expect(result?.status).toBe('COMPLETED');
+    expect(result?.gamesCompleted).toBe(20);
+  });
+
+  it('REGRESSION GUARD: onSnapshot→REST order converges to COMPLETED', () => {
+    // Simulate: onSnapshot fires first with RUNNING update (normal flow),
+    // then REST fetch arrives with the authoritative COMPLETED payload.
+    // The second call is a full cache.setQueryData to fullJob (not a merge),
+    // so we simulate that here by asserting the final state is COMPLETED.
+    const afterSnapshot = mergeFirestoreJobUpdate(RUNNING_JOB, {
+      status: 'RUNNING',
+      gamesCompleted: 12,
+    });
+    expect(afterSnapshot?.status).toBe('RUNNING');
+    expect(afterSnapshot?.gamesCompleted).toBe(12);
+
+    // Now the terminal REST fetch lands. The hook replaces cache wholesale
+    // via queryClient.setQueryData, but for the merge contract we re-run
+    // with the REST payload as `prev` to assert the terminal guard still
+    // protects against any subsequent stale onSnapshot.
+    const afterLateSnapshot = mergeFirestoreJobUpdate(COMPLETED_JOB, {
+      status: 'RUNNING',
+      gamesCompleted: 12,
+    });
+    expect(afterLateSnapshot?.status).toBe('COMPLETED');
+    expect(afterLateSnapshot?.gamesCompleted).toBe(20);
+  });
+
+  it('computes durationMs from startedAt+completedAt when both present', () => {
+    const result = mergeFirestoreJobUpdate(RUNNING_JOB, {
+      completedAt: '2026-04-10T12:00:10.000Z',
+    });
+    // completedAt - startedAt = 5s
+    expect(result?.durationMs).toBe(5000);
+  });
+
+  it('prefers completedSimCount over gamesCompleted when both provided', () => {
+    const result = mergeFirestoreJobUpdate(RUNNING_JOB, {
+      completedSimCount: 3, // 3 * GAMES_PER_CONTAINER
+      gamesCompleted: 999,   // stale, should lose
+    });
+    // GAMES_PER_CONTAINER is 4 per shared constants
+    expect(result?.gamesCompleted).toBe(12);
   });
 });

--- a/frontend/src/hooks/useJobStream.ts
+++ b/frontend/src/hooks/useJobStream.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { doc, collection, onSnapshot, getDoc, getDocs, query, orderBy, Timestamp } from 'firebase/firestore';
 import { db, isFirebaseConfigured } from '../firebase';
 import { getApiBase, fetchWithAuth } from '../api';
@@ -7,6 +7,50 @@ import { isTerminal } from '../utils/status';
 import { GAMES_PER_CONTAINER } from '@shared/types/job';
 import type { JobResponse } from '@shared/types/job';
 import type { SimulationStatus } from '@shared/types/simulation';
+
+// ---------------------------------------------------------------------------
+// Deck caching
+// ---------------------------------------------------------------------------
+
+interface CachedDeckMeta {
+  link: string | null;
+  colorIdentity: string[] | null;
+}
+
+/**
+ * Look up a deck's display metadata (link + color identity) from React
+ * Query's cache, falling back to a Firestore read on miss. Decks are
+ * effectively immutable after creation, so `staleTime: Infinity` is safe
+ * and saves ~4 Firestore reads per job view (previously every job load
+ * fetched the 4 deck docs even across repeated views of the same job).
+ */
+function deckMetaQueryKey(deckId: string): [string, string] {
+  return ['deckMeta', deckId];
+}
+
+async function fetchDeckMetaFirestore(deckId: string): Promise<CachedDeckMeta> {
+  const snap = await getDoc(doc(db!, 'decks', deckId));
+  if (!snap.exists()) return { link: null, colorIdentity: null };
+  const data = snap.data();
+  const link = (data.link as string | undefined) ?? null;
+  const ci = data.colorIdentity as string[] | undefined;
+  return {
+    link,
+    colorIdentity: ci && ci.length > 0 ? ci : null,
+  };
+}
+
+async function getCachedDeckMeta(
+  queryClient: QueryClient,
+  deckId: string,
+): Promise<CachedDeckMeta> {
+  return queryClient.fetchQuery({
+    queryKey: deckMetaQueryKey(deckId),
+    queryFn: () => fetchDeckMetaFirestore(deckId),
+    staleTime: Infinity,
+    gcTime: 30 * 60 * 1000, // 30 min idle eviction
+  });
+}
 
 // ---------------------------------------------------------------------------
 // REST API fetchers (LOCAL mode only)
@@ -54,6 +98,14 @@ function firestoreDocToJobResponse(
     ? data.deckIds as string[]
     : undefined;
 
+  // Denormalized deck metadata (written at job creation time by
+  // api/app/api/jobs/route.ts). Newer jobs carry these directly on the
+  // job doc, eliminating the 4 deck-doc reads the hook used to do on
+  // every job view. Older jobs pre-denormalization will be undefined
+  // and the fetch-and-cache fallback in fetchJobFirestore kicks in.
+  const denormalizedDeckLinks = data.deckLinks as Record<string, string | null> | undefined;
+  const denormalizedColorIdentity = data.colorIdentity as Record<string, string[]> | undefined;
+
   const createdAt = timestampToIso(data.createdAt) ?? new Date().toISOString();
   const startedAt = timestampToIso(data.startedAt);
   const completedAt = timestampToIso(data.completedAt);
@@ -93,6 +145,8 @@ function firestoreDocToJobResponse(
     ...(claimedAt ? { claimedAt } : undefined),
     retryCount: (data.retryCount as number) ?? 0,
     results: (data.results as JobResponse['results']) ?? null,
+    ...(denormalizedDeckLinks && { deckLinks: denormalizedDeckLinks }),
+    ...(denormalizedColorIdentity && { colorIdentity: denormalizedColorIdentity }),
   };
 }
 
@@ -100,30 +154,35 @@ function firestoreDocToJobResponse(
 // Firestore direct reads (GCP mode — bypasses Cloud Run)
 // ---------------------------------------------------------------------------
 
-async function fetchJobFirestore(jobId: string): Promise<JobResponse> {
+async function fetchJobFirestore(
+  jobId: string,
+  queryClient: QueryClient,
+): Promise<JobResponse> {
   const snapshot = await getDoc(doc(db!, 'jobs', jobId));
   if (!snapshot.exists()) throw new Error('Job not found');
   const job = firestoreDocToJobResponse(jobId, snapshot.data());
 
-  // Resolve deck links and color identity directly from the decks collection.
-  // These are parallel reads — no Cloud Run dependency.
+  // Fast path: job doc was denormalized at creation time (all jobs after
+  // the FU3 rollout). Zero Firestore deck reads. This path covers Browse,
+  // leaderboard, and detail views for any recent job.
+  if (job.deckLinks && job.deckNames.every((name) => name in (job.deckLinks ?? {}))) {
+    return job;
+  }
+
+  // Slow path: legacy job without denormalized metadata. Fall back to
+  // fetching each deck doc through the React Query cache so a given
+  // session only pays the Firestore read once.
   if (job.deckIds && job.deckIds.length === job.deckNames.length) {
-    const deckSnapshots = await Promise.all(
-      job.deckIds.map((id) => getDoc(doc(db!, 'decks', id))),
+    const deckMetas = await Promise.all(
+      job.deckIds.map((id) => getCachedDeckMeta(queryClient, id)),
     );
     const deckLinks: Record<string, string | null> = {};
     const colorIdentity: Record<string, string[]> = {};
-    for (let i = 0; i < deckSnapshots.length; i++) {
-      const snap = deckSnapshots[i];
+    for (let i = 0; i < deckMetas.length; i++) {
+      const meta = deckMetas[i];
       const name = job.deckNames[i];
-      if (snap.exists()) {
-        const data = snap.data();
-        deckLinks[name] = (data.link as string) ?? null;
-        const ci = data.colorIdentity as string[] | undefined;
-        if (ci && ci.length > 0) colorIdentity[name] = ci;
-      } else {
-        deckLinks[name] = null;
-      }
+      deckLinks[name] = meta.link;
+      if (meta.colorIdentity) colorIdentity[name] = meta.colorIdentity;
     }
     job.deckLinks = deckLinks;
     if (Object.keys(colorIdentity).length > 0) job.colorIdentity = colorIdentity;
@@ -148,8 +207,13 @@ async function fetchSimulationsFirestore(jobId: string): Promise<SimulationStatu
 /**
  * Merge real-time Firestore fields into an existing JobResponse.
  * Skips terminal jobs — the initial read is authoritative once complete.
+ *
+ * Exported for testing: the ordering contract (terminal state wins, no
+ * regression from later onSnapshot arriving with stale RUNNING data) is
+ * exercised by `useJobStream.test.ts` via direct calls so the assertions
+ * don't depend on Firestore mock internals.
  */
-function mergeFirestoreJobUpdate(
+export function mergeFirestoreJobUpdate(
   prev: JobResponse | undefined,
   firestoreData: Record<string, unknown>,
 ): JobResponse | undefined {
@@ -243,7 +307,7 @@ export function useJobStream(jobId: string | undefined) {
   // Primary data: Firestore direct reads in GCP mode, REST in local mode
   const jobQuery = useQuery({
     queryKey: ['job', jobId],
-    queryFn: () => db ? fetchJobFirestore(jobId!) : fetchJobRest(jobId!),
+    queryFn: () => db ? fetchJobFirestore(jobId!, queryClient) : fetchJobRest(jobId!),
     enabled: !!jobId,
     refetchInterval: (query) => {
       if (isFirebaseConfigured) return false;
@@ -293,7 +357,7 @@ export function useJobStream(jobId: string | undefined) {
           unsubscribed = true;
           if (!wasAlreadyTerminal) {
             // Re-read from Firestore to get final state with all fields
-            fetchJobFirestore(jobId).then((fullJob) => {
+            fetchJobFirestore(jobId, queryClient).then((fullJob) => {
               queryClient.setQueryData(['job', jobId], fullJob);
             }).catch((err) => {
               console.error('[useJobStream] Final Firestore fetch failed:', err);

--- a/frontend/src/pages/Browse.tsx
+++ b/frontend/src/pages/Browse.tsx
@@ -202,9 +202,10 @@ export default function Browse() {
    * Load the next page of older jobs. Works in both GCP and LOCAL mode:
    * - LOCAL: nextCursor came from the initial REST fetch.
    * - GCP: the initial list is live via Firestore onSnapshot, so we derive
-   *   the cursor from the createdAt of the oldest currently-visible job.
-   *   The backend cursor format is base64(createdAt ISO string), which
-   *   matches what `/api/jobs` returns in `nextCursor`.
+   *   the cursor from the oldest currently-visible job using a composite
+   *   (createdAt, id) cursor that matches the server's wire format.
+   *   Without the id tie-breaker, two jobs created in the same millisecond
+   *   could be skipped or duplicated on page boundaries.
    */
   const loadMore = useCallback(async () => {
     if (loadingMore) return;
@@ -213,11 +214,12 @@ export default function Browse() {
     try {
       let cursor = nextCursor;
       if (!cursor) {
-        // GCP mode first Load More: derive from oldest visible job.
+        // GCP mode first Load More: build a composite cursor from the
+        // oldest visible job. Wire format: base64(JSON({ts, id})).
         const visible = [...jobs, ...extraJobs];
         const oldest = visible[visible.length - 1];
         if (!oldest) return;
-        cursor = btoa(oldest.createdAt);
+        cursor = btoa(JSON.stringify({ ts: oldest.createdAt, id: oldest.id }));
       }
       const url = `${apiBase}/api/jobs?limit=100&cursor=${encodeURIComponent(cursor)}`;
       const res = await fetchWithAuth(url);

--- a/frontend/src/pages/Browse.tsx
+++ b/frontend/src/pages/Browse.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { collection, query, orderBy, limit, onSnapshot } from 'firebase/firestore';
 import type { Timestamp } from 'firebase/firestore';
@@ -105,6 +105,14 @@ export default function Browse() {
   const [jobs, setJobs] = useState<JobSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Pagination (M2): `jobs` holds the live first page. `extraJobs` holds
+  // older pages appended via "Load More". `nextCursor` is the REST cursor
+  // for the next page beyond what's currently visible; null means we've
+  // reached the end.
+  const [extraJobs, setExtraJobs] = useState<JobSummary[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
   // Admin bulk-delete state
   const [selectedJobs, setSelectedJobs] = useState<Set<string>>(new Set());
   const [isDeleting, setIsDeleting] = useState(false);
@@ -121,7 +129,7 @@ export default function Browse() {
     });
   };
 
-  const selectAll = () => setSelectedJobs(new Set(jobs.map((j) => j.id)));
+  const selectAll = () => setSelectedJobs(new Set([...jobs, ...extraJobs].map((j) => j.id)));
   const deselectAll = () => setSelectedJobs(new Set());
 
   const handleBulkDelete = async () => {
@@ -179,6 +187,7 @@ export default function Browse() {
       if (!res.ok) throw new Error('Failed to fetch jobs');
       const data = await res.json();
       setJobs(data.jobs || []);
+      setNextCursor((data.nextCursor as string | null) ?? null);
       setError(null);
       return data.jobs as JobSummary[];
     } catch (err) {
@@ -188,6 +197,54 @@ export default function Browse() {
       setIsLoading(false);
     }
   }, [apiBase]);
+
+  /**
+   * Load the next page of older jobs. Works in both GCP and LOCAL mode:
+   * - LOCAL: nextCursor came from the initial REST fetch.
+   * - GCP: the initial list is live via Firestore onSnapshot, so we derive
+   *   the cursor from the createdAt of the oldest currently-visible job.
+   *   The backend cursor format is base64(createdAt ISO string), which
+   *   matches what `/api/jobs` returns in `nextCursor`.
+   */
+  const loadMore = useCallback(async () => {
+    if (loadingMore) return;
+    setLoadingMore(true);
+    setLoadMoreError(null);
+    try {
+      let cursor = nextCursor;
+      if (!cursor) {
+        // GCP mode first Load More: derive from oldest visible job.
+        const visible = [...jobs, ...extraJobs];
+        const oldest = visible[visible.length - 1];
+        if (!oldest) return;
+        cursor = btoa(oldest.createdAt);
+      }
+      const url = `${apiBase}/api/jobs?limit=100&cursor=${encodeURIComponent(cursor)}`;
+      const res = await fetchWithAuth(url);
+      if (!res.ok) throw new Error(`Failed to load more jobs (HTTP ${res.status})`);
+      const data = await res.json();
+      const newJobs = (data.jobs as JobSummary[] | undefined) ?? [];
+      // Dedupe: if a job is already in the live list, drop it from the new
+      // page (can happen if Firestore onSnapshot and REST overlap at the
+      // boundary).
+      const existingIds = new Set([...jobs, ...extraJobs].map((j) => j.id));
+      const deduped = newJobs.filter((j) => !existingIds.has(j.id));
+      setExtraJobs((prev) => [...prev, ...deduped]);
+      setNextCursor((data.nextCursor as string | null) ?? null);
+    } catch (err) {
+      setLoadMoreError(err instanceof Error ? err.message : 'Failed to load more jobs');
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [apiBase, jobs, extraJobs, nextCursor, loadingMore]);
+
+  // Combined visible list: live first page + appended older pages.
+  const visibleJobs = useMemo(() => [...jobs, ...extraJobs], [jobs, extraJobs]);
+
+  // Whether more history is available. Unknown in GCP mode until the user
+  // clicks Load More once, so we optimistically show the button as long
+  // as the live list has the full 100 items (suggesting there may be more).
+  const hasMoreHistory = nextCursor != null || (extraJobs.length === 0 && jobs.length >= 100);
 
   useEffect(() => {
     if (db) return; // Handled by Firestore onSnapshot above
@@ -271,21 +328,21 @@ export default function Browse() {
         </div>
       )}
 
-      {!isLoading && !error && jobs.length === 0 && (
+      {!isLoading && !error && visibleJobs.length === 0 && (
         <div className="bg-gray-800 rounded-lg p-6 text-gray-400 text-center">
           No simulations yet.
         </div>
       )}
 
       {/* Admin bulk-delete toolbar */}
-      {isAdmin && !isLoading && jobs.length > 0 && (
+      {isAdmin && !isLoading && visibleJobs.length > 0 && (
         <div className="mb-3 flex items-center gap-3 bg-gray-800 rounded-lg px-4 py-2 border border-gray-700">
           <button
             type="button"
-            onClick={selectedJobs.size === jobs.length ? deselectAll : selectAll}
+            onClick={selectedJobs.size === visibleJobs.length ? deselectAll : selectAll}
             className="text-sm text-blue-400 hover:text-blue-300"
           >
-            {selectedJobs.size === jobs.length ? 'Deselect All' : 'Select All'}
+            {selectedJobs.size === visibleJobs.length ? 'Deselect All' : 'Select All'}
           </button>
           {selectedJobs.size > 0 && (
             <>
@@ -310,9 +367,9 @@ export default function Browse() {
         </div>
       )}
 
-      {!isLoading && !error && jobs.length > 0 && (
+      {!isLoading && !error && visibleJobs.length > 0 && (
         <div className="space-y-3">
-          {jobs.map((run) => (
+          {visibleJobs.map((run) => (
             <Link
               key={run.id}
               to={`/jobs/${run.id}`}
@@ -379,6 +436,27 @@ export default function Browse() {
               )}
             </Link>
           ))}
+
+          {/* Load More / end-of-history */}
+          {hasMoreHistory && (
+            <div className="pt-2 flex flex-col items-center gap-2">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="px-5 py-2 rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium flex items-center gap-2"
+              >
+                {loadingMore && <Spinner size="sm" />}
+                {loadingMore ? 'Loading...' : 'Load more'}
+              </button>
+              {loadMoreError && (
+                <p className="text-xs text-red-400">{loadMoreError}</p>
+              )}
+            </div>
+          )}
+          {!hasMoreHistory && visibleJobs.length >= 100 && (
+            <p className="pt-2 text-center text-xs text-gray-500">End of history.</p>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -7,6 +7,8 @@ import { ColorIdentity } from '../components/ColorIdentity';
 import { SliderWithInput } from '../components/SliderWithInput';
 import { LoginButton } from '../components/LoginButton';
 import { RequestAccessCard } from '../components/RequestAccessCard';
+import { WorkerStatusBanner } from '../components/WorkerStatusBanner';
+import { useWorkerStatus } from '../hooks/useWorkerStatus';
 import { GAMES_PER_CONTAINER } from '../types/simulation';
 
 interface Deck {
@@ -373,6 +375,10 @@ function SimulationForm() {
 
   return (
     <div className="max-w-4xl mx-auto">
+      {/* Worker pool health banner: shows when no workers are online so
+          users understand why newly-created jobs will sit in QUEUED. */}
+      <HomeWorkerStatus />
+
       {/* Add Deck Section */}
       <div className="bg-gray-800 rounded-lg p-6 mb-6">
         <h2 className="text-xl font-semibold mb-4">Add a Deck</h2>
@@ -692,5 +698,24 @@ function SimulationForm() {
         </button>
       </form>
     </div>
+  );
+}
+
+/**
+ * Thin wrapper so the simulation form doesn't need to know about the
+ * worker-status hook. Rendered above the form on Home so users see
+ * "No workers online" before they spend time building a job.
+ */
+function HomeWorkerStatus() {
+  const { user } = useAuth();
+  const { workers, queueDepth, isLoading, refresh } = useWorkerStatus(!!user);
+  return (
+    <WorkerStatusBanner
+      workers={workers}
+      queueDepth={queueDepth}
+      isLoading={isLoading}
+      onRefresh={refresh}
+      userEmail={user?.email}
+    />
   );
 }

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke tests — verify the app boots, routes render, and the critical
+ * unauthenticated entry points don't throw. These tests run against the
+ * Vite dev server (see playwright.config.ts).
+ *
+ * What's covered:
+ *   - / renders without JS errors
+ *   - Unauthenticated users see a sign-in prompt
+ *   - /browse is reachable
+ *   - No uncaught errors in the console during page load
+ *
+ * What's NOT covered (would require a test auth provider):
+ *   - End-to-end "create a job and watch it run" flow
+ *   - Firebase-authenticated routes
+ *   - Worker pool interactions
+ *
+ * To extend with authenticated flows: run the Firebase Auth Emulator and
+ * configure frontend/public/config.json to point at it; inject a test
+ * token via page.addInitScript() before the first navigation.
+ */
+
+test.describe('smoke', () => {
+  // Catch any console errors that happen during page load — these are
+  // almost always real bugs that would otherwise go unnoticed in CI.
+  test.beforeEach(async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        // Firebase config warnings when running against local without auth
+        // are expected; filter them out of the failure signal.
+        const text = msg.text();
+        if (text.includes('Firebase') || text.includes('firebase')) return;
+        errors.push(`console.error: ${text}`);
+      }
+    });
+    // Stash on the test info so individual tests can assert on it
+    test.info().annotations.push({ type: 'errors-array' });
+    (page as unknown as { _consoleErrors: string[] })._consoleErrors = errors;
+  });
+
+  test('home page renders without errors', async ({ page }) => {
+    await page.goto('/');
+    // The root app shell should render — <h1>, <nav>, or a recognizable
+    // branded element. We only assert that the body has non-empty content
+    // so we don't couple to specific copy.
+    await expect(page.locator('body')).not.toBeEmpty();
+    const errors = (page as unknown as { _consoleErrors: string[] })._consoleErrors;
+    expect(errors, `Unexpected console errors: ${errors.join('\n')}`).toHaveLength(0);
+  });
+
+  test('app shell renders branded header and nav', async ({ page }) => {
+    await page.goto('/');
+    // The Header is auth-state independent and always renders the branded
+    // logo text. If this is missing, the app shell failed to mount —
+    // routes, lazy imports, or the layout are broken.
+    await expect(
+      page.getByRole('link', { name: /magic bracket simulator/i })
+    ).toBeVisible({ timeout: 15_000 });
+    // The Rankings link is also always visible regardless of auth state.
+    await expect(page.getByRole('link', { name: /rankings/i })).toBeVisible();
+  });
+
+  test('/browse route is reachable', async ({ page }) => {
+    await page.goto('/browse');
+    await expect(page.locator('body')).not.toBeEmpty();
+    // Browse page either shows the jobs list or a sign-in prompt
+    // depending on auth state. Either is acceptable — we only care
+    // that the route loads without crashing.
+    const errors = (page as unknown as { _consoleErrors: string[] })._consoleErrors;
+    expect(errors, `Unexpected console errors: ${errors.join('\n')}`).toHaveLength(0);
+  });
+
+  test('unknown route does not white-screen', async ({ page }) => {
+    await page.goto('/this-route-does-not-exist');
+    await expect(page.locator('body')).not.toBeEmpty();
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,5 +6,7 @@ export default mergeConfig(viteConfig, defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    // Exclude Playwright E2E tests — they're run via `npm run test:e2e`.
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests/**'],
   },
 }));

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -31,8 +31,19 @@ services:
       - WORKER_ID=${WORKER_ID:-}
       - JOBS_DIR=/tmp/mbs-jobs
 
-      # Simulation image — full GHCR path for the worker to pull
-      - SIMULATION_IMAGE=${SIMULATION_IMAGE:-ghcr.io/tytaniumdev/magicbracketsimulator/simulation:latest}
+      # Simulation image — pinned to a SHA256 digest so an attacker who
+      # compromises the registry can't push a malicious :latest the worker
+      # would auto-pull on next restart. To upgrade to a newer build:
+      #
+      #   1. docker pull ghcr.io/tytaniumdev/magicbracketsimulator/simulation:latest
+      #   2. docker inspect --format='{{index .RepoDigests 0}}' \
+      #        ghcr.io/tytaniumdev/magicbracketsimulator/simulation:latest
+      #   3. Copy the printed `@sha256:...` string into the default below,
+      #      commit, and redeploy the worker.
+      #
+      # Override via env var (e.g. for local testing with a specific build):
+      #   SIMULATION_IMAGE=ghcr.io/.../simulation:my-branch docker compose up
+      - SIMULATION_IMAGE=${SIMULATION_IMAGE:-ghcr.io/tytaniumdev/magicbracketsimulator/simulation@sha256:330594cdd7a90a50d2c66c07af3674ab451dad489665cd63a927c57f730fc50e}
 
       # Worker owner email (for frontend UI ownership)
       - WORKER_OWNER_EMAIL=${WORKER_OWNER_EMAIL:-}
@@ -44,6 +55,13 @@ services:
       # Docker CLI API version — worker image ships Docker CLI v20 (API 1.41) but
       # newer daemons (v25+) require API ≥1.44. Override to negotiate correctly.
       - DOCKER_API_VERSION=1.44
+
+      # Opt-in read-only filesystem for simulation containers. When set to 1,
+      # each `docker run` for a simulation passes --read-only plus tmpfs
+      # mounts for the paths Forge writes to. Verified end-to-end against
+      # a real 4-player Commander game. See worker/src/docker-runner.ts
+      # for the exact flags.
+      - SIMULATION_READONLY=${SIMULATION_READONLY:-1}
 
     # Grant access to the host Docker socket (GID varies by runtime: Colima=991, Linux=999, etc.)
     # DOCKER_SOCK_GID is set by setup-worker.sh; falls back to 0 (root) if unset.

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google-cloud/pubsub": "^4.3.0",
         "@google-cloud/secret-manager": "^5.6.0",
+        "@sentry/node": "^10.48.0",
         "dotenv": "^17.2.3"
       },
       "devDependencies": {
@@ -434,6 +435,72 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fastify/otel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+      "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.2.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
@@ -562,11 +629,550 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
+      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+      "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+      "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+      "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+      "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+      "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+      "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+      "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+      "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
+      "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+      "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+      "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+      "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.36.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+      "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+      "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+      "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+      "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+      "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@opentelemetry/sql-common": "^0.41.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+      "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
+      "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+      "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.24.0.tgz",
+      "integrity": "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
+      "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -575,6 +1181,74 @@
       "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+      "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -631,6 +1305,138 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@sentry/core": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.48.0.tgz",
+      "integrity": "sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/context-async-hooks": "^2.6.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-ioredis": "0.62.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-redis": "0.62.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/instrumentation-undici": "0.24.0",
+        "@opentelemetry/resources": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.48.0",
+        "@sentry/node-core": "10.48.0",
+        "@sentry/opentelemetry": "10.48.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/node-core": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.48.0.tgz",
+      "integrity": "sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.48.0",
+        "@sentry/opentelemetry": "10.48.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/context-async-hooks": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.48.0.tgz",
+      "integrity": "sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -644,10 +1450,28 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.30",
@@ -655,6 +1479,26 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/request": {
@@ -666,6 +1510,15 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -682,6 +1535,27 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/agent-base": {
@@ -727,6 +1601,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -754,6 +1637,18 @@
         "node": "*"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -770,6 +1665,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -1010,6 +1911,12 @@
       "engines": {
         "node": ">= 0.12"
       }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1265,6 +2172,21 @@
         "node": ">= 14"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1363,6 +2285,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1409,6 +2352,76 @@
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proto3-json-serializer": {
@@ -1464,6 +2477,19 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1688,6 +2714,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/worker/package.json
+++ b/worker/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@google-cloud/pubsub": "^4.3.0",
     "@google-cloud/secret-manager": "^5.6.0",
+    "@sentry/node": "^10.48.0",
     "dotenv": "^17.2.3"
   },
   "devDependencies": {

--- a/worker/src/docker-runner.ts
+++ b/worker/src/docker-runner.ts
@@ -156,11 +156,59 @@ export async function runSimulationContainer(
     deckEnvVars.push('-e', `DECK_${i}_B64=${b64}`);
   }
 
+  // Hardening: simulation containers run untrusted user input (deck lists
+  // drive the Forge engine). These flags reduce blast radius if Forge or
+  // a dependency has a bug that lets user input escalate:
+  //   --cap-drop=ALL             no Linux capabilities (deny raw sockets etc.)
+  //   --security-opt=no-new-privileges
+  //                              suid/setgid binaries can't escalate
+  //   --pids-limit=256           fork bomb protection
+  //
+  // Opt-in via SIMULATION_READONLY=1:
+  //   --read-only                root filesystem is read-only, writable
+  //                              areas are tmpfs mounts covering every
+  //                              path Forge and our shell script write to:
+  //                                - /tmp              bash mktemp, JRE io.tmpdir
+  //                                - /home/simulator/.forge
+  //                                                    decks + user config
+  //                                - /home/simulator/.cache
+  //                                                    card database cache
+  //                                - /app/logs         per-game log files
+  //
+  //                              uid/gid=999 match the `simulator` user
+  //                              created in simulation/Dockerfile. Without
+  //                              these, tmpfs defaults to root-owned and
+  //                              the unprivileged simulator user can't
+  //                              write (mode=700/755 is too strict for
+  //                              the default world-writable 1777 fallback).
+  //                              If the Dockerfile's user/UID ever changes,
+  //                              update these values too.
+  //
+  //                              Verified end-to-end against a real Forge
+  //                              4-player Commander game before rolling out.
+  // Not applied:
+  //   --network=none             skipped per user: Forge/xvfb may need net
+  //                              access for card data downloads.
+  const readonly = process.env.SIMULATION_READONLY === '1';
+  const readonlyArgs = readonly
+    ? [
+        '--read-only',
+        '--tmpfs', '/tmp:rw,noexec,nosuid,size=128m,mode=1777',
+        '--tmpfs', '/home/simulator/.forge:rw,nosuid,size=64m,uid=999,gid=999,mode=700',
+        '--tmpfs', '/home/simulator/.cache:rw,nosuid,size=256m,uid=999,gid=999,mode=700',
+        '--tmpfs', '/app/logs:rw,noexec,nosuid,size=128m,uid=999,gid=999,mode=755',
+      ]
+    : [];
+
   const args = [
     'run', '--rm',
     '--name', containerName,
     '--memory', `${RAM_PER_SIM_MB}m`,
     '--cpus', String(CPUS_PER_SIM),
+    '--cap-drop=ALL',
+    '--security-opt=no-new-privileges',
+    '--pids-limit=256',
+    ...readonlyArgs,
     ...deckEnvVars,
     '-e', 'FORGE_PATH=/app/forge',
     '-e', 'LOGS_DIR=/app/logs',

--- a/worker/src/sentry.ts
+++ b/worker/src/sentry.ts
@@ -1,0 +1,79 @@
+/**
+ * Worker Sentry initialization.
+ *
+ * Graceful no-op when SENTRY_DSN is unset so LOCAL and dev workers don't
+ * need to care. All instrumentation goes through this module so we get
+ * consistent tags and a single place to change configuration.
+ */
+import * as Sentry from '@sentry/node';
+
+const dsn = process.env.SENTRY_DSN;
+const enabled = !!dsn;
+
+if (enabled) {
+  Sentry.init({
+    dsn,
+    environment: process.env.GOOGLE_CLOUD_PROJECT ? 'production' : 'local',
+    // Tracing is opt-in per-transaction; most worker code doesn't need it.
+    tracesSampleRate: 0.1,
+    // The worker runs long-lived processes; keep error sampling at 1.0 so
+    // we never miss failures (they're already rare).
+    sampleRate: 1.0,
+  });
+}
+
+export interface WorkerErrorTags {
+  jobId?: string;
+  simId?: string;
+  simIndex?: number;
+  workerId?: string;
+  component?: string;
+}
+
+/**
+ * Capture an exception with worker-specific tags. No-op if Sentry is disabled.
+ */
+export function captureWorkerException(
+  error: unknown,
+  tags: WorkerErrorTags = {}
+): void {
+  if (!enabled) return;
+  Sentry.captureException(error, {
+    tags: {
+      component: tags.component ?? 'worker',
+      ...(tags.jobId && { jobId: tags.jobId }),
+      ...(tags.simId && { simId: tags.simId }),
+      ...(tags.simIndex != null && { simIndex: String(tags.simIndex) }),
+      ...(tags.workerId && { workerId: tags.workerId }),
+    },
+  });
+}
+
+/**
+ * Add a breadcrumb for observability. No-op if Sentry is disabled.
+ */
+export function addWorkerBreadcrumb(
+  message: string,
+  data?: Record<string, unknown>
+): void {
+  if (!enabled) return;
+  Sentry.addBreadcrumb({
+    message,
+    category: 'worker',
+    level: 'info',
+    ...(data && { data }),
+  });
+}
+
+/**
+ * Flush pending Sentry events before the process exits. Call before
+ * process.exit() so fatal errors are reported.
+ */
+export async function flushSentry(timeoutMs = 2000): Promise<void> {
+  if (!enabled) return;
+  try {
+    await Sentry.flush(timeoutMs);
+  } catch {
+    // Best-effort flush; never block shutdown.
+  }
+}

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -50,6 +50,7 @@ import {
 import { startWorkerApi, stopWorkerApi, HealthStatus } from './worker-api.js';
 import { GAMES_PER_CONTAINER } from './constants.js';
 import { createLogger } from './logger.js';
+import { captureWorkerException, addWorkerBreadcrumb, flushSentry } from './sentry.js';
 
 const log = createLogger('Worker');
 
@@ -279,11 +280,21 @@ async function uploadSingleSimulationLog(
     });
     if (!res.ok) {
       console.warn(`[sim_${String(simIndex).padStart(3, '0')}] Log upload failed: HTTP ${res.status}`);
+      captureWorkerException(
+        new Error(`Log upload failed: HTTP ${res.status}`),
+        { component: 'log-upload', jobId, simIndex, workerId: currentWorkerId }
+      );
     } else {
       console.log(`[sim_${String(simIndex).padStart(3, '0')}] Log uploaded (${(logText.length / 1024).toFixed(1)}KB)`);
     }
   } catch (err) {
     console.warn(`[sim_${String(simIndex).padStart(3, '0')}] Log upload error:`, err instanceof Error ? err.message : err);
+    captureWorkerException(err, {
+      component: 'log-upload',
+      jobId,
+      simIndex,
+      workerId: currentWorkerId,
+    });
   }
 }
 
@@ -302,6 +313,31 @@ async function processSimulation(
 ): Promise<void> {
   const simLabel = `[${simId}]`;
   console.log(`${simLabel} Processing simulation for job ${jobId}`);
+  addWorkerBreadcrumb('processSimulation:start', { jobId, simId, simIndex });
+
+  try {
+    await processSimulationInternal(jobId, simId, simIndex);
+  } catch (err) {
+    // Any uncaught error from container orchestration, reporting, etc.
+    // lands here. Capture with full context before re-throwing so the
+    // caller's error handling (semaphore release, abort cleanup) still runs.
+    captureWorkerException(err, {
+      component: 'process-simulation',
+      jobId,
+      simId,
+      simIndex,
+      workerId: currentWorkerId,
+    });
+    throw err;
+  }
+}
+
+async function processSimulationInternal(
+  jobId: string,
+  simId: string,
+  simIndex: number
+): Promise<void> {
+  const simLabel = `[${simId}]`;
 
   // Fetch job for deck data
   const job = await fetchJob(jobId);
@@ -755,6 +791,7 @@ async function handleMessage(message: any): Promise<void> {
     messageData = JSON.parse(message.data.toString());
   } catch (error) {
     console.error('Failed to parse message:', error);
+    captureWorkerException(error, { component: 'pubsub-parse' });
     message.ack(); // Ack invalid messages to prevent redelivery
     return;
   }
@@ -789,6 +826,8 @@ async function handleMessage(message: any): Promise<void> {
       await processSimulation(jobId, simId, simIndex);
     } catch (error) {
       console.error(`Error processing simulation ${simId} for job ${jobId}:`, error);
+      // processSimulation already captured the exception with context;
+      // this outer catch is just the API-reporting safety net.
       await reportSimulationStatus(jobId, simId, {
         state: 'FAILED',
         errorMessage: error instanceof Error ? error.message : 'Unknown error',
@@ -920,6 +959,10 @@ async function pollForJobs(): Promise<void> {
     } catch (error) {
       if (error instanceof Error && error.name !== 'TimeoutError') {
         console.error('Polling error:', error);
+        captureWorkerException(error, {
+          component: 'polling-loop',
+          workerId: currentWorkerId,
+        });
       }
     }
     // No user jobs available — check for coverage work
@@ -1101,7 +1144,9 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
   log.error('Failed to start', { error: error instanceof Error ? error.message : String(error) });
+  captureWorkerException(error, { component: 'worker-startup' });
+  await flushSentry();
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

Closes the outstanding items from the two-reviewer architectural audit run earlier today. One PR, one squashable commit, everything lint-green, all tests green, and the Cloud Monitoring alert that depends on this code's structured log is already provisioned (snoozed for 6h while this merges).

## What's in here

**API**
- C1: `/api/jobs/:id/logs/simulation` rejects oversize uploads (10 MB cap) via early `Content-Length` + library defense-in-depth
- M5: deck-by-id cache converted FIFO → LRU via a new reusable `lib/lru.ts` helper (9 unit tests)
- M3: rate-limiter Firestore queries bounded with `.limit()`
- M2: `GET /api/jobs` cursor pagination (`?limit=N&cursor=X`, returns `nextCursor`); `listJobs` contract updated through factory + both stores
- C2: LOCAL-mode stuck-job recovery — detects dead-worker claims, resets RUNNING/FAILED sims to PENDING, aggregates when all terminal
- H4: `coverage-service.getAllMatchResults` replaced with a cursor-paginated `forEachMatchResult` streamer — no more unbounded `.get()` on matchResults
- M4: ESLint added to the API (`eslint.config.mjs`), wired into `npm run lint`, fixed 36 pre-existing warnings across 25 files (unused vars, `preserve-caught-error` with `{ cause }`, useless regex escapes, control-regex disables in deck sanitizer, one genuine test gap where `hackedCardLine` was assigned but never asserted)
- H5: new `/api/health/workers` endpoint returns 503 when no worker has heartbeated, ready for a Cloud Monitoring uptime check
- M6: cross-package condenser contract test (`api/test/condenser-contract.test.ts`) locks in the "both implementations agree on game count and winner identity" invariant; explicitly does NOT assert byte-for-byte splits or winning-turn equality since those are intentional per DATA_FLOW.md
- FU3: job docs now carry denormalized `deckLinks` + `colorIdentity` at creation time — kills 4 Firestore deck reads per job view on the hot path
- Sweeper emits a `{ component: "stale-sweeper", event: "sweep-complete" }` structured log on every successful run; Cloud Monitoring metric + alert already wired to this log filter

**Frontend**
- jsx-a11y plugin added to `frontend/eslint.config.js`; 34 a11y rules active, zero violations
- Playwright smoke tests: 4 tests, webServer auto-spawns Vite, `tests/smoke.spec.ts` covers app shell, routing, and unknown-route fallback
- H3: React Query deck cache with `staleTime: Infinity` via a new `getCachedDeckMeta(queryClient, deckId)` helper; `fetchJobFirestore` has a fast path that skips deck fetches entirely when the job doc already carries denormalized metadata, and falls back to the cache for legacy jobs
- M7: `mergeFirestoreJobUpdate` exported and locked down with 7 new tests for the REST/onSnapshot ordering race, including the terminal-state-guard regression
- FU4: Browse "Load More" button reads `nextCursor` from the API; works in both GCP mode (derives cursor from oldest visible job) and LOCAL mode (uses the REST `nextCursor` from the initial fetch); dedupes by job id to survive the onSnapshot/REST boundary
- Home now renders the existing `WorkerStatusBanner` so users see "no workers online" before they bother building a job

**Worker**
- Sentry instrumentation via new `worker/src/sentry.ts`: `captureWorkerException` wraps `processSimulation`, `uploadSingleSimulationLog`, the polling loop, and startup; graceful no-op when `SENTRY_DSN` is unset
- Simulation container hardening:
  - `--cap-drop=ALL --security-opt=no-new-privileges --pids-limit=256` (always on)
  - Opt-in `--read-only` via `SIMULATION_READONLY=1` (default `1` in compose), with tmpfs mounts for `/tmp`, `/home/simulator/.forge`, `/home/simulator/.cache`, `/app/logs`. Verified end-to-end: a full 4-player Commander game ran to completion under this config (Temur Roar won turn 18 in 38.5s)
- `SIMULATION_IMAGE` pinned to `@sha256:330594cdd7a90a50d2c66c07af3674ab451dad489665cd63a927c57f730fc50e` in `docker-compose.yml` with an upgrade recipe in the comment

**Compat**
- `better-sqlite3` 11.x → 12.8.0 — first version with Node 25 prebuilt ABI. Unblocks the full API `test:unit` suite on Node 25 (217 assertions / 14 files, previously 0 could run locally).

**Docs + infra**
- `docs/SWEEPER_ALERTING.md` — how to deploy the log-based metric and alert policy
- `docs/sweeper-alert-policy.yaml` — applied already, channel ID in place
- Cloud Monitoring state, applied out of band:
  - Log-based metric: `sweeper_completions` (filter: `jsonPayload.component="stale-sweeper" AND jsonPayload.event="sweep-complete"`)
  - Alert policy: "stale-sweeper has not completed a run in 30 minutes" → `projects/magic-bracket-simulator/alertPolicies/4953463769873939615`
  - Email channel: verified, wired to tywholland@gmail.com
  - 6h snooze (`271673547191117283491414869356895824408`) so the alert does not fire while the deploy catches up

## Test plan

- [x] `cd api && npm run lint` — tsc + eslint clean
- [x] `cd api && npm run test:unit` — **217 assertions across 14 files, all passing** on Node 25 (unblocked by the better-sqlite3 bump)
- [x] `cd frontend && npm run lint` — eslint clean including jsx-a11y
- [x] `cd frontend && npm test` — **91 vitest tests passing** (6 files)
- [x] `cd frontend && npx playwright test` — **4/4 smoke tests passing** (home renders, app shell, /browse, unknown route)
- [x] `cd worker && npx tsc --noEmit` — clean
- [x] Manual: simulation container `--read-only` verified end-to-end against the real `ghcr.io/.../simulation@sha256:330594cdd` image with 4 real Commander decks; full 18-turn game completed in 38.5s
- [x] Manual: Cloud Monitoring metric + alert + channel + snooze live

## Post-merge

- Firebase App Hosting auto-rolls the API on push to `main`; `rollout-safety-net.yml` is the backstop if the control plane misses the rollout
- `deploy.yml` deploys the frontend + Firestore rules
- Worker is on a separate lifecycle (`deploy-worker.yml`) — redeploy there when ready to pick up the Sentry instrumentation, read-only flag, and pinned image digest
- Snooze expires ~`2026-04-11T09:32:13Z`. Once the API deploy is live, the next 15-minute sweeper invocation will emit `sweep-complete` and the alert pipeline is fully validated in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)