### PR TITLE
fix(frontend): remove lazy route chunks to avoid stale-chunk white screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,12 @@
-import { Suspense, lazy } from 'react';
 import { Routes, Route, Link } from 'react-router-dom';
 import { LoginButton } from './components/LoginButton';
 import { useAuth } from './contexts/AuthContext';
-
-const Browse = lazy(() => import('./pages/Browse'));
-const Home = lazy(() => import('./pages/Home'));
-const JobStatus = lazy(() => import('./pages/JobStatus'));
-const WorkerSetup = lazy(() => import('./pages/WorkerSetup'));
-const Leaderboard = lazy(() => import('./pages/Leaderboard'));
-const SentryExamplePage = lazy(() => import('./pages/SentryExamplePage'));
+import Browse from './pages/Browse';
+import Home from './pages/Home';
+import JobStatus from './pages/JobStatus';
+import WorkerSetup from './pages/WorkerSetup';
+import Leaderboard from './pages/Leaderboard';
+import SentryExamplePage from './pages/SentryExamplePage';
 
 function Header() {
   const { user, isAllowed, loading } = useAuth();
@@ -94,20 +92,14 @@ export default function App() {
         <>
           <Header />
           <main className="container mx-auto px-4 py-8">
-            <Suspense fallback={
-              <div className="flex items-center justify-center py-20">
-                <div className="animate-spin h-8 w-8 border-4 border-purple-500 border-t-transparent rounded-full" />
-              </div>
-            }>
-              <Routes>
-                <Route path="/" element={<Browse />} />
-                <Route path="/submit" element={<Home />} />
-                <Route path="/jobs/:id" element={<JobStatus />} />
-                <Route path="/worker-setup" element={<WorkerSetup />} />
-                <Route path="/leaderboard" element={<Leaderboard />} />
-                <Route path="/sentry-example-page" element={<SentryExamplePage />} />
-              </Routes>
-            </Suspense>
+            <Routes>
+              <Route path="/" element={<Browse />} />
+              <Route path="/submit" element={<Home />} />
+              <Route path="/jobs/:id" element={<JobStatus />} />
+              <Route path="/worker-setup" element={<WorkerSetup />} />
+              <Route path="/leaderboard" element={<Leaderboard />} />
+              <Route path="/sentry-example-page" element={<SentryExamplePage />} />
+            </Routes>
           </main>
         </>
       )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route, Link } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { LoginButton } from './components/LoginButton';
 import { useAuth } from './contexts/AuthContext';
 import Browse from './pages/Browse';
@@ -92,14 +93,29 @@ export default function App() {
         <>
           <Header />
           <main className="container mx-auto px-4 py-8">
-            <Routes>
-              <Route path="/" element={<Browse />} />
-              <Route path="/submit" element={<Home />} />
-              <Route path="/jobs/:id" element={<JobStatus />} />
-              <Route path="/worker-setup" element={<WorkerSetup />} />
-              <Route path="/leaderboard" element={<Leaderboard />} />
-              <Route path="/sentry-example-page" element={<SentryExamplePage />} />
-            </Routes>
+            <Sentry.ErrorBoundary
+              fallback={
+                <div className="flex flex-col items-center justify-center py-20 gap-4 text-gray-400">
+                  <p>Something went wrong.</p>
+                  <button
+                    type="button"
+                    onClick={() => window.location.reload()}
+                    className="text-sm text-blue-400 hover:text-blue-300 font-medium transition-colors"
+                  >
+                    Reload page
+                  </button>
+                </div>
+              }
+            >
+              <Routes>
+                <Route path="/" element={<Browse />} />
+                <Route path="/submit" element={<Home />} />
+                <Route path="/jobs/:id" element={<JobStatus />} />
+                <Route path="/worker-setup" element={<WorkerSetup />} />
+                <Route path="/leaderboard" element={<Leaderboard />} />
+                <Route path="/sentry-example-page" element={<SentryExamplePage />} />
+              </Routes>
+            </Sentry.ErrorBoundary>
           </main>
         </>
       )}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,4 +19,10 @@ export default defineConfig({
   server: {
     port: 5173,
   },
+  build: {
+    // Single-bundle output is intentional to avoid stale-chunk white screens
+    // on deploy (see PR #157). Raise the advisory threshold so the warning
+    // doesn't drown out future, genuinely-interesting chunk-size warnings.
+    chunkSizeWarningLimit: 1000,
+  },
 });


### PR DESCRIPTION
## Summary
- Route components in `frontend/src/App.tsx` were loaded via `React.lazy(() => import(...))`, emitting hashed chunks like `JobStatus-Dan9ymUP.js` on each build.
- When a deploy landed while a user had a tab open, the in-memory bundle still referenced the old hashed filenames. Firebase Hosting no longer had those files, the SPA rewrite returned `index.html` with `Content-Type: text/html`, the browser's strict module-script MIME check rejected it, the dynamic import threw, and the whole tree crashed to a blank white page (no error boundary).
- Switched all six route components to direct imports and dropped the `<Suspense>` wrapper. The entire stale-chunk failure mode is eliminated.

## Why not code-split?
- Single bundle is now 949 KB raw / **270 KB gzipped**, which is fine for a 6-route React + Firebase + Tailwind + TanStack Query app.
- Users pay the cost once (cached for a year via hashed filename) instead of risking a white screen on every navigation-during-deploy.
- Also removes the spinner flicker between routes.
- Vite's 500 KB chunk advisory will print during build — that's the intentional tradeoff, ignore it.

## What this does NOT fix
- `ERR_BLOCKED_BY_CLIENT` Firestore errors in the console are an unrelated ad blocker killing Firestore's Listen websocket. Not addressed here.

## Test plan
- [x] `npm run lint --prefix frontend` — zero warnings
- [x] `npm run build --prefix frontend` — tsc + vite build succeed, single `index-<hash>.js` output
- [x] Verified `frontend/dist/assets/` contains exactly one JS bundle (no per-route chunks)
- [ ] After deploy: confirm navigating to a job page no longer produces a white screen when a deploy lands mid-session

🤖 Generated with [Claude Code](https://claude.com/claude-code)