### PR TITLE
fix(api): retry GCS uploads on TLS handshake socket disconnect

### DIFF
--- a/api/lib/gcs-retry.test.ts
+++ b/api/lib/gcs-retry.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for gcs-retry.ts — retry classification for GCS operations.
+ *
+ * Run with: npx tsx lib/gcs-retry.test.ts
+ */
+
+import { isRetryableGcsError } from './gcs-retry';
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+const results: TestResult[] = [];
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    results.push({ name, passed: true });
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    results.push({ name, passed: false, error: message });
+    console.log(`✗ ${name}`);
+    console.log(`  Error: ${message}`);
+  }
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message);
+}
+
+// ---------------------------------------------------------------------------
+// Non-Error inputs
+// ---------------------------------------------------------------------------
+
+test('returns false for non-Error values', () => {
+  assert(!isRetryableGcsError('some string'), 'string should not be retryable');
+  assert(!isRetryableGcsError(null), 'null should not be retryable');
+  assert(!isRetryableGcsError(undefined), 'undefined should not be retryable');
+  assert(!isRetryableGcsError({ message: 'socket hang up' }), 'plain object should not be retryable');
+});
+
+// ---------------------------------------------------------------------------
+// Known-retryable message substrings (existing behavior)
+// ---------------------------------------------------------------------------
+
+test('retries on socket hang up', () => {
+  assert(isRetryableGcsError(new Error('socket hang up')), 'socket hang up');
+});
+
+test('retries on ECONNRESET (case-insensitive)', () => {
+  assert(isRetryableGcsError(new Error('ECONNRESET')), 'uppercase ECONNRESET');
+  assert(isRetryableGcsError(new Error('read econnreset')), 'lowercase within message');
+});
+
+test('retries on ETIMEDOUT', () => {
+  assert(isRetryableGcsError(new Error('connect ETIMEDOUT 1.2.3.4:443')), 'ETIMEDOUT');
+});
+
+test('retries on ECONNREFUSED', () => {
+  assert(isRetryableGcsError(new Error('connect ECONNREFUSED')), 'ECONNREFUSED');
+});
+
+test('retries on generic network error wording', () => {
+  assert(isRetryableGcsError(new Error('Network error while uploading')), 'network error');
+});
+
+// ---------------------------------------------------------------------------
+// Regression for issue #158: TLS-handshake socket disconnect
+// ---------------------------------------------------------------------------
+
+test('retries on "Client network socket disconnected before secure TLS connection was established" (issue #158)', () => {
+  // Exact message observed in Sentry MAGIC-BRACKET-API-3.
+  const err = new Error(
+    'request to https://storage.googleapis.com/upload/storage/v1/b/magic-bracket-simulator-artifacts/o?name=jobs%2F4ipRXXpEREnNZa2sAVka%2Fraw%2Fgame_001.txt&uploadType=resumable failed, reason: Client network socket disconnected before secure TLS connection was established'
+  );
+  assert(isRetryableGcsError(err), 'TLS socket disconnect should be retryable');
+});
+
+test('retries on bare "Client network socket disconnected" wording', () => {
+  const err = new Error('Client network socket disconnected before secure TLS connection was established');
+  assert(isRetryableGcsError(err), 'bare TLS disconnect wording should be retryable');
+});
+
+// ---------------------------------------------------------------------------
+// HTTP status codes
+// ---------------------------------------------------------------------------
+
+test('retries on 429/500/502/503/504 via .code', () => {
+  for (const code of [429, 500, 502, 503, 504]) {
+    const err = Object.assign(new Error('server blew up'), { code });
+    assert(isRetryableGcsError(err), `code ${code} should be retryable`);
+  }
+});
+
+test('does NOT retry on 400/401/403/404', () => {
+  for (const code of [400, 401, 403, 404]) {
+    const err = Object.assign(new Error('nope'), { code });
+    assert(!isRetryableGcsError(err), `code ${code} should not be retryable`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Non-retryable cases
+// ---------------------------------------------------------------------------
+
+test('does not retry on arbitrary application errors', () => {
+  assert(!isRetryableGcsError(new Error('permission denied')), 'permission denied');
+  assert(!isRetryableGcsError(new Error('invalid bucket name')), 'invalid bucket');
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+const passed = results.filter((r) => r.passed).length;
+const failed = results.filter((r) => !r.passed).length;
+console.log('\n--- Test Summary ---');
+console.log(`Passed: ${passed}/${results.length}`);
+console.log(`Failed: ${failed}/${results.length}`);
+
+if (failed > 0) {
+  console.log('\nFailed tests:');
+  results
+    .filter((r) => !r.passed)
+    .forEach((r) => {
+      console.log(`  - ${r.name}: ${r.error}`);
+    });
+  process.exit(1);
+}

--- a/api/lib/gcs-retry.ts
+++ b/api/lib/gcs-retry.ts
@@ -5,6 +5,7 @@
  * real @google-cloud/storage client.
  */
 
+// All entries must be lowercase — error.message is lowercased before comparison.
 const RETRYABLE_MESSAGES = [
   'socket hang up',
   'econnreset',

--- a/api/lib/gcs-retry.ts
+++ b/api/lib/gcs-retry.ts
@@ -1,0 +1,37 @@
+/**
+ * Retry classification for GCS operations.
+ *
+ * Lives in its own module so it can be unit-tested without constructing a
+ * real @google-cloud/storage client.
+ */
+
+const RETRYABLE_MESSAGES = [
+  'socket hang up',
+  'econnreset',
+  'etimedout',
+  'econnrefused',
+  'network error',
+  // Node emits this when a socket closes mid-TLS-handshake. Observed in
+  // production against storage.googleapis.com resumable uploads (issue #158).
+  'client network socket disconnected',
+];
+const RETRYABLE_CODES = [429, 500, 502, 503, 504];
+
+/**
+ * Returns true for transient network/server errors that are safe to retry.
+ */
+export function isRetryableGcsError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const msg = error.message.toLowerCase();
+  if (RETRYABLE_MESSAGES.some(retryableMsg => msg.includes(retryableMsg))) {
+    return true;
+  }
+
+  const code = (error as { code?: number }).code;
+  if (typeof code === 'number' && RETRYABLE_CODES.includes(code)) {
+    return true;
+  }
+
+  return false;
+}

--- a/api/lib/gcs-storage.ts
+++ b/api/lib/gcs-storage.ts
@@ -1,4 +1,5 @@
 import { Storage } from '@google-cloud/storage';
+import { isRetryableGcsError } from './gcs-retry';
 import { withRetry } from './retry';
 
 // Initialize Cloud Storage client
@@ -8,34 +9,6 @@ const storage = new Storage({
 
 const BUCKET_NAME = process.env.GCS_BUCKET || 'magic-bracket-simulator-artifacts';
 const bucket = storage.bucket(BUCKET_NAME);
-
-/**
- * Returns true for transient network/server errors that are safe to retry.
- */
-function isRetryableGcsError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-
-  const RETRYABLE_MESSAGES = [
-    'socket hang up',
-    'econnreset',
-    'etimedout',
-    'econnrefused',
-    'network error',
-  ];
-  const RETRYABLE_CODES = [429, 500, 502, 503, 504];
-
-  const msg = error.message.toLowerCase();
-  if (RETRYABLE_MESSAGES.some(retryableMsg => msg.includes(retryableMsg))) {
-    return true;
-  }
-
-  const code = (error as { code?: number }).code;
-  if (typeof code === 'number' && RETRYABLE_CODES.includes(code)) {
-    return true;
-  }
-
-  return false;
-}
 
 /**
  * Upload a job artifact to GCS

--- a/api/package.json
+++ b/api/package.json
@@ -8,7 +8,7 @@
     "start": "next start -p ${PORT:-3000}",
     "lint": "tsc --noEmit && eslint . --report-unused-disable-directives --max-warnings 0",
     "test:integration": "tsx test/integration.test.ts",
-    "test:unit": "tsx test/state-machine.test.ts && tsx test/game-logs.test.ts && tsx lib/condenser/condenser.test.ts && tsx lib/condenser/structured.test.ts && tsx lib/condenser/derive-job-status.test.ts && tsx lib/condenser/win-tally.test.ts && tsx lib/condenser/pipeline.test.ts && tsx lib/log-store.test.ts && tsx lib/lru.test.ts && tsx lib/store-guards.test.ts && tsx lib/job-store-aggregation.test.ts && tsx lib/validation.test.ts && tsx lib/stale-sweeper.test.ts && tsx test/cors.test.ts && tsx test/cors-wildcard.test.ts && tsx test/job-store-contract.test.ts && tsx test/cancel-recover.test.ts && tsx test/condenser-contract.test.ts",
+    "test:unit": "tsx test/state-machine.test.ts && tsx test/game-logs.test.ts && tsx lib/condenser/condenser.test.ts && tsx lib/condenser/structured.test.ts && tsx lib/condenser/derive-job-status.test.ts && tsx lib/condenser/win-tally.test.ts && tsx lib/condenser/pipeline.test.ts && tsx lib/log-store.test.ts && tsx lib/lru.test.ts && tsx lib/store-guards.test.ts && tsx lib/job-store-aggregation.test.ts && tsx lib/validation.test.ts && tsx lib/stale-sweeper.test.ts && tsx lib/gcs-retry.test.ts && tsx test/cors.test.ts && tsx test/cors-wildcard.test.ts && tsx test/job-store-contract.test.ts && tsx test/cancel-recover.test.ts && tsx test/condenser-contract.test.ts",
     "test:cors": "tsx test/cors.test.ts && tsx test/cors-wildcard.test.ts",
     "test:ingestion": "tsx test/ingestion.test.ts",
     "test:condenser": "tsx lib/condenser/condenser.test.ts",


### PR DESCRIPTION
## Summary
- Sentry issue #158 fired on `Client network socket disconnected before secure TLS connection was established` escaping the GCS upload retry wrapper and tripping the Aggregation Failures (critical) alert.
- Root cause: `isRetryableGcsError` recognized `socket hang up`, `ECONNRESET`, `ETIMEDOUT`, `ECONNREFUSED`, and `network error` wording — but not Node's TLS-handshake phrasing. One transient handshake failure bypassed `withRetry` entirely.
- Added `'client network socket disconnected'` to the retryable allowlist, extracted the classifier to `api/lib/gcs-retry.ts` so it can be unit-tested without a real `@google-cloud/storage` client, and added `gcs-retry.test.ts` with regression coverage built from the exact Sentry message.

## Test Plan
- [x] New `api/lib/gcs-retry.test.ts` watched fail (2/11 red) before the fix, then all 11 pass after
- [x] `npm run test:unit --prefix api` — full suite green (19 test files)
- [x] `npm run lint --prefix api` — `tsc --noEmit` + ESLint zero-warning clean
- [ ] Post-merge: watch Sentry MAGIC-BRACKET-API-3 for recurrence over next upload cycles — expect the retry to absorb these transient failures

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)