### PR TITLE
fix(api): restore memory to 1GiB to stop sweeper OOM

### DIFF
--- a/api/apphosting.yaml
+++ b/api/apphosting.yaml
@@ -2,7 +2,7 @@
 runConfig:
   minInstances: 0
   maxInstances: 1
-  memory: 512MiB
+  memory: 1GiB
   cpu: 1
   concurrency: 80
 


### PR DESCRIPTION
## Summary

- **Incident:** `stale-sweeper` alert firing since ~20:40 UTC today. Every scheduled sweep since 20:15 has returned 503 because the API Cloud Run container is being OOM-killed mid-request.
- **Root cause:** #153 dropped memory from 1GiB → 512MiB banking on architectural wins in #148–#152. Current cold-start + sweep processing lands at 526–535 MiB — just past the ceiling. Logs show `Memory limit of 512 MiB exceeded` followed by `Uncaught signal: 6`.
- **Impact:** #151 made the sweeper the *only* recovery path for stuck jobs. An OOMing sweeper means stuck jobs accumulate unrecovered.
- **Fix:** reverse the memory change from #153 (512MiB → 1GiB). One-line config change.

## Why not investigate first

#153's commit message said: *"If we see OOMs come back, that's a signal the architectural work isn't complete, not a signal to bump memory."* The right long-term move is to find what regressed between #153 and today and fix it. But the alert is actively firing and stuck jobs are piling up, so this ships first to stop the bleeding. A follow-up will bisect #154, #155, #156 for the regression.

## Test plan

- [ ] CI passes (frontend lint+build, api lint+build+test:unit)
- [ ] After deploy, next scheduled sweeper run (15-min mark) completes with HTTP 200
- [ ] Verify `jsonPayload.component="stale-sweeper"` `sweep-complete` event lands in logs
- [ ] Alert clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)