### PR TITLE
fix(api): use correct memoryMiB field in apphosting.yaml

### DIFF
--- a/api/apphosting.yaml
+++ b/api/apphosting.yaml
@@ -2,7 +2,7 @@
 runConfig:
   minInstances: 0
   maxInstances: 1
-  memory: 1GiB
+  memoryMiB: 1024
   cpu: 1
   concurrency: 80
 


### PR DESCRIPTION
## Summary

Follow-up to #161. That PR changed `memory: 512MiB` → `memory: 1GiB` but the sweeper kept OOMing after rollout. The Cloud Run revision still came up at 512 MiB.

**Root cause:** the `memory:` key in `apphosting.yaml` is not a valid field in Firebase App Hosting's runConfig schema. The canonical schema lives in [firebase-tools/src/apphosting/config.ts](https://github.com/firebase/firebase-tools/blob/master/src/apphosting/config.ts):

```ts
export interface RunConfig {
  concurrency?: number;
  cpu?: number;
  memoryMiB?: number;
  minInstances?: number;
  maxInstances?: number;
}
```

The field is `memoryMiB` as an integer in MiB — not `memory: "1GiB"`.

**Verified against the builds REST API** for #161's merge commit `3615029`:
```json
"runConfig": {
  "cpu": 1,
  "concurrency": 80,
  "maxInstances": 1
}
```
No memory field at all. Firebase silently drops the unknown key and falls back to the Cloud Run default (512 MiB). Every Cloud Run revision for this service has been 512Mi since at least 2026-02-21, regardless of what the `memory:` value said.

## Implications for prior PRs

- **#146** ("bump to 1GiB to resolve OOM-kills") — was a no-op. OOMs went away because #148–#152 made 512 MiB actually fit, not because of any memory bump.
- **#153** ("drop back to 512MiB") — was also a no-op. The `memory: 512MiB` it reverted to was already being ignored.
- **#161** ("restore to 1GiB to stop sweeper OOM") — same no-op. Alert is still firing.

## Fix

Use `memoryMiB: 1024` (integer in MiB). After this rolls out, the API will actually have 1024 MiB and the sweeper should stop OOMing.

## Follow-up

Task #3 in the incident TODO list still stands: investigate what regressed memory from comfortably-within-512 to always-just-over. #154's `serverExternalPackages` expansion is the prime suspect — it externalizes the full `@google-cloud/*` suite instead of tree-shaking, which has a meaningful cold-start memory cost. Long-term, narrow that list to just `@google-cloud/tasks` and come back down to 512 MiB if the working set allows.

## Test plan

- [ ] CI green
- [ ] After rollout, verify Cloud Run revision shows `memory: 1024Mi` instead of `512Mi`
- [ ] Next scheduled sweeper run completes with HTTP 200
- [ ] `stale-sweeper` alert clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)