### PR TITLE
feat(leaderboard): replace TrueSkill rating with Bayesian-adjusted win rate

### DIFF
--- a/api/app/api/leaderboard/route.ts
+++ b/api/app/api/leaderboard/route.ts
@@ -1,7 +1,8 @@
 /**
  * GET /api/leaderboard
  *
- * Returns TrueSkill ratings for all decks, enriched with deck metadata.
+ * Returns Bayesian-adjusted win-rate rankings for all decks, enriched with
+ * deck metadata.
  *
  * Query parameters:
  *   minGames  — minimum games_played to include (default: 0)
@@ -10,10 +11,13 @@
  * Response:
  *   { decks: LeaderboardEntry[] }
  *
- * Optimizations:
- *   - Reads denormalized deck metadata from rating docs (no N+1 getDeckById calls)
- *   - Falls back to getDeckById only for rating docs missing denormalized fields
- *   - 5-minute in-memory cache + Cache-Control headers
+ * Implementation notes:
+ *   - The rating store's internal sort/limit is irrelevant here: we fetch all
+ *     matching ratings, re-score with the Bayesian formula, then sort/slice
+ *     in the route so top-N reflects the new ranking system.
+ *   - Reads denormalized deck metadata from rating docs (no N+1 getDeckById calls).
+ *   - Falls back to getDeckById only for rating docs missing denormalized fields.
+ *   - 5-minute in-memory cache + Cache-Control headers.
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAuth, unauthorizedResponse } from '@/lib/auth';
@@ -41,9 +45,16 @@ export interface LeaderboardEntry {
 // the prior, and the prior's influence fades as real games accumulate.
 const PRIOR_WIN_RATE = 0.25;
 const PRIOR_WEIGHT = 40;
+const PRIOR_WINS = PRIOR_WEIGHT * PRIOR_WIN_RATE;
+
+// Upper bound when fetching from the store — anything above this means we have
+// bigger problems than leaderboard truncation. The route applies the user's
+// `limit` itself after Bayesian scoring so the store's internal sort order
+// cannot silently drop high-Bayesian decks.
+const STORE_FETCH_CAP = 10_000;
 
 function bayesianScore(wins: number, gamesPlayed: number): number {
-  return ((wins + PRIOR_WEIGHT * PRIOR_WIN_RATE) / (gamesPlayed + PRIOR_WEIGHT)) * 100;
+  return ((wins + PRIOR_WINS) / (gamesPlayed + PRIOR_WEIGHT)) * 100;
 }
 
 // In-memory cache with 5-minute TTL
@@ -71,7 +82,10 @@ export async function GET(request: NextRequest) {
     }
 
     const store = getRatingStore();
-    const ratings = await store.getLeaderboard({ minGames, limit });
+    // Fetch without honoring the user's limit at the store layer: the store
+    // sorts by the legacy TrueSkill formula, which no longer matches the
+    // ranking we present. Sort/slice ourselves below.
+    const ratings = await store.getLeaderboard({ minGames, limit: STORE_FETCH_CAP });
 
     // Build leaderboard entries using denormalized metadata when available
     const entries = await Promise.all(
@@ -108,7 +122,10 @@ export async function GET(request: NextRequest) {
       }),
     );
 
-    const validEntries = entries.filter((e): e is LeaderboardEntry => e !== null);
+    const validEntries = entries
+      .filter((e): e is LeaderboardEntry => e !== null)
+      .sort((a, b) => b.rating - a.rating)
+      .slice(0, limit);
 
     // Update cache
     cache = { data: validEntries, minGames, limit, at: now };

--- a/api/app/api/leaderboard/route.ts
+++ b/api/app/api/leaderboard/route.ts
@@ -29,11 +29,21 @@ export interface LeaderboardEntry {
   primaryCommander: string | null;
   mu: number;
   sigma: number;
-  /** Conservative rating: mu - 3*sigma (display value) */
+  /** Bayesian-adjusted win rate as a percentage (prior = 25% over 40 games). */
   rating: number;
   gamesPlayed: number;
   wins: number;
   winRate: number;
+}
+
+// Prior: expected win rate in a 4-player free-for-all is 25%.
+// Weight: equivalent to "40 games of 25%" mixed in — a new deck scores exactly
+// the prior, and the prior's influence fades as real games accumulate.
+const PRIOR_WIN_RATE = 0.25;
+const PRIOR_WEIGHT = 40;
+
+function bayesianScore(wins: number, gamesPlayed: number): number {
+  return ((wins + PRIOR_WEIGHT * PRIOR_WIN_RATE) / (gamesPlayed + PRIOR_WEIGHT)) * 100;
 }
 
 // In-memory cache with 5-minute TTL
@@ -90,7 +100,7 @@ export async function GET(request: NextRequest) {
           primaryCommander: primaryCommander ?? null,
           mu: r.mu,
           sigma: r.sigma,
-          rating: r.mu - 3 * r.sigma,
+          rating: bayesianScore(r.wins, r.gamesPlayed),
           gamesPlayed: r.gamesPlayed,
           wins: r.wins,
           winRate: r.gamesPlayed > 0 ? r.wins / r.gamesPlayed : 0,

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -9,8 +9,6 @@ interface LeaderboardEntry {
   setName: string | null;
   isPrecon: boolean;
   primaryCommander: string | null;
-  mu: number;
-  sigma: number;
   rating: number;
   gamesPlayed: number;
   wins: number;
@@ -246,7 +244,7 @@ export default function Leaderboard() {
                     </div>
                   </td>
                   <td className="px-3 py-2.5 text-right font-mono font-semibold text-white">
-                    {entry.rating.toFixed(1)}
+                    {entry.rating.toFixed(1)}%
                   </td>
                   <td className="px-3 py-2.5 text-right text-gray-300">
                     {(entry.winRate * 100).toFixed(1)}%

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -17,17 +17,17 @@ interface LeaderboardEntry {
   winRate: number;
 }
 
-type SortKey = 'rating' | 'mu' | 'winRate' | 'gamesPlayed';
+type SortKey = 'rating' | 'winRate' | 'gamesPlayed';
 
-function ConfidenceBadge({ sigma }: { sigma: number }) {
-  if (sigma < 4) {
+function ConfidenceBadge({ gamesPlayed }: { gamesPlayed: number }) {
+  if (gamesPlayed >= 50) {
     return (
       <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-green-900/60 text-green-300 border border-green-700">
         stable
       </span>
     );
   }
-  if (sigma > 7) {
+  if (gamesPlayed < 10) {
     return (
       <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-yellow-900/60 text-yellow-300 border border-yellow-700">
         unsettled
@@ -134,7 +134,6 @@ export default function Leaderboard() {
     .filter((e) => !preconOnly || e.isPrecon)
     .sort((a, b) => {
       if (sortKey === 'rating') return b.rating - a.rating;
-      if (sortKey === 'mu') return b.mu - a.mu;
       if (sortKey === 'winRate') return b.winRate - a.winRate;
       if (sortKey === 'gamesPlayed') return b.gamesPlayed - a.gamesPlayed;
       return 0;
@@ -144,9 +143,9 @@ export default function Leaderboard() {
     <div className="max-w-5xl mx-auto">
       <h1 className="text-4xl font-bold text-center mb-2">Power Rankings</h1>
       <p className="text-gray-400 text-center mb-6">
-        TrueSkill ratings from Commander simulation results.{' '}
+        Relative power level from Commander simulation results.{' '}
         <span className="text-gray-500 text-sm">
-          Rating = μ − 3σ (conservative estimate, higher is stronger)
+          Rating is a win-rate percentage, smoothed toward 25% (4-player random baseline) until a deck has many games.
         </span>
       </p>
 
@@ -212,8 +211,6 @@ export default function Leaderboard() {
                 <th className="px-3 py-2 text-left text-gray-400 w-10">#</th>
                 <th className="px-3 py-2 text-left text-gray-400">Deck</th>
                 <SortHeader label="Rating" sortKey="rating" currentSort={sortKey} onSort={setSortKey} />
-                <SortHeader label="μ" sortKey="mu" currentSort={sortKey} onSort={setSortKey} />
-                <th className="px-3 py-2 text-right text-gray-400">σ</th>
                 <SortHeader label="Win Rate" sortKey="winRate" currentSort={sortKey} onSort={setSortKey} />
                 <SortHeader label="Games" sortKey="gamesPlayed" currentSort={sortKey} onSort={setSortKey} />
               </tr>
@@ -235,7 +232,7 @@ export default function Leaderboard() {
                               custom
                             </span>
                           )}
-                          <ConfidenceBadge sigma={entry.sigma} />
+                          <ConfidenceBadge gamesPlayed={entry.gamesPlayed} />
                         </div>
                         {entry.setName && (
                           <div className="text-xs text-gray-500 truncate">{entry.setName}</div>
@@ -249,13 +246,7 @@ export default function Leaderboard() {
                     </div>
                   </td>
                   <td className="px-3 py-2.5 text-right font-mono font-semibold text-white">
-                    {entry.rating.toFixed(2)}
-                  </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-gray-300">
-                    {entry.mu.toFixed(2)}
-                  </td>
-                  <td className="px-3 py-2.5 text-right font-mono text-gray-400">
-                    {entry.sigma.toFixed(2)}
+                    {entry.rating.toFixed(1)}
                   </td>
                   <td className="px-3 py-2.5 text-right text-gray-300">
                     {(entry.winRate * 100).toFixed(1)}%
@@ -269,8 +260,8 @@ export default function Leaderboard() {
       )}
 
       <p className="mt-4 text-xs text-gray-600 text-center">
-        TrueSkill ratings update automatically after each completed simulation job.
-        More games played → lower σ → more reliable Rating.
+        Ratings update automatically after each completed simulation job.
+        More games played → rating moves closer to the deck's true win rate.
       </p>
 
       {/* Coverage System */}


### PR DESCRIPTION
## Summary

- TrueSkill's μ−3σ display rating was producing misleading rankings. Once σ collapsed (e.g. 0.64 after 96 games), subsequent losses barely moved μ, so decks with unlucky early streaks locked in ratings disconnected from actual win rate. Example from the live leaderboard: a deck with 5.2% win rate ranking #1 with μ=119.
- Replace the display rating with a simple Bayesian-adjusted win rate:
  `score = (wins + 10) / (games + 40) * 100`
  A new deck scores 25.0 (4-player random baseline); the prior fades as real games accumulate.
- Drop μ/σ columns from the leaderboard UI and switch the confidence badge to games-played thresholds (≥50 = stable, <10 = unsettled).
- TrueSkill storage (μ, σ, match results) is untouched — easy to revisit later if we want.

## Test plan

- [ ] `npm run lint --prefix api` passes
- [ ] `npm run lint --prefix frontend` passes
- [ ] Leaderboard loads in the browser and ranks decks by Bayesian win rate (high WR with lots of games at top, low WR at bottom)
- [ ] New decks (<40 games) pulled toward 25.0 baseline
- [ ] "stable" badge appears on decks with ≥50 games; "unsettled" on decks with <10 games

🤖 Generated with [Claude Code](https://claude.com/claude-code)