### PR TITLE
fix(api): claim-sim 500 — avoid composite Firestore index

### DIFF
--- a/api/lib/firestore-job-store.ts
+++ b/api/lib/firestore-job-store.ts
@@ -509,14 +509,15 @@ export async function claimNextSim(
     const total = jobData.totalSimCount ?? 0;
     if (total > 0 && completed >= total) continue;
 
-    const pending = await simulationsCollection(jobDoc.id)
-      .where('state', '==', 'PENDING')
+    // Fetch sims ordered by index (single-field index, already present).
+    // Filter to PENDING in memory — per-job sim count is small (~25) so
+    // the overhead is negligible, and this avoids the composite index
+    // (state ASC + index ASC) the combined query would otherwise require.
+    const simsSnap = await simulationsCollection(jobDoc.id)
       .orderBy('index', 'asc')
-      .limit(1)
       .get();
-    if (pending.empty) continue;
-
-    const simDocSnap = pending.docs[0];
+    const simDocSnap = simsSnap.docs.find((d) => d.data()?.state === 'PENDING');
+    if (!simDocSnap) continue;
 
     try {
       const claimed = await firestore.runTransaction(async (tx) => {


### PR DESCRIPTION
## Summary

Hotfix for #167. The new claim-sim Firestore query needed a composite
index (state ASC + index ASC on the simulations subcollection) that
wasn't provisioned, so every claim-sim call returned HTTP 500 post-deploy.
Worker logs confirmed: hundreds of 'claim-sim unexpected status 500' lines
and zero successful claims.

## Fix

Drop the composite-index-requiring query. Instead, fetch the full
simulations subcollection ordered by index (using the already-present
single-field index) and find the first PENDING doc in memory. Per-job
sim count is ~25, so the overhead is negligible.

## Test plan

- [x] lint: clean
- [x] test:unit: all pass (claim-sim.test.ts hits the SQLite path; no
  Firestore emulator in this repo, so the Firestore path is exercised
  live against prod)
- [ ] After merge: verify /api/jobs/claim-sim returns 204 (no work) or 200
  against the production API, and that the worker logs stop reporting
  'unexpected status 500'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)