### PR TITLE
fix(api): transition job to FAILED when sweeper cancels all sims

### DIFF
--- a/api/lib/job-store-factory.ts
+++ b/api/lib/job-store-factory.ts
@@ -621,8 +621,10 @@ export async function aggregateJobResults(jobId: string): Promise<void> {
 
   const allCancelled = sims.every(s => s.state === 'CANCELLED');
   if (allCancelled) {
+    await setJobFailed(jobId, 'All simulations were cancelled (likely by stale-sweeper lifetime cap)');
     await setNeedsAggregation(jobId, false);
-    return; // Already handled by cancel flow
+    cancelRecoveryCheck(jobId).catch(err => log.warn('Cleanup fire-and-forget failed', { jobId, error: err instanceof Error ? err.message : err }));
+    return;
   }
 
   await setJobCompleted(jobId);

--- a/api/lib/stale-sweeper.test.ts
+++ b/api/lib/stale-sweeper.test.ts
@@ -263,6 +263,30 @@ async function runTests() {
     }
   });
 
+  await test('old RUNNING job with ALL sims cancelled transitions to FAILED', async () => {
+    wipeAllActiveJobs();
+    const jobId = makeRunningJob(2);
+    try {
+      // Both sims stay PENDING — sweeper will cancel both.
+      const farFuture = Date.now() + SIM_HARD_CANCEL_THRESHOLD_MS + 60_000;
+      const result = await sweep(farFuture);
+
+      assert(result.simsCancelled === 2, `both sims should be cancelled, got ${result.simsCancelled}`);
+
+      const sims = jobStoreSqlite.getSimulationStatuses(jobId);
+      assert(sims.every((s) => s.state === 'CANCELLED'), 'all sims should be CANCELLED');
+
+      const finalJob = jobStoreSqlite.getJob(jobId);
+      assert(finalJob!.status === 'FAILED', `job should be FAILED, got ${finalJob!.status}`);
+      assert(
+        (finalJob!.errorMessage ?? '').includes('cancelled'),
+        'errorMessage should mention cancellation'
+      );
+    } finally {
+      cleanupJob(jobId);
+    }
+  });
+
   await test('old QUEUED job is hard-failed', async () => {
     wipeAllActiveJobs();
     const job = jobStoreSqlite.createJob(DECKS, 4);


### PR DESCRIPTION
## Summary
- **Root cause:** `aggregateJobResults` early-returned when all sims were CANCELLED, assuming the user-cancel flow had already set `job.status=CANCELLED`. But when the stale-sweeper hard-cancelled every sim (lifetime cap), `job.status` stayed `RUNNING` — workers polled `claim-sim`, found no PENDING sims, returned 204 forever.
- **Fix:** Call `setJobFailed()` in the all-cancelled branch so the job exits the active queue.
- **Test:** New sweeper integration test: "old RUNNING job with ALL sims cancelled transitions to FAILED."
- **Prod unstick:** Manually patched `ojhWn8fUZNyEVHkGSCqv` to FAILED via Firestore REST API.

## Test plan
- [x] `npm run test:unit --prefix api` — all 15 sweeper tests pass (including new one)
- [x] `npm run lint --prefix api` — clean
- [ ] Monitor next coverage job after deploy to confirm sims are claimed and completed

🤖 Generated with [Claude Code](https://claude.ai/code)