### PR TITLE
chore(api): stop calculating TrueSkill, keep win/game stats only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Error tracking via `@sentry/nextjs` in `api/`. Graceful no-op when `SENTRY_DSN` 
   Also available in `api/.env` as `SENTRY_AUTH_TOKEN` for local use.
 - **Sentry org/project**: `tytaniumdev` / `magic-bracket-api`
 - **Alerts**: 4 alert rules configured with GitHub issue creation (labels: `bug`, `sentry`):
-  - Error Spike (catch-all), Aggregation Failures (critical), TrueSkill Rating Failures, Backfill Rating Failures
+  - Error Spike (catch-all), Aggregation Failures (critical), Rating Stats Failures, Backfill Rating Failures
 
 ## Lint & Type Checking
 

--- a/DATA_FLOW.md
+++ b/DATA_FLOW.md
@@ -278,7 +278,7 @@ second call exits immediately.
 ## 6. Auto-coverage system
 
 The coverage system automatically queues simulation jobs to ensure all deck
-pairs have sufficient game data for reliable TrueSkill rankings.
+pairs have sufficient game data for reliable Bayesian win-rate rankings.
 
 **Configuration (stored in `coverage_config` table/Firestore doc):**
 

--- a/api/app/api/admin/backfill-ratings/route.ts
+++ b/api/app/api/admin/backfill-ratings/route.ts
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/nextjs';
 import { errorResponse } from '@/lib/api-response';
 
 /**
- * POST /api/admin/backfill-ratings — Re-run TrueSkill ratings for completed jobs.
+ * POST /api/admin/backfill-ratings — Re-run per-deck win stats for completed jobs.
  *
  * Admin-only. For each COMPLETED job (or stuck RUNNING job with all sims done):
  * 1. Check if match results already exist (idempotent skip).
@@ -54,7 +54,7 @@ export async function POST(request: NextRequest) {
           await jobStore.aggregateJobResults(job.id);
         }
 
-        // Run TrueSkill rating
+        // Record match results and update per-deck win/game counters
         const { getStructuredLogs } = await import('@/lib/log-store');
         const structuredData = await getStructuredLogs(job.id);
 

--- a/api/app/api/leaderboard/route.ts
+++ b/api/app/api/leaderboard/route.ts
@@ -31,7 +31,9 @@ export interface LeaderboardEntry {
   setName: string | null;
   isPrecon: boolean;
   primaryCommander: string | null;
+  /** @deprecated Legacy TrueSkill mean; no longer updated. Neutral default (25) for new decks. */
   mu: number;
+  /** @deprecated Legacy TrueSkill uncertainty; no longer updated. Neutral default (≈8.33) for new decks. */
   sigma: number;
   /** Bayesian-adjusted win rate as a percentage (prior = 25% over 40 games). */
   rating: number;

--- a/api/app/api/leaderboard/route.ts
+++ b/api/app/api/leaderboard/route.ts
@@ -82,9 +82,9 @@ export async function GET(request: NextRequest) {
     }
 
     const store = getRatingStore();
-    // Fetch without honoring the user's limit at the store layer: the store
-    // sorts by the legacy TrueSkill formula, which no longer matches the
-    // ranking we present. Sort/slice ourselves below.
+    // Fetch without honoring the user's limit at the store layer: the store's
+    // internal sort order is legacy and may not match the Bayesian ranking we
+    // present here. Sort/slice ourselves below.
     const ratings = await store.getLeaderboard({ minGames, limit: STORE_FETCH_CAP });
 
     // Build leaderboard entries using denormalized metadata when available

--- a/api/lib/job-store-factory.ts
+++ b/api/lib/job-store-factory.ts
@@ -571,7 +571,7 @@ export async function aggregateJobResults(jobId: string): Promise<void> {
     await ingestLogs(jobId, rawLogs, deckNames, deckLists);
   }
 
-  // Load structured games for results computation and TrueSkill
+  // Load structured games for results computation and per-deck win stats
   const structuredData = await getStructuredLogs(jobId);
 
   // Compute aggregated results from structured games
@@ -604,12 +604,12 @@ export async function aggregateJobResults(jobId: string): Promise<void> {
     await setJobResults(jobId, results);
   }
 
-  // Update TrueSkill ratings for jobs with 4 resolved deck IDs
+  // Update per-deck win/game counters for jobs with 4 resolved deck IDs
   if (Array.isArray(job.deckIds) && job.deckIds.length === 4 && structuredData?.games?.length) {
     const { processJobForRatings } = await import('./trueskill-service');
     processJobForRatings(jobId, job.deckIds, structuredData.games).catch((err) => {
-      log.error('TrueSkill rating update failed (non-fatal)', { jobId, error: err instanceof Error ? err.message : String(err) });
-      Sentry.captureException(err, { tags: { component: 'trueskill', jobId } });
+      log.error('Rating stats update failed (non-fatal)', { jobId, error: err instanceof Error ? err.message : String(err) });
+      Sentry.captureException(err, { tags: { component: 'rating-stats', jobId } });
     });
   }
 

--- a/api/lib/trueskill-service.ts
+++ b/api/lib/trueskill-service.ts
@@ -1,21 +1,14 @@
 /**
- * TrueSkill rating service.
+ * Rating stats service.
  *
- * Implements the TrueSkill algorithm (Herbrich et al.) for 4-player Commander
- * games with win/loss only (no placement data).
+ * Records per-job match results and increments per-deck wins/gamesPlayed
+ * counters. The leaderboard then ranks decks with a Bayesian-adjusted win
+ * rate (see api/app/api/leaderboard/route.ts).
  *
- * For each game with one winner and three tied losers:
- *   - Winner vs each loser is treated as a pairwise TrueSkill win update
- *   - Loser vs loser updates cancel out (symmetric tie) so are skipped
- *   - All pairwise updates use initial ratings (computed simultaneously)
- *
- * TrueSkill defaults (matching Microsoft/ts-trueskill conventions):
- *   mu_0    = 25        (initial mean skill)
- *   sigma_0 = 25/3      (initial uncertainty ≈ 8.333)
- *   beta    = 25/6      (performance noise ≈ 4.167)
- *   tau     = 25/300    (dynamics factor ≈ 0.0833)
- *
- * Conservative display rating = mu - 3*sigma (starts near 0, rises with wins).
+ * Historical note: this module previously computed TrueSkill (mu/sigma)
+ * ratings. That math was removed in favor of the simpler Bayesian win-rate
+ * ranking. mu/sigma are still present in the DeckRating schema so existing
+ * Firestore docs remain valid; new writes leave mu/sigma at neutral defaults.
  */
 import type { DeckRating, MatchResult, StructuredGame } from './types';
 import { matchesDeckName } from './condenser/deck-match';
@@ -23,116 +16,14 @@ import { getDeckById } from './deck-store-factory';
 import { getRatingStore } from './rating-store-factory';
 import * as Sentry from '@sentry/nextjs';
 
-// ─── TrueSkill constants ──────────────────────────────────────────────────────
-
-const MU_0 = 25;
-const SIGMA_0 = 25 / 3;
-const BETA = 25 / 6;
-const TAU = 25 / 300;
-
-// ─── Gaussian utilities ───────────────────────────────────────────────────────
-
-/** Approximation of the error function (Abramowitz & Stegun 7.1.26, max error ≤ 1.5e-7). */
-function erf(x: number): number {
-  const sign = x < 0 ? -1 : 1;
-  const a = Math.abs(x);
-  const t = 1 / (1 + 0.3275911 * a);
-  const poly =
-    t *
-    (0.254829592 +
-      t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
-  return sign * (1 - poly * Math.exp(-a * a));
-}
-
-/** Standard normal PDF */
-function normPdf(x: number): number {
-  return Math.exp(-0.5 * x * x) / Math.sqrt(2 * Math.PI);
-}
-
-/** Standard normal CDF */
-function normCdf(x: number): number {
-  return 0.5 * (1 + erf(x / Math.sqrt(2)));
-}
+const MU_DEFAULT = 25;
+const SIGMA_DEFAULT = 25 / 3;
 
 /**
- * TrueSkill win-condition mean factor v(t).
- * v(t) = φ(t) / Φ(t), clamped to prevent division by near-zero.
- */
-function vWin(t: number): number {
-  const denom = normCdf(t);
-  if (denom < 1e-10) return -t; // prevent divide-by-zero
-  return normPdf(t) / denom;
-}
-
-/**
- * TrueSkill win-condition variance factor w(t).
- * w(t) = v(t) * (v(t) + t), clamped to [0, 1).
- */
-function wWin(t: number): number {
-  const v = vWin(t);
-  const w = v * (v + t);
-  return Math.min(Math.max(w, 0), 1 - 1e-10);
-}
-
-// ─── Rating update ────────────────────────────────────────────────────────────
-
-interface RatingSnapshot {
-  mu: number;
-  sigma: number;
-}
-
-/**
- * Compute TrueSkill updates for a 4-player game.
+ * Process all games in a completed job and update per-deck win/game counters.
  *
- * @param winnerIdx  Index of the winning deck in `ratings`.
- * @param ratings    Current ratings for all 4 decks.
- * @returns          New mu and sigma values for each deck (same order as input).
- */
-function computeTrueSkillUpdate(
-  winnerIdx: number,
-  ratings: RatingSnapshot[],
-): RatingSnapshot[] {
-  // Accumulate mu deltas (winner gets +, losers get -)
-  const muDeltas: number[] = ratings.map(() => 0);
-  // Accumulate w deltas for sigma (always positive reduction)
-  const wDeltas: number[] = ratings.map(() => 0);
-
-  const winnerRating = ratings[winnerIdx]!;
-
-  for (let i = 0; i < ratings.length; i++) {
-    if (i === winnerIdx) continue; // Skip winner vs winner
-
-    const loser = ratings[i]!;
-
-    const c = Math.sqrt(winnerRating.sigma ** 2 + loser.sigma ** 2 + 2 * BETA ** 2);
-    const t = (winnerRating.mu - loser.mu) / c;
-    const v = vWin(t);
-    const w = wWin(t);
-
-    // Winner gets a positive mu boost from each loser comparison
-    muDeltas[winnerIdx] = (muDeltas[winnerIdx] ?? 0) + (winnerRating.sigma ** 2 / c) * v;
-    wDeltas[winnerIdx] = (wDeltas[winnerIdx] ?? 0) + (winnerRating.sigma ** 4 / c ** 2) * w;
-
-    // Loser gets a negative mu update from losing to the winner
-    muDeltas[i] = (muDeltas[i] ?? 0) - (loser.sigma ** 2 / c) * v;
-    wDeltas[i] = (wDeltas[i] ?? 0) + (loser.sigma ** 4 / c ** 2) * w;
-  }
-
-  return ratings.map((r, idx) => {
-    const newMu = r.mu + (muDeltas[idx] ?? 0);
-    // sigma update: subtract skill info gained, then add dynamics tau^2
-    const newSigma2 = Math.max(r.sigma ** 2 - (wDeltas[idx] ?? 0) + TAU ** 2, 0.01);
-    return { mu: newMu, sigma: Math.sqrt(newSigma2) };
-  });
-}
-
-// ─── Public API ───────────────────────────────────────────────────────────────
-
-/**
- * Process all games in a completed job and update TrueSkill ratings.
- *
- * This is fire-and-forget — called from aggregateJobResults with a .catch()
- * so failures never break job completion.
+ * Fire-and-forget — called from aggregateJobResults with a .catch() so
+ * failures never break job completion.
  *
  * @param jobId    The job ID (for idempotency).
  * @param deckIds  4 deck IDs (same order used throughout the job).
@@ -145,13 +36,11 @@ export async function processJobForRatings(
 ): Promise<void> {
   const store = getRatingStore();
 
-  // Idempotency: skip if we've already processed this job
   if (await store.hasMatchResultsForJob(jobId)) {
-    console.log(`[TrueSkill] Job ${jobId} already rated, skipping`);
+    console.log(`[RatingStats] Job ${jobId} already rated, skipping`);
     return;
   }
 
-  // Resolve full deck metadata for winner matching and rating denormalization
   const deckInfos = await Promise.all(
     deckIds.map(async (id) => {
       const deck = await getDeckById(id);
@@ -165,18 +54,15 @@ export async function processJobForRatings(
     }),
   );
 
-  // Fetch initial ratings for all 4 decks
   const initialStoredRatings = await Promise.all(deckIds.map((id) => store.getRating(id)));
 
-  // Build in-memory state, starting from stored values (or TrueSkill defaults)
-  // Always include denormalized deck metadata for leaderboard optimization
   const currentRatings: DeckRating[] = deckIds.map((id, idx) => {
     const stored = initialStoredRatings[idx];
     const info = deckInfos[idx]!;
     const base = stored ?? {
       deckId: id,
-      mu: MU_0,
-      sigma: SIGMA_0,
+      mu: MU_DEFAULT,
+      sigma: SIGMA_DEFAULT,
       gamesPlayed: 0,
       wins: 0,
       lastUpdated: new Date().toISOString(),
@@ -197,7 +83,6 @@ export async function processJobForRatings(
     const game = games[i]!;
     const winner = game.winner;
 
-    // Resolve winner string → deck ID
     let winnerDeckId: string | null = null;
     if (winner) {
       for (const { id, name } of deckInfos) {
@@ -219,9 +104,8 @@ export async function processJobForRatings(
     });
 
     if (!winnerDeckId) {
-      // No winner resolved — record the match but skip rating update
       Sentry.addBreadcrumb({
-        category: 'trueskill',
+        category: 'rating-stats',
         message: `Game ${i} in job ${jobId}: winner "${winner}" could not be resolved to a deck ID`,
         level: 'warning',
         data: { jobId, gameIndex: i, winner, deckNames: deckInfos.map(d => d.name) },
@@ -232,21 +116,10 @@ export async function processJobForRatings(
     const winnerIdx = deckIds.indexOf(winnerDeckId);
     if (winnerIdx === -1) continue;
 
-    // Compute TrueSkill update using current in-memory ratings
-    const snapshots: RatingSnapshot[] = currentRatings.map((r) => ({
-      mu: r.mu,
-      sigma: r.sigma,
-    }));
-    const updated = computeTrueSkillUpdate(winnerIdx, snapshots);
-
-    // Apply updates to in-memory state
     for (let j = 0; j < deckIds.length; j++) {
-      const updatedRating = updated[j]!;
       const current = currentRatings[j]!;
       currentRatings[j] = {
         ...current,
-        mu: updatedRating.mu,
-        sigma: updatedRating.sigma,
         gamesPlayed: current.gamesPlayed + 1,
         wins: current.wins + (j === winnerIdx ? 1 : 0),
         lastUpdated: new Date().toISOString(),
@@ -255,21 +128,19 @@ export async function processJobForRatings(
     updatedAtLeastOne = true;
   }
 
-  // Save match results first (idempotency guard)
   for (const result of matchResults) {
     await store.recordMatchResult(result);
   }
 
-  // Save updated ratings only if at least one game was resolved
   if (updatedAtLeastOne) {
     await store.updateRatings(currentRatings);
     console.log(
-      `[TrueSkill] Job ${jobId}: rated ${games.length} game(s) for decks [${deckIds.join(', ')}]`,
+      `[RatingStats] Job ${jobId}: recorded ${games.length} game(s) for decks [${deckIds.join(', ')}]`,
     );
   } else {
     Sentry.addBreadcrumb({
-      category: 'trueskill',
-      message: `Job ${jobId}: no games had resolvable winners — ratings unchanged`,
+      category: 'rating-stats',
+      message: `Job ${jobId}: no games had resolvable winners — counters unchanged`,
       level: 'warning',
       data: { jobId, gameCount: games.length, deckIds },
     });

--- a/api/lib/trueskill-service.ts
+++ b/api/lib/trueskill-service.ts
@@ -77,7 +77,7 @@ export async function processJobForRatings(
   });
 
   const matchResults: MatchResult[] = [];
-  let updatedAtLeastOne = false;
+  let resolvedGames = 0;
 
   for (let i = 0; i < games.length; i++) {
     const game = games[i]!;
@@ -125,17 +125,17 @@ export async function processJobForRatings(
         lastUpdated: new Date().toISOString(),
       };
     }
-    updatedAtLeastOne = true;
+    resolvedGames += 1;
   }
 
   for (const result of matchResults) {
     await store.recordMatchResult(result);
   }
 
-  if (updatedAtLeastOne) {
+  if (resolvedGames > 0) {
     await store.updateRatings(currentRatings);
     console.log(
-      `[RatingStats] Job ${jobId}: recorded ${games.length} game(s) for decks [${deckIds.join(', ')}]`,
+      `[RatingStats] Job ${jobId}: recorded ${resolvedGames}/${games.length} game(s) for decks [${deckIds.join(', ')}]`,
     );
   } else {
     Sentry.addBreadcrumb({


### PR DESCRIPTION
## Summary
- Strip TrueSkill math (`erf`, `vWin`, `wWin`, `computeTrueSkillUpdate`) from `api/lib/trueskill-service.ts`. The leaderboard already switched to a Bayesian-adjusted win rate in #165, so mu/sigma updates were dead weight running on every aggregation.
- `processJobForRatings` still records match results and increments per-deck wins/gamesPlayed — which the Bayesian leaderboard actually reads. mu/sigma stay in the schema for backcompat; new writes use neutral defaults.
- Rename the Sentry component tag `trueskill` → `rating-stats` and update the matching alert rule filter + CLAUDE.md reference so the alert still fires on the new code path.

Motivated by Sentry issue MAGIC-BRACKET-API-4: TrueSkill update in the sweeper path occasionally hit a 75s Firestore `DEADLINE_EXCEEDED`. With the math gone, there's less Firestore work on the fire-and-forget path.

## Test plan
- [x] `npm run lint` (api) passes
- [ ] Deploy and confirm no new `component:rating-stats` Sentry errors on the next sweep + aggregation
- [ ] Verify leaderboard still ranks after a completed job (Bayesian score driven by `wins`/`gamesPlayed`, which are still written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)