### PR TITLE
fix: backfill Timestamp handling + win-turn tooltip rendering

### DIFF
--- a/api/app/api/admin/backfill-win-turns/route.ts
+++ b/api/app/api/admin/backfill-win-turns/route.ts
@@ -132,9 +132,18 @@ async function* iterateFirestoreMatchResults(): AsyncGenerator<MatchResult[]> {
  * check throw "Right-hand side of 'instanceof' is not an object".
  */
 function firestoreTimestampToIso(value: unknown): string {
-  if (value && typeof (value as { toDate?: unknown }).toDate === 'function') {
-    const d = (value as { toDate: () => Date }).toDate();
-    if (d instanceof Date && !Number.isNaN(d.getTime())) return d.toISOString();
+  if (value && typeof value === 'object') {
+    const v = value as { toDate?: unknown; _seconds?: unknown; _nanoseconds?: unknown };
+    if (typeof v.toDate === 'function') {
+      const d = (v.toDate as () => Date)();
+      if (d instanceof Date && !Number.isNaN(d.getTime())) return d.toISOString();
+    }
+    // Serialized POJO form (e.g., after JSON round-trip): { _seconds, _nanoseconds }
+    if (typeof v._seconds === 'number') {
+      const nanos = typeof v._nanoseconds === 'number' ? v._nanoseconds : 0;
+      const d = new Date(v._seconds * 1000 + Math.floor(nanos / 1e6));
+      if (!Number.isNaN(d.getTime())) return d.toISOString();
+    }
   }
   return String(value ?? '');
 }

--- a/api/app/api/admin/backfill-win-turns/route.ts
+++ b/api/app/api/admin/backfill-win-turns/route.ts
@@ -124,13 +124,7 @@ async function* iterateFirestoreMatchResults(): AsyncGenerator<MatchResult[]> {
   }
 }
 
-/**
- * Convert a Firestore Timestamp-like value to an ISO string.
- * Uses duck-typing rather than `instanceof Timestamp` because dynamic imports
- * of @google-cloud/firestore can yield a module namespace where Timestamp is
- * not the same constructor the SDK internally attaches, making the instanceof
- * check throw "Right-hand side of 'instanceof' is not an object".
- */
+// Duck-typed: dynamic @google-cloud/firestore imports can produce a Timestamp constructor that differs from the one attached to runtime values, breaking `instanceof`.
 function firestoreTimestampToIso(value: unknown): string {
   if (value && typeof value === 'object') {
     const v = value as { toDate?: unknown; _seconds?: unknown; _nanoseconds?: unknown };
@@ -138,7 +132,6 @@ function firestoreTimestampToIso(value: unknown): string {
       const d = (v.toDate as () => Date)();
       if (d instanceof Date && !Number.isNaN(d.getTime())) return d.toISOString();
     }
-    // Serialized POJO form (e.g., after JSON round-trip): { _seconds, _nanoseconds }
     if (typeof v._seconds === 'number') {
       const nanos = typeof v._nanoseconds === 'number' ? v._nanoseconds : 0;
       const d = new Date(v._seconds * 1000 + Math.floor(nanos / 1e6));

--- a/frontend/src/components/WinTurnTooltip.tsx
+++ b/frontend/src/components/WinTurnTooltip.tsx
@@ -14,28 +14,30 @@ export function WinTurnTooltip({ histogram, avgWinTurn, totalWins }: WinTurnTool
   return (
     <div
       role="tooltip"
-      className="pointer-events-none absolute z-20 w-64 rounded-md border border-gray-700 bg-gray-900 p-3 shadow-lg"
+      className="pointer-events-none w-80 rounded-md border border-gray-700 bg-gray-900 p-3 shadow-lg"
     >
       <div className="mb-2 text-xs text-gray-300">
         Avg: <span className="font-mono text-white">{avgWinTurn.toFixed(1)}</span>
         <span className="text-gray-500"> · </span>
         <span>{totalWins} wins</span>
       </div>
-      <div className="flex h-20 items-end gap-0.5">
+      <div className="flex h-24 items-end gap-0.5">
         {histogram.map((count, i) => {
           const pct = (count / max) * 100;
           return (
-            <div key={i} className="flex flex-1 items-end">
-              <div
-                data-testid="win-turn-bar"
-                className="w-full rounded-sm bg-blue-500"
-                style={{ height: `${pct}%` }}
-              />
-            </div>
+            <div
+              key={i}
+              data-testid="win-turn-bar"
+              className="flex-1 rounded-sm bg-blue-500"
+              style={{
+                height: `${pct}%`,
+                minHeight: count > 0 ? '2px' : undefined,
+              }}
+            />
           );
         })}
       </div>
-      <div className="mt-1 flex gap-0.5 text-[9px] text-gray-500">
+      <div className="mt-1 flex gap-0.5 text-[10px] text-gray-500">
         {BIN_LABELS.map((label, i) => (
           <div key={i} className="flex-1 text-center">{label}</div>
         ))}

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -1,8 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { getApiBase, fetchWithAuth, getCoverageConfig, updateCoverageConfig, getCoverageStatus } from '../api';
 import type { CoverageConfig, CoverageStatus } from '../api';
 import { useAuth } from '../contexts/AuthContext';
 import { WinTurnTooltip } from '../components/WinTurnTooltip';
+
+const TOOLTIP_WIDTH = 320;
+const TOOLTIP_MARGIN = 8;
 
 interface LeaderboardEntry {
   deckId: string;
@@ -45,38 +49,54 @@ function AvgWinTurnCell({
   avgWinTurn: number;
   histogram: number[] | null;
 }) {
-  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
   const totalWins = histogram ? histogram.reduce((a, b) => a + b, 0) : 0;
   const canShowTooltip = histogram !== null && totalWins > 0;
+
+  const showTooltip = () => {
+    if (!btnRef.current) return;
+    const rect = btnRef.current.getBoundingClientRect();
+    const maxLeft = window.innerWidth - TOOLTIP_WIDTH - TOOLTIP_MARGIN;
+    const left = Math.max(
+      TOOLTIP_MARGIN,
+      Math.min(rect.right - TOOLTIP_WIDTH, maxLeft),
+    );
+    setCoords({ top: rect.bottom + 4, left });
+  };
+  const hideTooltip = () => setCoords(null);
+
   return (
     <span className="inline-flex items-center justify-end gap-1">
       <span>{avgWinTurn.toFixed(1)}</span>
       {canShowTooltip && (
-        <span
-          className="relative inline-flex"
-          onMouseEnter={() => setOpen(true)}
-          onMouseLeave={() => setOpen(false)}
-          onFocus={() => setOpen(true)}
-          onBlur={() => setOpen(false)}
-        >
+        <>
           <button
+            ref={btnRef}
             type="button"
             tabIndex={0}
             aria-label="Show win turn distribution"
             className="text-gray-500 hover:text-gray-300 cursor-help"
+            onMouseEnter={showTooltip}
+            onMouseLeave={hideTooltip}
+            onFocus={showTooltip}
+            onBlur={hideTooltip}
           >
             ⓘ
           </button>
-          {open && (
-            <span className="absolute right-0 top-full mt-1">
+          {coords && createPortal(
+            <div
+              style={{ position: 'fixed', top: coords.top, left: coords.left, zIndex: 50 }}
+            >
               <WinTurnTooltip
                 histogram={histogram}
                 avgWinTurn={avgWinTurn}
                 totalWins={totalWins}
               />
-            </span>
+            </div>,
+            document.body,
           )}
-        </span>
+        </>
       )}
     </span>
   );

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -6,7 +6,11 @@ import { useAuth } from '../contexts/AuthContext';
 import { WinTurnTooltip } from '../components/WinTurnTooltip';
 
 const TOOLTIP_WIDTH = 320;
+// Approximate — the tooltip's actual height depends on bar rendering, but a
+// conservative estimate is enough to pick "flip above" vs "stay below".
+const TOOLTIP_ESTIMATED_HEIGHT = 180;
 const TOOLTIP_MARGIN = 8;
+const TOOLTIP_GAP = 4;
 
 interface LeaderboardEntry {
   deckId: string;
@@ -62,7 +66,11 @@ function AvgWinTurnCell({
       TOOLTIP_MARGIN,
       Math.min(rect.right - TOOLTIP_WIDTH, maxLeft),
     );
-    setCoords({ top: rect.bottom + 4, left });
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const top = spaceBelow < TOOLTIP_ESTIMATED_HEIGHT + TOOLTIP_GAP + TOOLTIP_MARGIN
+      ? Math.max(TOOLTIP_MARGIN, rect.top - TOOLTIP_ESTIMATED_HEIGHT - TOOLTIP_GAP)
+      : rect.bottom + TOOLTIP_GAP;
+    setCoords({ top, left });
   };
   const hideTooltip = () => setCoords(null);
 

--- a/frontend/tests/win-turn-tooltip.spec.ts
+++ b/frontend/tests/win-turn-tooltip.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Regression guard for the Power Rankings "Avg Win Turn" tooltip.
+ *
+ * Covers the three bugs that were visible at PR #175:
+ *   1. Tooltip rendered too narrow (16 bars in w-64).
+ *   2. Tooltip was clipped by the table's overflow-x-auto container.
+ *   3. Histogram bars had 0 computed height (percentage heights didn't
+ *      resolve against the flex ancestor), so no data was visible.
+ */
+
+const HISTOGRAM = [0, 0, 0, 0, 2, 5, 10, 15, 8, 4, 3, 2, 1, 0, 0, 0];
+const MAX_BIN_INDEX = 7;
+
+const mockLeaderboard = {
+  decks: [
+    {
+      deckId: 'test-deck',
+      name: 'Test Deck',
+      setName: 'Test Set',
+      isPrecon: true,
+      primaryCommander: null,
+      rating: 50.0,
+      gamesPlayed: 100,
+      wins: 50,
+      winRate: 0.5,
+      avgWinTurn: 7.8,
+      winTurnHistogram: HISTOGRAM,
+    },
+  ],
+};
+
+async function stubLeaderboardApis(page: Page) {
+  await page.route('**/api/leaderboard*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockLeaderboard),
+    }),
+  );
+  await page.route('**/api/coverage/config', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ enabled: false, targetGamesPerPair: 100 }),
+    }),
+  );
+  await page.route('**/api/coverage/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ coveredPairs: 0, totalPairs: 0, percentComplete: 0 }),
+    }),
+  );
+  // Any other API calls from the page shell — keep them from 404-ing into
+  // visible error states that could block the leaderboard from rendering.
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ isAdmin: false }),
+    }),
+  );
+}
+
+test.describe('WinTurnTooltip', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubLeaderboardApis(page);
+  });
+
+  test('renders with visible bars, readable width, inside the viewport', async ({ page }) => {
+    await page.goto('/leaderboard');
+
+    const icon = page.getByRole('button', { name: /show win turn distribution/i }).first();
+    await expect(icon).toBeVisible();
+    await icon.hover();
+
+    const tooltip = page.getByRole('tooltip');
+    await expect(tooltip).toBeVisible();
+
+    // --- Size (regression guard for "too small") ---
+    const box = await tooltip.boundingBox();
+    expect(box, 'tooltip should have a measurable bounding box').not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(300);
+    expect(box!.height).toBeGreaterThanOrEqual(80);
+
+    // --- Viewport containment (regression guard for "cut off by outer container") ---
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.y).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width);
+    expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+
+    // --- Bar data (regression guard for "no actual data") ---
+    const bars = tooltip.locator('[data-testid="win-turn-bar"]');
+    await expect(bars).toHaveCount(16);
+
+    const heights = await bars.evaluateAll((els) =>
+      els.map((el) => el.getBoundingClientRect().height),
+    );
+    // Bins with zero count should measure ~0; non-zero bins should render
+    // a visible bar. The max-count bin must be the tallest.
+    for (let i = 0; i < HISTOGRAM.length; i++) {
+      if (HISTOGRAM[i] === 0) {
+        expect(heights[i], `bin ${i} should be empty`).toBeLessThanOrEqual(1);
+      } else {
+        expect(heights[i], `bin ${i} (count ${HISTOGRAM[i]}) should be visible`)
+          .toBeGreaterThan(1);
+      }
+    }
+    const tallestIndex = heights.indexOf(Math.max(...heights));
+    expect(tallestIndex).toBe(MAX_BIN_INDEX);
+  });
+
+  test('tooltip is not clipped at a narrow viewport', async ({ page }) => {
+    // Narrow viewport forces the table's overflow-x-auto to engage — if the
+    // tooltip were still a child of the table, it would be clipped here.
+    await page.setViewportSize({ width: 600, height: 800 });
+    await page.goto('/leaderboard');
+
+    const icon = page.getByRole('button', { name: /show win turn distribution/i }).first();
+    await icon.scrollIntoViewIfNeeded();
+    await icon.hover();
+
+    const tooltip = page.getByRole('tooltip');
+    await expect(tooltip).toBeVisible();
+
+    const box = await tooltip.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(300);
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(600);
+  });
+
+  test('tooltip portals to document.body, outside the table', async ({ page }) => {
+    await page.goto('/leaderboard');
+    const icon = page.getByRole('button', { name: /show win turn distribution/i }).first();
+    await icon.hover();
+
+    const tooltip = page.getByRole('tooltip');
+    await expect(tooltip).toBeVisible();
+
+    // If the tooltip is rendered via createPortal to document.body, it will
+    // not be a descendant of the <table>. This is the structural guarantee
+    // that keeps the overflow-x-auto container from clipping it.
+    const isInsideTable = await tooltip.evaluate(
+      (el) => el.closest('table') !== null,
+    );
+    expect(isInsideTable).toBe(false);
+  });
+});

--- a/frontend/tests/win-turn-tooltip.spec.ts
+++ b/frontend/tests/win-turn-tooltip.spec.ts
@@ -13,30 +13,38 @@ import { test, expect, type Page } from '@playwright/test';
 const HISTOGRAM = [0, 0, 0, 0, 2, 5, 10, 15, 8, 4, 3, 2, 1, 0, 0, 0];
 const MAX_BIN_INDEX = 7;
 
+function makeDeck(n: number) {
+  return {
+    deckId: `test-deck-${n}`,
+    name: `Test Deck ${n}`,
+    setName: 'Test Set',
+    isPrecon: true,
+    primaryCommander: null,
+    rating: 50.0,
+    gamesPlayed: 100,
+    wins: 50,
+    winRate: 0.5,
+    avgWinTurn: 7.8,
+    winTurnHistogram: HISTOGRAM,
+  };
+}
+
 const mockLeaderboard = {
-  decks: [
-    {
-      deckId: 'test-deck',
-      name: 'Test Deck',
-      setName: 'Test Set',
-      isPrecon: true,
-      primaryCommander: null,
-      rating: 50.0,
-      gamesPlayed: 100,
-      wins: 50,
-      winRate: 0.5,
-      avgWinTurn: 7.8,
-      winTurnHistogram: HISTOGRAM,
-    },
-  ],
+  decks: [makeDeck(1)],
 };
 
-async function stubLeaderboardApis(page: Page) {
+// Many-row fixture for scrolling tests — enough rows that the last row sits
+// near the bottom of the viewport and exercises vertical clamping.
+const mockLeaderboardLong = {
+  decks: Array.from({ length: 30 }, (_, i) => makeDeck(i + 1)),
+};
+
+async function stubLeaderboardApis(page: Page, payload = mockLeaderboard) {
   await page.route('**/api/leaderboard*', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(mockLeaderboard),
+      body: JSON.stringify(payload),
     }),
   );
   await page.route('**/api/coverage/config', (route) =>
@@ -132,6 +140,48 @@ test.describe('WinTurnTooltip', () => {
     expect(box!.width).toBeGreaterThanOrEqual(300);
     expect(box!.x).toBeGreaterThanOrEqual(0);
     expect(box!.x + box!.width).toBeLessThanOrEqual(600);
+  });
+
+  test('flips above the icon when there is not enough space below', async ({ page }) => {
+    await page.unroute('**/api/leaderboard*');
+    await page.route('**/api/leaderboard*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockLeaderboardLong),
+      }),
+    );
+    await page.setViewportSize({ width: 1200, height: 700 });
+    await page.goto('/leaderboard');
+
+    const icons = page.getByRole('button', { name: /show win turn distribution/i });
+    await expect(icons.first()).toBeVisible();
+    const lastIcon = icons.last();
+    await lastIcon.scrollIntoViewIfNeeded();
+
+    // Force the last icon near the bottom of the viewport — enough that a
+    // ~180px-tall tooltip positioned below it would overflow.
+    await lastIcon.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      const targetFromBottom = 40;
+      window.scrollBy({ top: rect.bottom - (window.innerHeight - targetFromBottom) });
+    });
+
+    await lastIcon.hover();
+    const tooltip = page.getByRole('tooltip');
+    await expect(tooltip).toBeVisible();
+
+    const viewport = page.viewportSize()!;
+    const tooltipBox = await tooltip.boundingBox();
+    const iconBox = await lastIcon.boundingBox();
+    expect(tooltipBox).not.toBeNull();
+    expect(iconBox).not.toBeNull();
+
+    // Stays inside the viewport vertically.
+    expect(tooltipBox!.y).toBeGreaterThanOrEqual(0);
+    expect(tooltipBox!.y + tooltipBox!.height).toBeLessThanOrEqual(viewport.height);
+    // And specifically flipped above the icon (tooltip bottom is at or above icon top).
+    expect(tooltipBox!.y + tooltipBox!.height).toBeLessThanOrEqual(iconBox!.y + 1);
   });
 
   test('tooltip portals to document.body, outside the table', async ({ page }) => {

--- a/frontend/tests/win-turn-tooltip.spec.ts
+++ b/frontend/tests/win-turn-tooltip.spec.ts
@@ -1,15 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
 
-/**
- * Regression guard for the Power Rankings "Avg Win Turn" tooltip.
- *
- * Covers the three bugs that were visible at PR #175:
- *   1. Tooltip rendered too narrow (16 bars in w-64).
- *   2. Tooltip was clipped by the table's overflow-x-auto container.
- *   3. Histogram bars had 0 computed height (percentage heights didn't
- *      resolve against the flex ancestor), so no data was visible.
- */
-
 const HISTOGRAM = [0, 0, 0, 0, 2, 5, 10, 15, 8, 4, 3, 2, 1, 0, 0, 0];
 const MAX_BIN_INDEX = 7;
 


### PR DESCRIPTION
## Summary

Two bundled fixes on this branch:

- **API**: `backfill-win-turns` crashed on Firestore Timestamp values because the `instanceof` check didn't match Timestamps coming back as plain serialized objects. Swapped to a duck-typed check.
- **Frontend**: The Power Rankings "Avg Win Turn" tooltip was unusable — too narrow for 16 bars, bars rendered at 0 height (percentage heights didn't resolve against the intermediate flex wrapper), and the tooltip was clipped by the table's `overflow-x-auto` ancestor. Widened to `w-80`, flattened the bar structure so percentages resolve against the `h-24` container, and moved the tooltip into a body-level portal with fixed coordinates clamped to the viewport.

## Test plan

- [x] `npm run test --prefix frontend` — WinTurnTooltip unit tests pass
- [x] `npm run test:e2e --prefix frontend` — new `win-turn-tooltip.spec.ts` Playwright regression test passes
- [x] `npm run lint --prefix frontend` — clean
- [x] `npm run build --prefix frontend` / `tsc -b` — clean
- [x] Each of the three tooltip fixes was individually reverted and the corresponding Playwright assertion failed as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)