### PR TITLE
fix: align worker/API extractWinningTurn on per-deck count

### DIFF
--- a/api/test/condenser-contract.test.ts
+++ b/api/test/condenser-contract.test.ts
@@ -22,12 +22,12 @@
  *   - Byte-for-byte game boundaries. Both implementations agree on the
  *     game count and on the line containing the winner, but they may
  *     include slightly different surrounding noise in each chunk.
- *   - extractWinningTurn. The worker's turn count is a preliminary
- *     preview; the API's aggregation uses per-deck turn tracking which
- *     is authoritative and overwrites it.
  *
- * If a future change makes the worker's turn extraction authoritative,
- * add the stricter assertion here so drift is caught at test time.
+ * extractWinningTurn MUST agree: the worker reports winningTurns[] on
+ * simulation docs (seen in DeckShowcase) while the API feeds the rating
+ * store / Power Rankings histogram from its own aggregation. When the
+ * two diverge, users see different turn values in the two views for the
+ * same game — see the contract test below.
  *
  * Run with: npx tsx test/condenser-contract.test.ts
  */
@@ -149,6 +149,16 @@ test('extractWinningTurn: empty log returns no turn on both sides', () => {
   const workerT = normTurn(workerExtractWinningTurn(''));
   assertEqual(apiT, undefined, 'api empty');
   assertEqual(workerT, undefined, 'worker empty');
+});
+
+test('extractWinningTurn: worker and API agree for every split game', () => {
+  const apiGames = apiSplit(RAW_LOG);
+  const workerGames = workerSplit(RAW_LOG);
+  for (let i = 0; i < apiGames.length; i++) {
+    const apiT = normTurn(apiExtractWinningTurn(apiGames[i]));
+    const workerT = normTurn(workerExtractWinningTurn(workerGames[i]));
+    assertEqual(workerT, apiT, `game ${i} winning turn`);
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/api/test/condenser-contract.test.ts
+++ b/api/test/condenser-contract.test.ts
@@ -161,6 +161,44 @@ test('extractWinningTurn: worker and API agree for every split game', () => {
   }
 });
 
+test('extractWinningTurn: worker and API agree when winner name does not match any turn owner', () => {
+  // Synthetic: turn markers attribute to Alice/Bob/Carol/Dan, but the winner
+  // line names someone not in the turn ranges. Both sides must fall through
+  // to max-per-deck (Bob=3) instead of returning 0 or diverging.
+  const log = [
+    'Turn: Turn 1 (Alice)', 'stuff',
+    'Turn: Turn 2 (Bob)', 'stuff',
+    'Turn: Turn 3 (Carol)', 'stuff',
+    'Turn: Turn 4 (Dan)', 'stuff',
+    'Turn: Turn 5 (Alice)', 'stuff',
+    'Turn: Turn 6 (Bob)', 'stuff',
+    'Turn: Turn 7 (Carol)', 'stuff',
+    'Turn: Turn 8 (Dan)', 'stuff',
+    'Turn: Turn 9 (Bob)', 'stuff',
+    'Eve has won because all opponents have lost',
+  ].join('\n');
+  const apiT = normTurn(apiExtractWinningTurn(log));
+  const workerT = normTurn(workerExtractWinningTurn(log));
+  assertEqual(workerT, apiT, 'unknown winner falls through to same value');
+  assertEqual(apiT, 3, 'max-per-deck is Bob = 3');
+});
+
+test('extractWinningTurn: worker and API agree when turn markers lack player attribution', () => {
+  // Forge's older log format emits "Turn N: <player>" where <player> can be
+  // empty; both implementations should reach the last-resort round fallback.
+  const log = [
+    'Turn 1:',
+    'Turn 2:',
+    'Turn 3:',
+    'Turn 4:',
+    'Turn 5:',
+    'Alice has won because all opponents have lost',
+  ].join('\n');
+  const apiT = normTurn(apiExtractWinningTurn(log));
+  const workerT = normTurn(workerExtractWinningTurn(log));
+  assertEqual(workerT, apiT, 'last-resort fallback agrees');
+});
+
 // ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------

--- a/worker/src/condenser.ts
+++ b/worker/src/condenser.ts
@@ -395,12 +395,13 @@ function matchesDeckName(fullName: string, shortName: string): boolean {
   return false;
 }
 
-// Number of Turn: markers owned by each player — accurate with eliminations.
-function calculatePerDeckTurns(ranges: TurnRange[]): Record<string, number> {
-  const result: Record<string, number> = {};
+// Shape mirrors api/lib/condenser/turns.ts so drift is obvious if the two diverge.
+function calculatePerDeckTurns(ranges: TurnRange[]): Record<string, { turnsTaken: number }> {
+  const result: Record<string, { turnsTaken: number }> = {};
   for (const range of ranges) {
     if (!range.player) continue;
-    result[range.player] = (result[range.player] ?? 0) + 1;
+    if (!result[range.player]) result[range.player] = { turnsTaken: 0 };
+    result[range.player].turnsTaken++;
   }
   return result;
 }
@@ -413,11 +414,15 @@ export function extractWinningTurn(rawLog: string): number {
   const winner = extractWinner(rawLog);
   if (winner) {
     const winnerKey = Object.keys(perDeck).find((k) => matchesDeckName(k, winner));
-    if (winnerKey) return perDeck[winnerKey]!;
+    if (winnerKey) return perDeck[winnerKey].turnsTaken;
   }
 
-  const counts = Object.values(perDeck);
-  return counts.length > 0 ? Math.max(...counts) : 0;
+  const allTurns = Object.values(perDeck).map((d) => d.turnsTaken);
+  if (allTurns.length > 0) return Math.max(...allTurns);
+
+  // Last resort: turn markers present but none had a player name (old log format
+  // with missing player). Fall back to the round-count approximation.
+  return getMaxRound(turnRanges, getNumPlayers(turnRanges));
 }
 
 // ============================================================================

--- a/worker/src/condenser.ts
+++ b/worker/src/condenser.ts
@@ -383,30 +383,41 @@ export function extractWinner(rawLog: string): string {
   return '';
 }
 
+// Keep in sync with api/lib/condenser/deck-match.ts:matchesDeckName.
+function matchesDeckName(fullName: string, shortName: string): boolean {
+  if (fullName === shortName) return true;
+  if (fullName.endsWith('-' + shortName)) return true;
+  const stripped = fullName.replace(/^Ai\(\d+\)-/, '');
+  if (stripped !== fullName) {
+    if (stripped === shortName) return true;
+    if (stripped.startsWith(shortName + ' - ')) return true;
+  }
+  return false;
+}
+
+// Number of Turn: markers owned by each player — accurate with eliminations.
+function calculatePerDeckTurns(ranges: TurnRange[]): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const range of ranges) {
+    if (!range.player) continue;
+    result[range.player] = (result[range.player] ?? 0) + 1;
+  }
+  return result;
+}
+
 export function extractWinningTurn(rawLog: string): number {
-  const lines = rawLog.replace(/\r\n/g, '\n').split('\n');
   const turnRanges = extractTurnRanges(rawLog);
-  const numPlayers = getNumPlayers(turnRanges);
+  if (turnRanges.length === 0) return 0;
 
-  // Find the line with the win condition and determine its turn
-  for (let i = 0; i < lines.length; i++) {
-    if (KeepWinCondition.test(lines[i])) {
-      // Find which turn range this line belongs to
-      for (const tr of turnRanges) {
-        if (i >= tr.startIndex && i <= tr.endIndex) {
-          // Convert to round
-          return Math.ceil(tr.turnNumber / numPlayers);
-        }
-      }
-    }
+  const perDeck = calculatePerDeckTurns(turnRanges);
+  const winner = extractWinner(rawLog);
+  if (winner) {
+    const winnerKey = Object.keys(perDeck).find((k) => matchesDeckName(k, winner));
+    if (winnerKey) return perDeck[winnerKey]!;
   }
 
-  // If we can't find the win line in a turn, return the last round
-  if (turnRanges.length > 0) {
-    return getMaxRound(turnRanges, numPlayers);
-  }
-
-  return 0;
+  const counts = Object.values(perDeck);
+  return counts.length > 0 ? Math.max(...counts) : 0;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The worker's \`extractWinningTurn\` and the API's version computed different things. With eliminations, they drifted, and the discrepancy surfaced as: DeckShowcase (live sim data, worker-reported) showing lower turn numbers than the Power Rankings histogram (API-aggregated from matchResults) for the same wins.

Concrete example from a real job (Temur Roar Upgraded, 46 wins):
- DeckShowcase card: avg 9.5, min turn 6 in the "Turns:" preview.
- Power Rankings tooltip: avg 10.6, histogram empty in bins 1–7.
- Same 46 games in both — different numbers.

**Mechanism**: worker used \`ceil(segmentCount / initialPlayerCount)\` — a round-count approximation that only holds when turns still divide evenly across players. Once a player is eliminated mid-rotation, segments keep incrementing but only for the surviving players, so the winner's actual turn marker count climbs past the round-count estimate.

**Fix**: port the API's per-deck count (\`matchesDeckName\` + \`calculatePerDeckTurns\`) into the worker. Both sides now count the winner's actual Turn: markers, which matches how MTG players think about "won on turn 8" after eliminations.

## Test plan

- [x] \`npm run test:unit --prefix api\` — passes (11/11), including the new contract assertion.
- [x] Condenser contract test: \`extractWinningTurn: worker and API agree for every split game\` — passes on the real 4-game fixture.
- [x] \`tsc --noEmit\` clean on both api and worker.
- [x] \`npm run build --prefix worker\` clean.

## Rollout note

This change affects newly-completed simulations only. Existing \`simulation\` docs keep their old worker-reported \`winningTurns\`; DeckShowcase for those jobs will still show the old numbers until the user loads structured logs (which already use the per-deck count). No data migration required — the rating store's histogram was already built from the correct API-side values, so the Power Rankings tooltip is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)