### PR TITLE
fix(api): batch Firestore writes to avoid DEADLINE_EXCEEDED

### DIFF
--- a/api/lib/archidekt-sync.ts
+++ b/api/lib/archidekt-sync.ts
@@ -319,20 +319,30 @@ export async function syncPrecons(): Promise<SyncResult> {
   const orphanIds = [...allExistingPreconIds].filter((id) => !keepPreconIds.has(id));
   if (orphanIds.length > 0 && archidektDecks.length >= allExistingPreconIds.size * 0.5) {
     console.log(`[PreconSync] Removing ${orphanIds.length} orphaned precons...`);
-    for (const id of orphanIds) {
+    if (USE_FIRESTORE) {
       try {
-        if (USE_FIRESTORE) {
-          const firestoreDecks = await import('./firestore-decks');
-          await firestoreDecks.deletePrecon(id);
-        } else {
-          const { getDb } = await import('./db');
-          const db = getDb();
-          db.prepare('DELETE FROM precons WHERE id = ?').run(id);
-        }
-        result.removed++;
-        console.log(`[PreconSync] Removed orphan: ${id}`);
+        const firestoreDecks = await import('./firestore-decks');
+        await firestoreDecks.deletePrecons(orphanIds);
+        result.removed += orphanIds.length;
+        console.log(`[PreconSync] Removed ${orphanIds.length} orphans`);
       } catch (err) {
-        const msg = `Failed to remove orphan "${id}": ${err instanceof Error ? err.message : err}`;
+        const msg = `Failed to batch-delete ${orphanIds.length} orphans: ${err instanceof Error ? err.message : err}`;
+        console.error(`[PreconSync] ${msg}`);
+        result.errors.push(msg);
+      }
+    } else {
+      const { getDb } = await import('./db');
+      const db = getDb();
+      const stmt = db.prepare('DELETE FROM precons WHERE id = ?');
+      const deleteAll = db.transaction((ids: string[]) => {
+        for (const id of ids) stmt.run(id);
+      });
+      try {
+        deleteAll(orphanIds);
+        result.removed += orphanIds.length;
+        console.log(`[PreconSync] Removed ${orphanIds.length} orphans`);
+      } catch (err) {
+        const msg = `Failed to delete ${orphanIds.length} orphans: ${err instanceof Error ? err.message : err}`;
         console.error(`[PreconSync] ${msg}`);
         result.errors.push(msg);
       }

--- a/api/lib/deck-resolver.ts
+++ b/api/lib/deck-resolver.ts
@@ -19,16 +19,15 @@ export async function resolveDeckId(deckId: string): Promise<DeckSlot | undefine
 export async function resolveDeckIds(
   deckIds: string[]
 ): Promise<{ decks: DeckSlot[]; errors: string[] }> {
+  const resolved = await Promise.all(
+    deckIds.map(async (id) => ({ id, deck: await resolveDeckId(id) }))
+  );
+
   const decks: DeckSlot[] = [];
   const errors: string[] = [];
-
-  for (const id of deckIds) {
-    const deck = await resolveDeckId(id);
-    if (deck) {
-      decks.push(deck);
-    } else {
-      errors.push(id);
-    }
+  for (const { id, deck } of resolved) {
+    if (deck) decks.push(deck);
+    else errors.push(id);
   }
 
   return { decks, errors };

--- a/api/lib/firestore-decks.ts
+++ b/api/lib/firestore-decks.ts
@@ -215,3 +215,19 @@ export async function deleteDeck(id: string, userId: string): Promise<boolean> {
 export async function deletePrecon(id: string): Promise<void> {
   await decksCollection.doc(id).delete();
 }
+
+/**
+ * Delete many precon decks by ID in batched writes (for sync cleanup).
+ * Chunks at the Firestore 500-write batch limit.
+ */
+export async function deletePrecons(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const CHUNK = 500;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const batch = firestore.batch();
+    for (const id of ids.slice(i, i + CHUNK)) {
+      batch.delete(decksCollection.doc(id));
+    }
+    await batch.commit();
+  }
+}

--- a/api/lib/job-store-factory.ts
+++ b/api/lib/job-store-factory.ts
@@ -375,41 +375,44 @@ async function recoverStaleSimulations(
 
   const now = Date.now();
   const activeWorkerIds = new Set(activeWorkers.map((w) => w.workerId));
-  let recovered = false;
 
-  for (const sim of sims) {
-    // Case 1: RUNNING sim stuck for >2.5 hours — container hung.
-    if (sim.state === 'RUNNING' && sim.startedAt) {
-      const runningForMs = now - new Date(sim.startedAt).getTime();
-      if (runningForMs > STALE_RUNNING_THRESHOLD_MS) {
+  const recoveryFlags = await Promise.all(
+    sims.map(async (sim) => {
+      // Case 1: RUNNING sim stuck for >2.5 hours — container hung.
+      if (sim.state === 'RUNNING' && sim.startedAt) {
+        const runningForMs = now - new Date(sim.startedAt).getTime();
+        if (runningForMs > STALE_RUNNING_THRESHOLD_MS) {
+          const updated = await conditionalResetSimulationToPending(jobId, sim.simId, ['RUNNING']);
+          if (updated) {
+            recoveryLog.info('Sim RUNNING too long, reset to PENDING', { jobId, simId: sim.simId, runningMin: Math.round(runningForMs / 60000) });
+          }
+          return updated;
+        }
+      }
+
+      // Case 2: RUNNING sim whose worker is dead.
+      if (sim.state === 'RUNNING' && sim.workerId && !activeWorkerIds.has(sim.workerId)) {
         const updated = await conditionalResetSimulationToPending(jobId, sim.simId, ['RUNNING']);
         if (updated) {
-          recoveryLog.info('Sim RUNNING too long, reset to PENDING', { jobId, simId: sim.simId, runningMin: Math.round(runningForMs / 60000) });
-          recovered = true;
+          recoveryLog.info('Sim worker is dead, reset to PENDING', { jobId, simId: sim.simId, deadWorker: sim.workerId });
         }
-        continue;
+        return updated;
       }
-    }
 
-    // Case 2: RUNNING sim whose worker is dead.
-    if (sim.state === 'RUNNING' && sim.workerId && !activeWorkerIds.has(sim.workerId)) {
-      const updated = await conditionalResetSimulationToPending(jobId, sim.simId, ['RUNNING']);
-      if (updated) {
-        recoveryLog.info('Sim worker is dead, reset to PENDING', { jobId, simId: sim.simId, deadWorker: sim.workerId });
-        recovered = true;
+      // Case 3: FAILED sim — retry if any worker is online to pick it up.
+      if (sim.state === 'FAILED' && activeWorkers.length > 0) {
+        const updated = await conditionalResetSimulationToPending(jobId, sim.simId, ['FAILED']);
+        if (updated) {
+          recoveryLog.info('Sim FAILED, reset to PENDING for retry', { jobId, simId: sim.simId });
+        }
+        return updated;
       }
-      continue;
-    }
 
-    // Case 3: FAILED sim — retry if any worker is online to pick it up.
-    if (sim.state === 'FAILED' && activeWorkers.length > 0) {
-      const updated = await conditionalResetSimulationToPending(jobId, sim.simId, ['FAILED']);
-      if (updated) {
-        recoveryLog.info('Sim FAILED, reset to PENDING for retry', { jobId, simId: sim.simId });
-        recovered = true;
-      }
-    }
-  }
+      return false;
+    })
+  );
+
+  const recovered = recoveryFlags.some(Boolean);
 
   // Only aggregate when all sims are terminal. FAILED sims above are reset
   // to PENDING and will be retried; they're not terminal here.
@@ -487,18 +490,18 @@ async function recoverStaleSimulationsLocal(
   if (workerStillAlive) return false;
 
   // Worker is dead. Reset in-flight sims so the re-claim has clean state.
-  let resetCount = 0;
-  for (const sim of sims) {
-    if (sim.state === 'RUNNING' || sim.state === 'FAILED') {
-      const updated = await conditionalUpdateSimulationStatus(
+  const resetResults = await Promise.all(
+    sims.map(async (sim) => {
+      if (sim.state !== 'RUNNING' && sim.state !== 'FAILED') return false;
+      return conditionalUpdateSimulationStatus(
         jobId,
         sim.simId,
         [sim.state],
         { state: 'PENDING' }
       );
-      if (updated) resetCount++;
-    }
-  }
+    })
+  );
+  const resetCount = resetResults.filter(Boolean).length;
 
   const jobReset = await resetJobForRetry(jobId);
   recoveryLog.info('LOCAL: reset stuck RUNNING job for re-claim', {

--- a/api/lib/rating-store-firestore.ts
+++ b/api/lib/rating-store-firestore.ts
@@ -71,15 +71,25 @@ export const firestoreRatingStore: RatingStore = {
     await batch.commit();
   },
 
-  async recordMatchResult(result: MatchResult): Promise<void> {
-    await matchResultsCol.doc(result.id).set({
-      jobId: result.jobId,
-      gameIndex: result.gameIndex,
-      deckIds: result.deckIds,
-      winnerDeckId: result.winnerDeckId ?? null,
-      turnCount: result.turnCount ?? null,
-      playedAt: Timestamp.now(),
-    });
+  async recordMatchResults(results: MatchResult[]): Promise<void> {
+    if (results.length === 0) return;
+    const now = Timestamp.now();
+    // Firestore batches cap at 500 writes; chunk to stay under the limit.
+    const CHUNK = 500;
+    for (let i = 0; i < results.length; i += CHUNK) {
+      const batch = firestore.batch();
+      for (const r of results.slice(i, i + CHUNK)) {
+        batch.set(matchResultsCol.doc(r.id), {
+          jobId: r.jobId,
+          gameIndex: r.gameIndex,
+          deckIds: r.deckIds,
+          winnerDeckId: r.winnerDeckId ?? null,
+          turnCount: r.turnCount ?? null,
+          playedAt: now,
+        });
+      }
+      await batch.commit();
+    }
   },
 
   async hasMatchResultsForJob(jobId: string): Promise<boolean> {

--- a/api/lib/rating-store-sqlite.ts
+++ b/api/lib/rating-store-sqlite.ts
@@ -94,20 +94,27 @@ export const sqliteRatingStore: RatingStore = {
     runAll(updates);
   },
 
-  async recordMatchResult(result: MatchResult): Promise<void> {
+  async recordMatchResults(results: MatchResult[]): Promise<void> {
+    if (results.length === 0) return;
     const db = getDb();
-    db.prepare(`
+    const stmt = db.prepare(`
       INSERT OR IGNORE INTO match_results (id, job_id, game_index, deck_ids, winner_deck_id, turn_count, played_at)
       VALUES (?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      result.id,
-      result.jobId,
-      result.gameIndex,
-      JSON.stringify(result.deckIds),
-      result.winnerDeckId ?? null,
-      result.turnCount ?? null,
-      result.playedAt,
-    );
+    `);
+    const runAll = db.transaction((rows: MatchResult[]) => {
+      for (const r of rows) {
+        stmt.run(
+          r.id,
+          r.jobId,
+          r.gameIndex,
+          JSON.stringify(r.deckIds),
+          r.winnerDeckId ?? null,
+          r.turnCount ?? null,
+          r.playedAt,
+        );
+      }
+    });
+    runAll(results);
   },
 
   async hasMatchResultsForJob(jobId: string): Promise<boolean> {

--- a/api/lib/rating-store.ts
+++ b/api/lib/rating-store.ts
@@ -18,8 +18,8 @@ export interface RatingStore {
   /** Upsert ratings for multiple decks in one operation. */
   updateRatings(updates: DeckRating[]): Promise<void>;
 
-  /** Record a match result (for idempotency checks). */
-  recordMatchResult(result: MatchResult): Promise<void>;
+  /** Record match results (for idempotency checks). Writes are batched. */
+  recordMatchResults(results: MatchResult[]): Promise<void>;
 
   /** Return true if match results already exist for this jobId. */
   hasMatchResultsForJob(jobId: string): Promise<boolean>;

--- a/api/lib/stale-sweeper.ts
+++ b/api/lib/stale-sweeper.ts
@@ -79,27 +79,27 @@ export async function hardCancelStaleSimsForJob(
   if (sims.length === 0) return 0;
 
   const baselineMs = jobBaselineMs(job);
-  let cancelled = 0;
   const message = `Hard-cancelled by stale-sweeper after exceeding ${Math.round(
     SIM_HARD_CANCEL_THRESHOLD_MS / 60000
   )}m lifetime cap`;
 
-  for (const sim of sims) {
-    if (!shouldHardCancelSim(sim, baselineMs, nowMs)) continue;
-    const updated = await jobStore.conditionalUpdateSimulationStatus(
-      job.id,
-      sim.simId,
-      ['PENDING', 'RUNNING', 'FAILED'],
-      {
-        state: 'CANCELLED',
-        errorMessage: message,
-        completedAt: new Date(nowMs).toISOString(),
-      }
-    );
-    if (updated) cancelled += 1;
-  }
+  const results = await Promise.all(
+    sims.map((sim) => {
+      if (!shouldHardCancelSim(sim, baselineMs, nowMs)) return Promise.resolve(false);
+      return jobStore.conditionalUpdateSimulationStatus(
+        job.id,
+        sim.simId,
+        ['PENDING', 'RUNNING', 'FAILED'],
+        {
+          state: 'CANCELLED',
+          errorMessage: message,
+          completedAt: new Date(nowMs).toISOString(),
+        }
+      );
+    })
+  );
 
-  return cancelled;
+  return results.filter(Boolean).length;
 }
 
 /**
@@ -175,9 +175,11 @@ export async function sweepStaleJobs(nowMs: number = Date.now()): Promise<SweepR
       // Local mode + post-cancel catch-up: if the job is still RUNNING but
       // every sim is terminal, explicitly aggregate. recoverStaleJob's
       // built-in re-trigger is gated on GCP mode, so we cover the gap here.
-      const refreshed = await jobStore.getJob(job.id);
+      const [refreshed, sims] = await Promise.all([
+        jobStore.getJob(job.id),
+        jobStore.getSimulationStatuses(job.id),
+      ]);
       if (refreshed && refreshed.status === 'RUNNING') {
-        const sims = await jobStore.getSimulationStatuses(job.id);
         const allTerminal =
           sims.length > 0 &&
           sims.every((s) => s.state === 'COMPLETED' || s.state === 'CANCELLED');

--- a/api/lib/trueskill-service.ts
+++ b/api/lib/trueskill-service.ts
@@ -149,9 +149,7 @@ export async function processJobForRatings(
     resolvedGames += 1;
   }
 
-  for (const result of matchResults) {
-    await store.recordMatchResult(result);
-  }
+  await store.recordMatchResults(matchResults);
 
   if (resolvedGames > 0) {
     await store.updateRatings(currentRatings);


### PR DESCRIPTION
## Summary
- Fixes Sentry [MAGIC-BRACKET-API-4](https://tytaniumdev.sentry.io/issues/MAGIC-BRACKET-API-4): `processJobForRatings` wrote match results in a serial loop, so a single grpc `DEADLINE_EXCEEDED` could fail mid-aggregation and leak partial state past the `hasMatchResultsForJob` idempotency guard. Replaced `recordMatchResult` with a batched `recordMatchResults` (Firestore WriteBatch, chunked at 500; single SQLite transaction).
- Swept the rest of `api/` for similar serial-write patterns:
  - `archidekt-sync` orphan precon deletion → one batched delete.
  - Sim recovery loops in `job-store-factory` (`recoverStaleJob` GCP path, `recoverStaleSimulationsLocal`) and `stale-sweeper` (`hardCancelStaleSimsForJob`) → `Promise.all` over sims (each conditional update is its own Firestore transaction, so a real batch isn't possible).
  - `sweepStaleJobs` reads `getJob` + `getSimulationStatuses` in parallel inside each iteration.
  - `resolveDeckIds` → `Promise.all`.

## Test plan
- [x] `npm run lint --prefix api` (tsc passes)
- [x] `npm run test:unit --prefix api` (11/11 + 8/8 contract tests pass)
- [ ] Verify on production: next sweep cycle should not regress `MAGIC-BRACKET-API-4`
- [ ] Spot-check a completed job's match results land in Firestore correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)