### PR TITLE
chore(macos): point Fastlane at renamed tytaniumdev-certificates repo

### DIFF
--- a/.github/workflows/release-worker-macos.yml
+++ b/.github/workflows/release-worker-macos.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure SSH for certs repo
-        # The BlinkBreak-certificates repo is private; match needs an SSH
+        # The TytaniumDev-certificates repo is private; match needs an SSH
         # key to read it. The secret is the private half of a deploy key
         # added to that repo with read-only permissions.
         env:

--- a/docs/superpowers/specs/2026-05-12-desktop-app-evolution-design.md
+++ b/docs/superpowers/specs/2026-05-12-desktop-app-evolution-design.md
@@ -178,7 +178,7 @@ Re-enable `tray_manager` calls in cloud mode bootstrap only (not offline mode �
 Mirror BlinkBreak's Fastlane match pattern, with these adjustments for macOS:
 
 1. **Cert type:** `developer_id` (not `appstore`). Distributes outside the App Store.
-2. **Storage:** new directory `developer_id/` in the existing `BlinkBreak-certificates` repo (so we don't manage two cert repos). Optional: rename repo to a generic name in a separate change.
+2. **Storage:** new directory `developer_id/` in the existing `TytaniumDev-certificates` repo (so we don't manage two cert repos). Optional: rename repo to a generic name in a separate change.
 3. **Seed step (run once locally):** `fastlane match developer_id --app_identifier=com.tytaniumdev.workerFlutter`. Requires the user to first create a "Developer ID Application" cert in the Apple Developer portal (or let match create it). This is a manual step — match cannot run unattended for cert creation the very first time.
 4. **CI lane (Fastfile):** `sync_certs` → `update_code_signing_settings` for `worker_flutter/macos/Runner.xcodeproj` → `flutter build macos --release` → `notarize` (xcrun notarytool via Fastlane's `notarize` action) → staple → zip → upload artifact.
 5. **Credentials:** reuse ASC API key from BlinkBreak (ASC_KEY_ID / ASC_ISSUER_ID / ASC_API_KEY_CONTENT) since same team (F2HXQGU2CC).
@@ -215,7 +215,7 @@ Given the prerequisites (signing first on both platforms), this is parked until 
 | Risk | Mitigation |
 |---|---|
 | Google Sign-In via `firebase_auth_macos` historically crashed natively in unsigned/sandbox-disabled config (the original Plan 3 deferral reason). | Sub-project D (signing) runs first, OR we use `google_sign_in` desktop OAuth flow which doesn't go through firebase_auth's native crash path. Plan to use the latter as a safety net. |
-| Developer ID cert doesn't exist in `BlinkBreak-certificates` repo yet (verified 2026-05-12 — only iOS App Store cert present). | Sub-project D explicitly includes a manual "seed cert" step. Fastlane config is written so once the cert exists, the rest is unattended. |
+| Developer ID cert doesn't exist in `TytaniumDev-certificates` repo yet (verified 2026-05-12 — only iOS App Store cert present). | Sub-project D explicitly includes a manual "seed cert" step. Fastlane config is written so once the cert exists, the rest is unattended. |
 | Drift codegen requires running `build_runner` — first-time setup cost. | Single `pub run build_runner build` step documented in worker_flutter/README. CI runs it before `flutter test`. |
 | Refactor of `worker/` → `cloud/` + `shared/` touches many files; risk of breaking the existing PR #189 work. | Refactor lands as one mechanical commit *after* PR #189 merges. Or: rebased into the same PR if not yet merged. |
 | Storage pruner deleting active job logs. | Pruner skips jobs with status != COMPLETED/FAILED/CANCELLED. |
@@ -226,7 +226,7 @@ Given the prerequisites (signing first on both platforms), this is parked until 
 - Cloud → offline sync (one-way only: separate worlds).
 - Moxfield URL fetch / raw deck paste in offline v1 (precons only).
 - Auto-updater on Windows (requires Windows code signing).
-- Migrating existing iOS App Store creds repo to a renamed "tytaniumdev-certificates" generic repo (separate refactor).
+- Migrating existing iOS App Store creds repo to a renamed "TytaniumDev-certificates" generic repo (separate refactor).
 
 ---
 

--- a/worker_flutter/macos/fastlane/Fastfile
+++ b/worker_flutter/macos/fastlane/Fastfile
@@ -5,7 +5,7 @@
 #   1. Create a "Developer ID Application" cert in the Apple Developer
 #      portal for team F2HXQGU2CC.
 #   2. Run `bundle exec fastlane seed_certs` to seed the cert/profile
-#      into the BlinkBreak-certificates git repo.
+#      into the TytaniumDev-certificates git repo.
 #   3. From CI, the `release` lane below uses `sync_certs` (readonly)
 #      to install the cert + profile into an ephemeral keychain.
 #
@@ -41,7 +41,7 @@ platform :mac do
   lane :seed_certs do
     match(
       api_key:        asc_api_key,
-      git_url:        "git@github.com:TytaniumDev/BlinkBreak-certificates.git",
+      git_url:        "git@github.com:TytaniumDev/TytaniumDev-certificates.git",
       storage_mode:   "git",
       type:           "developer_id",
       app_identifier: [APP_IDENTIFIER],
@@ -66,7 +66,7 @@ platform :mac do
 
     match(
       api_key:        asc_api_key,
-      git_url:        "git@github.com:TytaniumDev/BlinkBreak-certificates.git",
+      git_url:        "git@github.com:TytaniumDev/TytaniumDev-certificates.git",
       storage_mode:   "git",
       type:           "developer_id",
       app_identifier: [APP_IDENTIFIER],

--- a/worker_flutter/macos/fastlane/Matchfile
+++ b/worker_flutter/macos/fastlane/Matchfile
@@ -1,4 +1,4 @@
-git_url("git@github.com:TytaniumDev/BlinkBreak-certificates.git")
+git_url("git@github.com:TytaniumDev/TytaniumDev-certificates.git")
 storage_mode("git")
 type("developer_id")
 app_identifier(["com.tytaniumdev.workerFlutter"])

--- a/worker_flutter/macos/fastlane/README.md
+++ b/worker_flutter/macos/fastlane/README.md
@@ -3,14 +3,22 @@
 Fastlane match + notarytool pipeline for distributing the Magic Bracket
 worker as a signed, notarized `.app` outside the Mac App Store.
 
-The certs are shared with BlinkBreak (same Apple team, same git repo):
-private repo `TytaniumDev/BlinkBreak-certificates`.
+The certs live alongside BlinkBreak's (same Apple team `F2HXQGU2CC`)
+in the private repo `TytaniumDev/TytaniumDev-certificates` — which is
+the renamed `BlinkBreak-certificates` repo, generalized for all of
+this team's signing assets.
 
 ## One-time setup (manual)
 
-Before the CI workflow can succeed, the Developer ID Application cert
-needs to exist in the certs repo. As of 2026-05-12 the repo only has the
-iOS App Store cert, so you'll need to seed the macOS one.
+Before the CI workflow can succeed:
+
+- The cert storage repo must be renamed from `BlinkBreak-certificates`
+  → `TytaniumDev-certificates` in GitHub (Settings → Repository name).
+  GitHub auto-redirects the old name to the new one, so BlinkBreak's
+  existing pipeline continues to work without changes; updating its
+  Matchfile/Fastfile to the new name is a follow-up cleanup.
+- A "Developer ID Application" cert must exist for team `F2HXQGU2CC`.
+  As of 2026-05-12 the repo only has the iOS App Store cert.
 
 1. **Create the cert in the Apple Developer portal** (or let match create
    it on first run — it will try). Required: a "Developer ID Application"
@@ -44,7 +52,7 @@ iOS App Store cert, so you'll need to seed the macOS one.
    | `ASC_ISSUER_ID` | Same page. |
    | `ASC_API_KEY_CONTENT` | Contents of the `AuthKey_<ID>.p8` file (raw text or base64). |
    | `ASC_API_KEY_IS_BASE64` | `"true"` if you base64-encoded the previous; else omit. |
-   | `CERTS_REPO_DEPLOY_KEY` | Private half of an SSH deploy key. Add the public half to `BlinkBreak-certificates` repo settings → Deploy keys, read-only. |
+   | `CERTS_REPO_DEPLOY_KEY` | Private half of an SSH deploy key. Add the public half to `TytaniumDev-certificates` repo settings → Deploy keys, read-only. |
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

- Updates Fastlane references in `worker_flutter/macos/` to point at the renamed `tytaniumdev-certificates` repo (was `BlinkBreak-certificates`).
- Sister change to the BlinkBreak PR that does the same on that side.
- GitHub auto-redirects the old URL, so order of merge / rename doesn't matter.

## Why

The certs repo was named after the first app that used it; now that the macOS worker also signs there, the generic name is more accurate.

## Test plan

- [ ] Repo renamed in GitHub UI (`TytaniumDev/BlinkBreak-certificates` → `TytaniumDev/tytaniumdev-certificates`)
- [ ] Next `fastlane seed_certs` run picks up the new git_url cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)