### PR TITLE
feat(worker): rename bundle ID + migrate signing CI to Doppler

### DIFF
--- a/.github/workflows/release-worker-macos.yml
+++ b/.github/workflows/release-worker-macos.yml
@@ -1,9 +1,17 @@
-name: Release worker_flutter (macOS)
+name: Release magic-bracket-simulator (macOS)
 
 # Triggered manually or on push of a tag matching `worker-v*` (e.g.
 # `worker-v0.1.0`). Builds, signs, and notarizes the .app, then
-# uploads the zipped artifact to the workflow run. A follow-up step
-# can attach it to a GitHub Release.
+# uploads the zipped artifact to the workflow run and attaches it to
+# the GitHub Release for the tag.
+#
+# Secrets pattern mirrors BlinkBreak's deploy-testflight.yml: only
+# DOPPLER_BLINKBREAK_TOKEN is a GitHub Actions secret (a service token
+# scoped to Doppler project "blinkbreak", config "prd"). Everything
+# else (match password, ASC API key, certs-repo SSH key) comes from
+# Doppler. The repo's other workflows use DOPPLER_TOKEN scoped to
+# magic-bracket-simulator — this workflow needs a separately-scoped
+# token because the signing secrets live in BlinkBreak's Doppler config.
 
 on:
   workflow_dispatch:
@@ -19,29 +27,49 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 45
 
-    env:
-      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-      MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
-      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-      ASC_API_KEY_CONTENT: ${{ secrets.ASC_API_KEY_CONTENT }}
-      ASC_API_KEY_IS_BASE64: ${{ secrets.ASC_API_KEY_IS_BASE64 }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure SSH for certs repo
-        # The TytaniumDev-certificates repo is private; match needs an SSH
-        # key to read it. The secret is the private half of a deploy key
-        # added to that repo with read-only permissions.
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Load secrets from Doppler
         env:
-          DEPLOY_KEY: ${{ secrets.CERTS_REPO_DEPLOY_KEY }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_BLINKBREAK_TOKEN }}
+        run: |
+          DELIM=$(openssl rand -hex 16)
+          # Token is already scoped to blinkbreak/prd; no need to pass them.
+          SECRETS=$(doppler secrets download --no-file --format json)
+          KEYS='[
+            "MATCH_PASSWORD",
+            "MATCH_SSH_PRIVATE_KEY",
+            "MATCH_KEYCHAIN_PASSWORD",
+            "ASC_KEY_ID",
+            "ASC_ISSUER_ID",
+            "ASC_API_KEY_CONTENT",
+            "ASC_API_KEY_IS_BASE64"
+          ]'
+          # Mask every value before using it.
+          echo "$SECRETS" | jq -r --argjson keys "$KEYS" '
+            to_entries[] | select(.key | IN($keys[])) | .value
+          ' | while IFS= read -r val; do
+            [ -n "$val" ] && echo "::add-mask::$val"
+          done
+          # Write into $GITHUB_ENV with a random heredoc delimiter so multi-line
+          # values (RSA/ED25519 private key, base64 .p8, etc.) survive intact.
+          echo "$SECRETS" | jq -r --argjson keys "$KEYS" --arg d "$DELIM" '
+            to_entries[] | select(.key | IN($keys[])) | "\(.key)<<\($d)\n\(.value)\n\($d)"
+          ' >> "$GITHUB_ENV"
+
+      - name: Install SSH deploy key for certs repo
+        env:
+          MATCH_SSH_PRIVATE_KEY: ${{ env.MATCH_SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
-          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          printf '%s\n' "$MATCH_SSH_PRIVATE_KEY" > ~/.ssh/match_deploy_key
+          chmod 600 ~/.ssh/match_deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
@@ -66,12 +94,25 @@ jobs:
 
       - name: Fastlane release (sign + notarize)
         working-directory: worker_flutter/macos
+        env:
+          MATCH_PASSWORD: ${{ env.MATCH_PASSWORD }}
+          MATCH_KEYCHAIN_PASSWORD: ${{ env.MATCH_KEYCHAIN_PASSWORD }}
+          ASC_KEY_ID: ${{ env.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ env.ASC_ISSUER_ID }}
+          ASC_API_KEY_CONTENT: ${{ env.ASC_API_KEY_CONTENT }}
+          ASC_API_KEY_IS_BASE64: ${{ env.ASC_API_KEY_IS_BASE64 }}
+          FASTLANE_HIDE_CHANGELOG: "1"
+          FASTLANE_SKIP_UPDATE_CHECK: "1"
+          FASTLANE_DISABLE_COLORS: "1"
+          # Force match's git operations to use the deploy key, regardless of
+          # the runner's default SSH config.
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/match_deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: bundle exec fastlane release
 
       - name: Upload signed artifact
         uses: actions/upload-artifact@v4
         with:
-          name: worker_flutter-macos
+          name: magic-bracket-simulator-macos
           path: worker_flutter/build/worker_flutter-macos.zip
           if-no-files-found: error
 

--- a/docs/superpowers/specs/2026-05-12-desktop-app-evolution-design.md
+++ b/docs/superpowers/specs/2026-05-12-desktop-app-evolution-design.md
@@ -178,8 +178,8 @@ Re-enable `tray_manager` calls in cloud mode bootstrap only (not offline mode �
 Mirror BlinkBreak's Fastlane match pattern, with these adjustments for macOS:
 
 1. **Cert type:** `developer_id` (not `appstore`). Distributes outside the App Store.
-2. **Storage:** new directory `developer_id/` in the existing `TytaniumDev-certificates` repo (so we don't manage two cert repos). Optional: rename repo to a generic name in a separate change.
-3. **Seed step (run once locally):** `fastlane match developer_id --app_identifier=com.tytaniumdev.workerFlutter`. Requires the user to first create a "Developer ID Application" cert in the Apple Developer portal (or let match create it). This is a manual step — match cannot run unattended for cert creation the very first time.
+2. **Storage:** new directory `developer_id/` in the existing `TytaniumDev-certificates` repo (so we don't manage two cert repos).
+3. **Seed step (run once locally):** `fastlane match developer_id --app_identifier=com.tytaniumdev.magicBracketSimulator`. Requires the user to first create a "Developer ID Application" cert in the Apple Developer portal (or let match create it). This is a manual step — match cannot run unattended for cert creation the very first time.
 4. **CI lane (Fastfile):** `sync_certs` → `update_code_signing_settings` for `worker_flutter/macos/Runner.xcodeproj` → `flutter build macos --release` → `notarize` (xcrun notarytool via Fastlane's `notarize` action) → staple → zip → upload artifact.
 5. **Credentials:** reuse ASC API key from BlinkBreak (ASC_KEY_ID / ASC_ISSUER_ID / ASC_API_KEY_CONTENT) since same team (F2HXQGU2CC).
 6. **Local dev unchanged:** unsigned debug build still works for fast iteration.

--- a/worker_flutter/README.md
+++ b/worker_flutter/README.md
@@ -14,7 +14,7 @@ collections — see `../docs/superpowers/specs/2026-05-11-flutter-worker-archite
 MVP working on macOS (May 2026). The app:
 - Builds, launches, stays alive
 - On first launch, automatically downloads + extracts the JRE and Forge
-  into `~/Library/Application Support/com.tytaniumdev.workerFlutter/`
+  into `~/Library/Application Support/com.tytaniumdev.magicBracketSimulator/`
   (~540 MB one-time, ~40 seconds on broadband)
 - Runs the worker engine in the background (Firestore listener, atomic
   claim transaction, lease writer, Java sim spawner)
@@ -109,7 +109,7 @@ The Flutter worker depends on the lease-sweep infrastructure from PR #188:
   the existing `POST /api/jobs/:id/logs/simulation` endpoint is a small
   follow-up so frontend dashboards can show full game logs.
 - **Diagnostic log file**: the app writes to
-  `~/Library/Logs/com.tytaniumdev.workerFlutter.log` on every launch.
+  `~/Library/Logs/com.tytaniumdev.magicBracketSimulator.log` on every launch.
   Useful for debugging boot issues; safe to delete.
 
 ## Verification done

--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -246,7 +246,7 @@ Future<void> _initFileLogger() async {
   final home = Platform.environment['HOME'] ?? '';
   final logsDir = Directory('$home/Library/Logs');
   if (!logsDir.existsSync()) logsDir.createSync(recursive: true);
-  _logFile = File('${logsDir.path}/com.tytaniumdev.workerFlutter.log');
+  _logFile = File('${logsDir.path}/com.tytaniumdev.magicBracketSimulator.log');
   _logFile!.writeAsStringSync(
     '\n=== ${DateTime.now().toIso8601String()} app launched ===\n',
     mode: FileMode.append,

--- a/worker_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/worker_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -483,7 +483,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.workerFlutter.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.magicBracketSimulator.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/worker_flutter.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/worker_flutter";
@@ -498,7 +498,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.workerFlutter.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.magicBracketSimulator.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/worker_flutter.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/worker_flutter";
@@ -513,7 +513,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.workerFlutter.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.magicBracketSimulator.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/worker_flutter.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/worker_flutter";
@@ -576,14 +576,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = F2HXQGU2CC;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.magicBracketSimulator;
+				PROVISIONING_PROFILE_SPECIFIER = "match Direct com.tytaniumdev.magicBracketSimulator macos";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Profile;
@@ -708,14 +711,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = F2HXQGU2CC;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.magicBracketSimulator;
+				PROVISIONING_PROFILE_SPECIFIER = "match Direct com.tytaniumdev.magicBracketSimulator macos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -728,14 +734,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = F2HXQGU2CC;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.magicBracketSimulator;
+				PROVISIONING_PROFILE_SPECIFIER = "match Direct com.tytaniumdev.magicBracketSimulator macos";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/worker_flutter/macos/Runner/Configs/AppInfo.xcconfig
+++ b/worker_flutter/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = worker_flutter
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.workerFlutter
+PRODUCT_BUNDLE_IDENTIFIER = com.tytaniumdev.magicBracketSimulator
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 com.tytaniumdev. All rights reserved.

--- a/worker_flutter/macos/Runner/Configs/Release.xcconfig
+++ b/worker_flutter/macos/Runner/Configs/Release.xcconfig
@@ -1,2 +1,12 @@
 #include "../../Flutter/Flutter-Release.xcconfig"
 #include "Warnings.xcconfig"
+
+// Required by Apple's notarization service.
+//   - ENABLE_HARDENED_RUNTIME=YES: opts into Apple's hardened runtime. The
+//     specific entitlement allowances we need (JIT, unsigned executable memory,
+//     library validation disable) live in Runner/Release.entitlements.
+//   - OTHER_CODE_SIGN_FLAGS=--timestamp: makes codesign embed an RFC3161
+//     timestamp from Apple's timestamping server. Notarization rejects builds
+//     without it.
+ENABLE_HARDENED_RUNTIME = YES
+OTHER_CODE_SIGN_FLAGS = --timestamp

--- a/worker_flutter/macos/fastlane/Appfile
+++ b/worker_flutter/macos/fastlane/Appfile
@@ -1,2 +1,2 @@
-app_identifier("com.tytaniumdev.workerFlutter")
+app_identifier("com.tytaniumdev.magicBracketSimulator")
 team_id("F2HXQGU2CC")

--- a/worker_flutter/macos/fastlane/Fastfile
+++ b/worker_flutter/macos/fastlane/Fastfile
@@ -21,7 +21,7 @@
 
 default_platform(:mac)
 
-APP_IDENTIFIER = "com.tytaniumdev.workerFlutter".freeze
+APP_IDENTIFIER = "com.tytaniumdev.magicBracketSimulator".freeze
 TEAM_ID        = "F2HXQGU2CC".freeze
 XCODEPROJ      = "Runner.xcodeproj".freeze
 SCHEME         = "Runner".freeze
@@ -87,7 +87,7 @@ platform :mac do
       targets:               ["Runner"],
       team_id:               TEAM_ID,
       code_sign_identity:    "Developer ID Application",
-      profile_name:          "match Direct #{APP_IDENTIFIER}",
+      profile_name:          "match Direct #{APP_IDENTIFIER} macos",
       bundle_identifier:     APP_IDENTIFIER
     )
 
@@ -108,8 +108,14 @@ platform :mac do
     )
 
     # Zip for distribution. The stapled .app inside the zip is what users
-    # download.
-    sh("cd ../build/macos/Build/Products/Release && zip -ry " \
-       "../../../../worker_flutter-macos.zip worker_flutter.app")
+    # download. Use absolute paths so fastlane's `sh` working-directory
+    # quirks don't bite.
+    flutter_root = File.expand_path('../..', __dir__)
+    release_dir = File.join(flutter_root, 'build/macos/Build/Products/Release')
+    zip_path = File.join(flutter_root, 'build/worker_flutter-macos.zip')
+    FileUtils.rm_f(zip_path)
+    Dir.chdir(release_dir) do
+      sh("zip -ry #{zip_path.shellescape} worker_flutter.app")
+    end
   end
 end

--- a/worker_flutter/macos/fastlane/Matchfile
+++ b/worker_flutter/macos/fastlane/Matchfile
@@ -1,5 +1,5 @@
 git_url("git@github.com:TytaniumDev/TytaniumDev-certificates.git")
 storage_mode("git")
 type("developer_id")
-app_identifier(["com.tytaniumdev.workerFlutter"])
+app_identifier(["com.tytaniumdev.magicBracketSimulator"])
 team_id("F2HXQGU2CC")

--- a/worker_flutter/macos/fastlane/README.md
+++ b/worker_flutter/macos/fastlane/README.md
@@ -1,80 +1,48 @@
-# macOS code signing + notarization
+fastlane documentation
+----
 
-Fastlane match + notarytool pipeline for distributing the Magic Bracket
-worker as a signed, notarized `.app` outside the Mac App Store.
+# Installation
 
-The certs live alongside BlinkBreak's (same Apple team `F2HXQGU2CC`)
-in the private repo `TytaniumDev/TytaniumDev-certificates` — which is
-the renamed `BlinkBreak-certificates` repo, generalized for all of
-this team's signing assets.
+Make sure you have the latest version of the Xcode command line tools installed:
 
-## One-time setup (manual)
-
-Before the CI workflow can succeed:
-
-- The cert storage repo must be renamed from `BlinkBreak-certificates`
-  → `TytaniumDev-certificates` in GitHub (Settings → Repository name).
-  GitHub auto-redirects the old name to the new one, so BlinkBreak's
-  existing pipeline continues to work without changes; updating its
-  Matchfile/Fastfile to the new name is a follow-up cleanup.
-- A "Developer ID Application" cert must exist for team `F2HXQGU2CC`.
-  As of 2026-05-12 the repo only has the iOS App Store cert.
-
-1. **Create the cert in the Apple Developer portal** (or let match create
-   it on first run — it will try). Required: a "Developer ID Application"
-   cert for team `F2HXQGU2CC`. If you let match create it, your dev
-   account needs the "Account Holder" or "Admin" role.
-
-2. **Seed the cert into the certs repo locally:**
-
-   ```bash
-   cd worker_flutter/macos
-   bundle install
-   export MATCH_PASSWORD=...           # AES key for the certs repo
-   export ASC_KEY_ID=...               # App Store Connect API key ID
-   export ASC_ISSUER_ID=...
-   export ASC_API_KEY_CONTENT=...      # contents of AuthKey_*.p8
-   export ASC_API_KEY_IS_BASE64=false  # or "true" if base64-encoded
-   bundle exec fastlane seed_certs
-   ```
-
-   This pushes a `developer_id/` directory into the certs repo. After it
-   succeeds, the cert is available to CI and other developers.
-
-3. **Add GitHub Actions secrets** to this repo (Settings → Secrets and
-   variables → Actions):
-
-   | Secret | Source |
-   |---|---|
-   | `MATCH_PASSWORD` | Same value as the local `MATCH_PASSWORD` above. |
-   | `MATCH_KEYCHAIN_PASSWORD` | Any random string; CI uses it for the ephemeral keychain. |
-   | `ASC_KEY_ID` | App Store Connect → Users and Access → Keys. |
-   | `ASC_ISSUER_ID` | Same page. |
-   | `ASC_API_KEY_CONTENT` | Contents of the `AuthKey_<ID>.p8` file (raw text or base64). |
-   | `ASC_API_KEY_IS_BASE64` | `"true"` if you base64-encoded the previous; else omit. |
-   | `CERTS_REPO_DEPLOY_KEY` | Private half of an SSH deploy key. Add the public half to `TytaniumDev-certificates` repo settings → Deploy keys, read-only. |
-
-## Releasing
-
-Tag a release commit with `worker-v*` and push:
-
-```bash
-git tag worker-v0.1.0
-git push origin worker-v0.1.0
+```sh
+xcode-select --install
 ```
 
-The `release-worker-macos.yml` workflow signs, notarizes, and attaches
-the zipped `.app` to the GitHub release.
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
 
-## Local signed build (smoke test)
+# Available Actions
 
-```bash
-cd worker_flutter/macos
-# Same env vars as the "seed_certs" step above.
-bundle exec fastlane release
-open ../build/macos/Build/Products/Release/worker_flutter.app
+## Mac
+
+### mac seed_certs
+
+```sh
+[bundle exec] fastlane mac seed_certs
 ```
 
-If macOS refuses to open it ("damaged", "unidentified developer"), the
-signing step didn't apply or notarization isn't stapled. Run with
-`FASTLANE_VERBOSE=1 bundle exec fastlane release` to see the full log.
+Seed the match certs repo with a Developer ID Application cert + profile (run once locally)
+
+### mac sync_certs
+
+```sh
+[bundle exec] fastlane mac sync_certs
+```
+
+Install signing assets from match (read-only)
+
+### mac release
+
+```sh
+[bundle exec] fastlane mac release
+```
+
+Build, sign, and notarize the macOS Flutter app for outside-MAS distribution
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/worker_flutter/macos/fastlane/SETUP.md
+++ b/worker_flutter/macos/fastlane/SETUP.md
@@ -1,0 +1,73 @@
+# macOS code signing + notarization setup
+
+Fastlane match + notarytool pipeline for distributing the Magic Bracket
+worker as a signed, notarized `.app` outside the Mac App Store.
+
+The certs live alongside BlinkBreak's (same Apple team `F2HXQGU2CC`) in
+the private repo `TytaniumDev/TytaniumDev-certificates`.
+
+> **Note:** Fastlane regenerates `README.md` in this directory on every run.
+> Read this `SETUP.md` instead — it survives.
+
+## Secrets
+
+All secrets live in **Doppler**, project `blinkbreak`, config `prd`.
+Both BlinkBreak's iOS pipeline and this macOS pipeline read from the same
+config. The only GitHub Actions secret the workflow needs is
+`DOPPLER_TOKEN` — everything else is pulled at runtime via
+`doppler secrets download`.
+
+Required Doppler keys (already populated for BlinkBreak; this pipeline
+reuses them):
+
+| Key | What it is |
+|---|---|
+| `MATCH_PASSWORD` | AES key for the certs repo. |
+| `MATCH_KEYCHAIN_PASSWORD` | Password for the ephemeral CI keychain. |
+| `MATCH_SSH_PRIVATE_KEY` | Private half of the SSH deploy key for the certs repo (must be added as a read-only deploy key on `TytaniumDev/TytaniumDev-certificates`). |
+| `ASC_KEY_ID` | App Store Connect API key ID. |
+| `ASC_ISSUER_ID` | Same page in App Store Connect. |
+| `ASC_API_KEY_CONTENT` | Contents of the `AuthKey_<ID>.p8` file (raw or base64). |
+| `ASC_API_KEY_IS_BASE64` | `"true"` if the previous is base64-encoded. |
+
+## Running locally
+
+```bash
+cd worker_flutter/macos
+bundle install
+doppler run --project blinkbreak --config prd -- bundle exec fastlane release
+```
+
+`release` does: `sync_certs` → flutter macos release build → codesign →
+notarize (waits on Apple ~1–3 min) → staple → zip. Output ends up at
+`worker_flutter/build/worker_flutter-macos.zip`.
+
+## Releasing via CI
+
+Tag a release commit with `worker-v*` and push:
+
+```bash
+git tag worker-v0.1.0
+git push origin worker-v0.1.0
+```
+
+The `release-worker-macos.yml` workflow signs, notarizes, and attaches
+the zipped `.app` to the matching GitHub Release.
+
+## Seed-certs (one-time, already done as of 2026-05-12)
+
+The Developer ID Application cert + provisioning profile for
+`com.tytaniumdev.magicBracketSimulator` have already been seeded into
+the certs repo (commits visible in `TytaniumDev/TytaniumDev-certificates`
+under `certs/developer_id/` and `profiles/developer_id/`). If you ever
+need to re-seed (e.g. after cert revocation), the steps are documented
+in the Fastfile header.
+
+## Known issue: fastlane G2 cert preference
+
+Fastlane 2.234.0 defaults to creating `DEVELOPER_ID_APPLICATION_G2` certs,
+which Apple's API rejects unless your team is enrolled in the G2 program.
+The Fastfile is paired with a small `RUBYOPT=-r/path/to/patch.rb`
+workaround in the original cert-seeding session that reverses fastlane's
+type preference. Day-to-day runs of `release` (which uses the existing
+cert in the repo) don't need the patch.


### PR DESCRIPTION
## Summary

- Renames the Flutter worker's bundle ID from `com.tytaniumdev.workerFlutter` → `com.tytaniumdev.magicBracketSimulator` (more descriptive).
- Migrates `release-worker-macos.yml` to BlinkBreak's Doppler pattern — only `DOPPLER_TOKEN` is a GitHub Actions secret.
- Enables hardened runtime + timestamped signature in `Release.xcconfig` so notarization succeeds.
- Fixes two Fastfile bugs discovered during the local smoke test (profile-name suffix, final-zip relative path).

## Smoke-tested locally (✅)

Ran `doppler run --project blinkbreak --config prd -- bundle exec fastlane release`:
- Build: 105.8 MB `.app`
- Notarize: stapled successfully (~48s round trip with Apple)
- Codesign verify: `valid on disk` + `satisfies its Designated Requirement`
- `xcrun stapler validate`: `The validate action worked!`
- Final artifact: 35 MB zip

## Apple Developer portal side (done out-of-band)

- New bundle ID `com.tytaniumdev.magicBracketSimulator` registered (Spaceship API)
- New Developer ID Application provisioning profile (`match Direct com.tytaniumdev.magicBracketSimulator macos`) created and seeded into the renamed `TytaniumDev-certificates` repo

## Firebase config

`GoogleService-Info.plist` and `firebase_options.dart` still reference the old bundle ID. Firebase Console doesn't allow renaming an app's bundle ID; we'd need to register a new Firebase app and run `flutterfire configure`. Deferred to the Plan 3 Google Sign-In work since auth is the only thing that strictly enforces the bundle ID match — Firestore writes work fine with the mismatch.

## Test plan

- [x] `flutter analyze` (clean before push)
- [x] `flutter test` 18/18 pass (no Dart changes affecting tests)
- [x] Local `fastlane release` end-to-end
- [ ] After merge: tag `worker-v0.1.0`, push, verify CI produces a notarized GitHub Release asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)