### PR TITLE
feat(worker): manifest-driven Forge updates + Sparkle app self-updater

### DIFF
--- a/.github/workflows/release-worker-macos.yml
+++ b/.github/workflows/release-worker-macos.yml
@@ -39,8 +39,11 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_BLINKBREAK_TOKEN }}
         run: |
           DELIM=$(openssl rand -hex 16)
-          # Token is already scoped to blinkbreak/prd; no need to pass them.
-          SECRETS=$(doppler secrets download --no-file --format json)
+          # Service token is scoped to blinkbreak/prd, but still pass the
+          # flags explicitly — without them, the CLI tries to use a local
+          # Doppler config that doesn't exist on a fresh runner and the
+          # request 401s as "Invalid Auth token".
+          SECRETS=$(doppler secrets download --project blinkbreak --config prd --no-file --format json)
           KEYS='[
             "MATCH_PASSWORD",
             "MATCH_SSH_PRIVATE_KEY",

--- a/worker_flutter/appcast.xml
+++ b/worker_flutter/appcast.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Sparkle appcast for Magic Bracket Simulator desktop worker.
+
+  Fetched at runtime from this file on `main`:
+    https://raw.githubusercontent.com/TytaniumDev/MagicBracketSimulator/main/worker_flutter/appcast.xml
+
+  Each release adds an <item> below the most recent. Sparkle picks the
+  highest sparkle:version and offers it as the update.
+
+  Release flow (manual for now):
+    1. Tag a new `worker-v*` commit. CI signs + notarizes + attaches the
+       zip to the GitHub Release.
+    2. Note the zip's `length` (bytes) from the release asset.
+    3. Add a new <item> block above the v0.1.0 entry with:
+         - sparkle:version       = build number, monotonic (e.g. 2, 3, ...)
+         - sparkle:shortVersionString = display version (e.g. "0.2.0")
+         - enclosure url         = GitHub Release download URL
+         - enclosure length      = byte size
+         - pubDate               = RFC 822 date
+    4. Commit + push to `main`. Existing installs notice within ~1 hour.
+
+  Automating this in CI is in the TODO list — see
+  worker_flutter/macos/fastlane/SETUP.md.
+-->
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Magic Bracket Simulator</title>
+    <description>Desktop worker for the Magic Bracket Simulator project.</description>
+    <language>en</language>
+
+    <item>
+      <title>Version 0.1.0</title>
+      <pubDate>Wed, 13 May 2026 06:37:00 -0700</pubDate>
+      <sparkle:version>1</sparkle:version>
+      <sparkle:shortVersionString>0.1.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.1.0/worker_flutter-macos.zip"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>

--- a/worker_flutter/forge-manifest.json
+++ b/worker_flutter/forge-manifest.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0.10",
+  "url": "https://github.com/Card-Forge/forge/releases/download/forge-2.0.10/forge-installer-2.0.10.tar.bz2",
+  "sha256": "4d44183d2438877bf2c3879e69f2ec0922b41f346bfd168bf71e9c61e3164066",
+  "size": 286557618,
+  "jarName": "forge-gui-desktop-2.0.10-jar-with-dependencies.jar"
+}

--- a/worker_flutter/lib/installer/forge_manifest.dart
+++ b/worker_flutter/lib/installer/forge_manifest.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Snapshot of the canonical Forge release we want the worker to use.
+///
+/// Hosted as `worker_flutter/forge-manifest.json` in the repo, fetched
+/// via raw.githubusercontent.com at boot. Updating the file on `main`
+/// is what triggers existing installs to pull a new Forge version —
+/// no .app release required. SHA-256 keeps content honest even if the
+/// raw URL is MITM'd.
+class ForgeManifest {
+  ForgeManifest({
+    required this.version,
+    required this.url,
+    required this.sha256,
+    required this.size,
+    required this.jarName,
+  });
+
+  final String version;
+  final String url;
+  final String sha256;
+  final int size;
+  final String jarName;
+
+  factory ForgeManifest.fromJson(Map<String, dynamic> json) => ForgeManifest(
+    version: json['version'] as String,
+    url: json['url'] as String,
+    sha256: json['sha256'] as String,
+    size: (json['size'] as num).toInt(),
+    jarName: json['jarName'] as String,
+  );
+}
+
+/// Default location of the manifest. Pinned to `main` so existing installs
+/// always read the latest authoritative version.
+const _kDefaultManifestUrl =
+    'https://raw.githubusercontent.com/TytaniumDev/MagicBracketSimulator/main/worker_flutter/forge-manifest.json';
+
+class ForgeManifestClient {
+  ForgeManifestClient({http.Client? client, this.url = _kDefaultManifestUrl})
+    : _client = client ?? http.Client();
+
+  final http.Client _client;
+  final String url;
+
+  /// Fetch the manifest. Returns `null` on any failure (network down,
+  /// malformed JSON, etc.) so the caller can fall back to whatever
+  /// version is already installed.
+  Future<ForgeManifest?> fetch({
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    try {
+      final resp = await _client.get(Uri.parse(url)).timeout(timeout);
+      if (resp.statusCode != 200) return null;
+      final json = jsonDecode(resp.body) as Map<String, dynamic>;
+      return ForgeManifest.fromJson(json);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void close() => _client.close();
+}

--- a/worker_flutter/lib/installer/installer.dart
+++ b/worker_flutter/lib/installer/installer.dart
@@ -1,35 +1,37 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 
-/// One-time installer that downloads the JRE and Forge into the app's
-/// support directory on first launch. After this the worker can run real
-/// simulations without the user installing anything by hand.
+import 'forge_manifest.dart';
+
+/// First-launch installer for the JRE + Forge bundle.
 ///
-/// Why first-launch instead of bundled inside the .app:
-///   - .app ships at ~50MB (just Flutter + plugins) instead of ~500MB
-///   - JRE and Forge are easily re-downloadable if something corrupts
-///   - Forge data updates can be handled independently of app releases
+/// Forge versioning is now manifest-driven:
+///   - `worker_flutter/forge-manifest.json` is the source of truth.
+///   - On every boot the worker fetches the manifest from
+///     raw.githubusercontent.com (pinned to `main`).
+///   - If the manifest's version doesn't match what's installed on disk,
+///     the installer re-downloads + extracts + verifies SHA-256 +
+///     removes old `forge-gui-desktop-*.jar` files. This lets a Forge
+///     bump ship without a .app release: bump the JSON on `main` and
+///     every running install picks it up on its next launch.
 ///
-/// Trade-off: requires network on first launch. Subsequent launches use
-/// the local install. The installer is idempotent — re-running it with
-/// existing files is a no-op.
+/// JRE versioning is still pinned to Adoptium's "latest" Java 17.
+/// Existing installs are not bumped to newer JREs — we only fetch if
+/// the bundled JRE binary is missing. Adoptium's JRE is generally
+/// API-stable within a feature release, so this is intentional.
 class Installer {
-  Installer({http.Client? client}) : _client = client ?? http.Client();
+  Installer({http.Client? client, ForgeManifestClient? manifestClient})
+    : _client = client ?? http.Client(),
+      _manifestClient = manifestClient ?? ForgeManifestClient();
 
   final http.Client _client;
+  final ForgeManifestClient _manifestClient;
 
-  // Pinned versions. Bump these as needed.
-  static const forgeVersion = '2.0.10';
   static const _jreVersionFeature = 17;
-
-  /// Filename of the Forge JAR inside `forgePath`. Public so `SimRunner`
-  /// resolves the same filename the installer downloads — keeps the two
-  /// in lockstep when the version is bumped.
-  static const forgeJarName =
-      'forge-gui-desktop-$forgeVersion-jar-with-dependencies.jar';
 
   /// Hard cap on redirect follows. Adoptium typically issues one 3xx
   /// (to a CDN); we allow up to 5 to handle geo-routing chains, then bail.
@@ -39,6 +41,10 @@ class Installer {
   final _progress = StreamController<InstallProgress>.broadcast();
   Stream<InstallProgress> get progressStream => _progress.stream;
 
+  /// Cached after first successful fetch. Used by [installedJarName] so
+  /// callers (SimRunner) don't have to fetch again.
+  ForgeManifest? _lastManifest;
+
   Future<String> _supportDir() async {
     final dir = await getApplicationSupportDirectory();
     if (!dir.existsSync()) dir.createSync(recursive: true);
@@ -47,21 +53,37 @@ class Installer {
 
   Future<String> jrePath() async => '${await _supportDir()}/jre';
   Future<String> forgePath() async => '${await _supportDir()}/forge';
-  Future<String> javaBinary() async => '${await jrePath()}/Contents/Home/bin/java';
+  Future<String> javaBinary() async =>
+      '${await jrePath()}/Contents/Home/bin/java';
 
-  /// True iff both JRE and Forge are installed and look valid.
+  /// True iff:
+  /// - the JRE binary is present, and
+  /// - either we couldn't reach the manifest (so we trust whatever JAR
+  ///   is on disk), or the on-disk JAR matches the manifest's version.
+  ///
+  /// The "manifest unreachable" fallback keeps the worker bootable
+  /// offline; the user gets the previously-installed Forge.
   Future<bool> isReady() async {
     final java = await javaBinary();
-    final forgeJar = '${await forgePath()}/$forgeJarName';
-    return File(java).existsSync() && File(forgeJar).existsSync();
+    if (!File(java).existsSync()) return false;
+
+    final manifest = await _manifestClient.fetch();
+    _lastManifest = manifest;
+    final forge = await forgePath();
+
+    if (manifest == null) {
+      // Offline: accept whatever Forge JAR is present.
+      return _findAnyForgeJar(forge) != null;
+    }
+    final wantedJar = File('$forge/${manifest.jarName}');
+    return wantedJar.existsSync();
   }
 
-  /// Install whatever is missing. Idempotent.
+  /// Install whatever is missing or out of date.
   Future<void> install() async {
     final jre = await jrePath();
-    final forge = await forgePath();
     final java = await javaBinary();
-    final forgeJar = '$forge/$forgeJarName';
+    final forge = await forgePath();
 
     if (!File(java).existsSync()) {
       _emit('jre', 'Downloading Java runtime', 0);
@@ -71,15 +93,50 @@ class Installer {
       _emit('jre', 'Java already installed', 1);
     }
 
-    if (!File(forgeJar).existsSync()) {
-      _emit('forge', 'Downloading Forge $forgeVersion (~270 MB)', 0);
-      await _installForge(forge);
-      _emit('forge', 'Forge ready', 1);
+    final manifest = _lastManifest ?? await _manifestClient.fetch();
+    _lastManifest = manifest;
+
+    if (manifest == null) {
+      // Offline: keep whatever is installed; surface in UI.
+      _emit('forge', 'Forge manifest unreachable — using local install', 1);
     } else {
-      _emit('forge', 'Forge already installed', 1);
+      final wantedJar = File('$forge/${manifest.jarName}');
+      if (wantedJar.existsSync()) {
+        _emit('forge', 'Forge ${manifest.version} already installed', 1);
+      } else {
+        final sizeMb = (manifest.size / (1024 * 1024)).toStringAsFixed(0);
+        _emit(
+          'forge',
+          'Downloading Forge ${manifest.version} (~$sizeMb MB)',
+          0,
+        );
+        await _installForge(forge, manifest);
+        _emit('forge', 'Forge ${manifest.version} ready', 1);
+      }
     }
 
     _emit('done', 'All set', 1);
+  }
+
+  /// Resolved Forge JAR filename. Reflects whatever the most recent
+  /// [isReady]/[install] call established. Returns null if neither has
+  /// run yet AND no JAR exists on disk.
+  Future<String?> installedJarName() async {
+    if (_lastManifest != null) return _lastManifest!.jarName;
+    return _findAnyForgeJar(await forgePath());
+  }
+
+  String? _findAnyForgeJar(String forgeDir) {
+    final dir = Directory(forgeDir);
+    if (!dir.existsSync()) return null;
+    for (final entry in dir.listSync()) {
+      final name = entry.path.split(Platform.pathSeparator).last;
+      if (name.startsWith('forge-gui-desktop-') &&
+          name.endsWith('-jar-with-dependencies.jar')) {
+        return name;
+      }
+    }
+    return null;
   }
 
   Future<void> _installJre(String destDir) async {
@@ -94,10 +151,13 @@ class Installer {
     //   <name>/Contents/Home/bin/java
     // Extract into destDir, stripping the top-level archive folder.
     Directory(destDir).createSync(recursive: true);
-    final res = await Process.run(
-      'tar',
-      ['-xzf', tmpFile.path, '-C', destDir, '--strip-components=1'],
-    );
+    final res = await Process.run('tar', [
+      '-xzf',
+      tmpFile.path,
+      '-C',
+      destDir,
+      '--strip-components=1',
+    ]);
     if (res.exitCode != 0) {
       throw Exception('tar (jre) failed: ${res.stderr}');
     }
@@ -106,24 +166,57 @@ class Installer {
     await Process.run('chmod', ['-R', '+x', '$destDir/Contents/Home/bin']);
   }
 
-  Future<void> _installForge(String destDir) async {
-    final url = Uri.parse(
-      'https://github.com/Card-Forge/forge/releases/download/forge-$forgeVersion/forge-installer-$forgeVersion.tar.bz2',
-    );
+  Future<void> _installForge(String destDir, ForgeManifest manifest) async {
     final tmpFile = File('${await _supportDir()}/forge-download.tar.bz2');
-    await _downloadWithProgress(url, tmpFile, label: 'forge');
-
-    Directory(destDir).createSync(recursive: true);
-    _emit('forge', 'Extracting Forge', 0);
-    final res = await Process.run(
-      'tar',
-      ['-xjf', tmpFile.path, '-C', destDir],
+    await _downloadWithProgress(
+      Uri.parse(manifest.url),
+      tmpFile,
+      label: 'forge',
     );
+
+    // Verify SHA-256 before trusting the bytes. A mismatched hash means
+    // either a corrupted download or a tampered redirect target — either
+    // way, do not extract.
+    _emit('forge', 'Verifying download', 0.95);
+    final actual = await _sha256OfFile(tmpFile);
+    if (actual.toLowerCase() != manifest.sha256.toLowerCase()) {
+      tmpFile.deleteSync();
+      throw Exception(
+        'Forge download SHA-256 mismatch: expected ${manifest.sha256}, got $actual',
+      );
+    }
+
+    // Clean up any older forge-gui-desktop JARs so we don't leak ~270 MB
+    // per bump. Other Forge resources (decks, images, configs) are kept.
+    final dir = Directory(destDir);
+    if (dir.existsSync()) {
+      for (final entry in dir.listSync()) {
+        final name = entry.path.split(Platform.pathSeparator).last;
+        if (name.startsWith('forge-gui-desktop-') &&
+            name.endsWith('-jar-with-dependencies.jar') &&
+            name != manifest.jarName) {
+          try {
+            File(entry.path).deleteSync();
+          } catch (_) {
+            /* best effort */
+          }
+        }
+      }
+    }
+
+    dir.createSync(recursive: true);
+    _emit('forge', 'Extracting Forge ${manifest.version}', 0);
+    final res = await Process.run('tar', ['-xjf', tmpFile.path, '-C', destDir]);
     if (res.exitCode != 0) {
       throw Exception('tar (forge) failed: ${res.stderr}');
     }
     tmpFile.deleteSync();
     await Process.run('chmod', ['+x', '$destDir/forge.sh']);
+  }
+
+  Future<String> _sha256OfFile(File f) async {
+    final digest = await sha256.bind(f.openRead()).first;
+    return digest.toString();
   }
 
   Future<void> _downloadWithProgress(
@@ -134,7 +227,9 @@ class Installer {
   }) async {
     final req = http.Request('GET', url);
     final resp = await _client.send(req);
-    if (resp.statusCode >= 300 && resp.statusCode < 400 && resp.headers['location'] != null) {
+    if (resp.statusCode >= 300 &&
+        resp.statusCode < 400 &&
+        resp.headers['location'] != null) {
       if (redirectsRemaining <= 0) {
         throw Exception('exceeded $_maxRedirects redirects downloading $url');
       }
@@ -167,12 +262,15 @@ class Installer {
   }
 
   void _emit(String stage, String message, double progress) {
-    _progress.add(InstallProgress(stage: stage, message: message, progress: progress));
+    _progress.add(
+      InstallProgress(stage: stage, message: message, progress: progress),
+    );
   }
 
   void dispose() {
     _progress.close();
     _client.close();
+    _manifestClient.close();
   }
 }
 

--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:auto_updater/auto_updater.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
@@ -88,6 +89,12 @@ Future<void> _appMain() async {
     await windowManager.setPreventClose(true);
   });
   _log('window ready, shown');
+
+  // Self-update: ask Sparkle (via auto_updater) to check the appcast in
+  // the repo. New `worker-v*` tags add an entry there; users running the
+  // old build see the update offer on next launch and again every hour
+  // while running. Non-fatal on failure (e.g. offline / appcast 404).
+  await _initAutoUpdater();
 
   // Persistent worker identity + paths.
   final config = await WorkerConfig.loadOrInit();
@@ -242,6 +249,37 @@ Future<void> _bootEngine(WorkerConfig config) async {
 // Tray-only apps have no stderr console visible to the user; we write
 // to ~/Library/Logs/ which is the standard macOS user log location.
 File? _logFile;
+
+/// Appcast URL — RSS feed Sparkle polls to discover new releases. Pinned
+/// to `main` so a tag push that updates the appcast hits existing
+/// installs without any extra deploy step.
+const _kAppcastUrl =
+    'https://raw.githubusercontent.com/TytaniumDev/MagicBracketSimulator/main/worker_flutter/appcast.xml';
+
+/// Check on launch + every hour while the app is open. Sparkle will
+/// surface a "new version available" dialog itself; we don't render UI.
+const _kAutoUpdateCheckIntervalSeconds = 3600;
+
+Future<void> _initAutoUpdater() async {
+  try {
+    await autoUpdater.setFeedURL(_kAppcastUrl);
+    await autoUpdater.setScheduledCheckInterval(
+      _kAutoUpdateCheckIntervalSeconds,
+    );
+    // Background check so the user doesn't see a "no update available" toast
+    // when nothing is new.
+    await autoUpdater.checkForUpdates(inBackground: true);
+    _log(
+      'AutoUpdater: feed=$_kAppcastUrl, interval=${_kAutoUpdateCheckIntervalSeconds}s',
+    );
+  } catch (e, st) {
+    // Sparkle init failure (e.g. missing SUPublicEDKey in some configs) is
+    // not fatal — the worker still runs, just without self-update. Log
+    // so we notice in the diagnostic file.
+    _log('AutoUpdater init failed (non-fatal): $e\n$st');
+  }
+}
+
 Future<void> _initFileLogger() async {
   final home = Platform.environment['HOME'] ?? '';
   final logsDir = Directory('$home/Library/Logs');

--- a/worker_flutter/lib/worker/sim_runner.dart
+++ b/worker_flutter/lib/worker/sim_runner.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import '../installer/installer.dart';
 import '../models/sim.dart';
 
 /// Spawns a Forge `sim` invocation as a child Java process and captures the
@@ -49,15 +48,19 @@ class SimRunner {
       );
     }
 
-    final forgeJar = '$forgePath/${Installer.forgeJarName}';
-    if (!File(forgeJar).existsSync()) {
+    // Resolve the JAR by globbing `forgePath`. The version isn't baked
+    // into the worker any more — it's manifest-driven via the installer,
+    // so a single Forge bump can ship without an .app release.
+    final forgeJar = _findForgeJar(forgePath);
+    if (forgeJar == null) {
       return SimResult(
         success: false,
         durationMs: 0,
         winners: const [],
         winningTurns: const [],
         logText: '',
-        errorMessage: 'Forge JAR not found at $forgeJar',
+        errorMessage:
+            'Forge JAR not found in $forgePath. Did the first-run installer complete?',
       );
     }
     if (javaPath != 'java' && !File(javaPath).existsSync()) {
@@ -102,17 +105,24 @@ class SimRunner {
     final logBuf = StringBuffer();
     // utf8.decoder buffers partial multi-byte chars across chunks so we don't
     // mangle non-ASCII output (e.g. card names with em-dashes or accents).
-    final stdoutSub = process.stdout.transform(utf8.decoder).listen(logBuf.write);
-    final stderrSub = process.stderr.transform(utf8.decoder).listen(logBuf.write);
+    final stdoutSub = process.stdout
+        .transform(utf8.decoder)
+        .listen(logBuf.write);
+    final stderrSub = process.stderr
+        .transform(utf8.decoder)
+        .listen(logBuf.write);
 
     var cancelled = false;
-    unawaited(cancelSignal?.then((_) {
-      cancelled = true;
-      process.kill(ProcessSignal.sigterm);
-      Future<void>.delayed(const Duration(seconds: 3), () {
-        process.kill(ProcessSignal.sigkill);
-      });
-    }) ?? Future<void>.value());
+    unawaited(
+      cancelSignal?.then((_) {
+            cancelled = true;
+            process.kill(ProcessSignal.sigterm);
+            Future<void>.delayed(const Duration(seconds: 3), () {
+              process.kill(ProcessSignal.sigkill);
+            });
+          }) ??
+          Future<void>.value(),
+    );
 
     final exitCode = await process.exitCode;
     await stdoutSub.cancel();
@@ -152,6 +162,22 @@ class SimRunner {
       errorMessage: parsed.winners.isEmpty ? 'no winner detected in log' : null,
     );
   }
+
+  /// Glob-style lookup for the installed Forge JAR. Mirrors the pattern
+  /// the installer writes (`forge-gui-desktop-<version>-jar-with-dependencies.jar`).
+  /// Returns null if no matching JAR is present.
+  String? _findForgeJar(String dir) {
+    final d = Directory(dir);
+    if (!d.existsSync()) return null;
+    for (final entry in d.listSync()) {
+      final name = entry.path.split(Platform.pathSeparator).last;
+      if (name.startsWith('forge-gui-desktop-') &&
+          name.endsWith('-jar-with-dependencies.jar')) {
+        return entry.path;
+      }
+    }
+    return null;
+  }
 }
 
 /// Pure log parser. Lives here (not in a separate file) since SimRunner is
@@ -177,7 +203,9 @@ ParsedGameLog parseGameLog(String logText) {
   final winners = <String>[];
   final winningTurns = <int>[];
 
-  final winnerRegex = RegExp(r'Game Result: Game (\d+) ended in \d+ ms\.\s*(.+?) has won!');
+  final winnerRegex = RegExp(
+    r'Game Result: Game (\d+) ended in \d+ ms\.\s*(.+?) has won!',
+  );
   final turnRegex = RegExp(r'Game outcome: Turn (\d+)');
 
   // For each "has won" line we walk back through the text to find the most

--- a/worker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/worker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import auto_updater_macos
 import cloud_firestore
 import firebase_auth
 import firebase_core
@@ -15,6 +16,7 @@ import tray_manager
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AutoUpdaterMacosPlugin.register(with: registry.registrar(forPlugin: "AutoUpdaterMacosPlugin"))
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))

--- a/worker_flutter/macos/Runner/Info.plist
+++ b/worker_flutter/macos/Runner/Info.plist
@@ -36,5 +36,37 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+
+	<!-- Sparkle (auto_updater) configuration.
+	     SUFeedURL points at the appcast in this repo on `main`. Updates
+	     are surfaced by Sparkle itself; the worker just calls
+	     checkForUpdates() at boot + every hour.
+
+	     SUEnableInstallerLauncherService=YES: required by Sparkle 2 when
+	     the host app has app-sandbox=NO (which is our case — see
+	     Release.entitlements).
+
+	     SUEnableAutomaticChecks=YES: lets Sparkle's scheduled-check
+	     timer run.
+
+	     ⚠️ SUEnableInstallerInteractionService is intentionally absent:
+	     not required for Developer-ID-signed apps. Sparkle verifies the
+	     downloaded .app's Developer ID matches the running app's. As
+	     long as v0.1.0's signing identity matches future versions',
+	     update install works.
+
+	     TODO before going live with auto-update: generate Ed25519
+	     signing keys (sign_update tool ships with Sparkle), embed the
+	     public key here as SUPublicEDKey, and have the release workflow
+	     sign each appcast entry. Until that lands, Sparkle's EdDSA
+	     verification falls back to Developer ID code-signing check,
+	     which works for our case but is weaker. See
+	     worker_flutter/macos/fastlane/SETUP.md. -->
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/TytaniumDev/MagicBracketSimulator/main/worker_flutter/appcast.xml</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
 </dict>
 </plist>

--- a/worker_flutter/macos/fastlane/SETUP.md
+++ b/worker_flutter/macos/fastlane/SETUP.md
@@ -63,6 +63,48 @@ under `certs/developer_id/` and `profiles/developer_id/`). If you ever
 need to re-seed (e.g. after cert revocation), the steps are documented
 in the Fastfile header.
 
+## Auto-update flow
+
+The worker has two independent update channels:
+
+1. **Forge updates** — manifest-driven, no .app release needed.
+   - Source of truth: `worker_flutter/forge-manifest.json`.
+   - Fetched at boot from raw.githubusercontent.com on `main`.
+   - To bump Forge: download the new tarball, compute its sha256,
+     update the manifest JSON, commit + push to `main`. Existing
+     installs pick it up on next launch — the installer cleans the
+     old jar, verifies the new sha256, extracts.
+
+2. **App updates** — Sparkle appcast at `worker_flutter/appcast.xml`.
+   - Fetched at boot (and every hour while running) from
+     raw.githubusercontent.com on `main`.
+   - To release a new app version:
+     1. Bump `version:` in `worker_flutter/pubspec.yaml` (e.g.
+        `0.1.0+1` → `0.2.0+2`). The `+N` is the monotonic build
+        number Sparkle uses internally.
+     2. Tag the commit (e.g. `worker-v0.2.0`) and push. CI signs,
+        notarizes, and attaches `worker_flutter-macos.zip` to the
+        GitHub Release.
+     3. Add a new `<item>` to `appcast.xml` matching the tag
+        (template in the file header). Commit + push to `main`.
+     4. Existing installs see the update within ~1 hour.
+
+### ⚠️ Pre-go-live TODO: EdDSA signing of appcast entries
+
+Sparkle 2 *can* fall back to Developer ID code-signing verification
+when `SUPublicEDKey` is absent, but the recommended setup is to also
+EdDSA-sign each appcast entry. To upgrade:
+
+1. Generate a key pair with Sparkle's `generate_keys` (ships in the
+   `auto_updater_macos` plugin's Sparkle bundle, or download
+   Sparkle's tools dist).
+2. Add the public key to `worker_flutter/macos/Runner/Info.plist`
+   under `SUPublicEDKey`.
+3. Store the private key in Doppler (`SPARKLE_ED_PRIVATE_KEY`).
+4. Add a CI step that runs `sign_update worker_flutter-macos.zip`
+   and writes the signature into the appcast item's
+   `sparkle:edSignature` attribute before pushing.
+
 ## Known issue: fastlane G2 cert preference
 
 Fastlane 2.234.0 defaults to creating `DEVELOPER_ID_APPLICATION_G2` certs,

--- a/worker_flutter/pubspec.lock
+++ b/worker_flutter/pubspec.lock
@@ -49,6 +49,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  auto_updater:
+    dependency: "direct main"
+    description:
+      name: auto_updater
+      sha256: "74fd008b021d15e4fc50fb5f1923870e6374ae831bb1168241c23bc35a4e898b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  auto_updater_macos:
+    dependency: transitive
+    description:
+      name: auto_updater_macos
+      sha256: ef9de0daf38d782d2243fe131503a9404d62df762f5386e5360020e43c01867f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  auto_updater_platform_interface:
+    dependency: transitive
+    description:
+      name: auto_updater_platform_interface
+      sha256: ed5dff8cea18c58bc5ac787ff9122fedd1644272e02015d28c9b592f8078c5dc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  auto_updater_windows:
+    dependency: transitive
+    description:
+      name: auto_updater_windows
+      sha256: "2bba20a71eee072f49b7267fedd5c4f1406c4b1b1e5b83932c634dbab75b80c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -194,7 +226,7 @@ packages:
     source: hosted
     version: "3.1.2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/worker_flutter/pubspec.yaml
+++ b/worker_flutter/pubspec.yaml
@@ -32,6 +32,12 @@ dependencies:
   # First-run installer downloads (JRE + Forge)
   http: ^1.2.2
 
+  # SHA-256 verification of downloaded Forge bundles before extract.
+  crypto: ^3.0.5
+
+  # macOS app self-update (Sparkle wrapper).
+  auto_updater: ^1.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary

Closes the auto-update half of Plan 3 — both Forge bumps and .app updates now reach existing installs without users manually downloading anything.

## Forge (decoupled from .app releases)

- New `worker_flutter/forge-manifest.json` is the source of truth (version + URL + sha256 + jar name).
- Installer fetches it at every boot, compares to the on-disk JAR, downloads + sha256-verifies + cleans old JARs + extracts if out of date.
- Offline-friendly: manifest fetch failure falls back to the local install.
- `sim_runner.dart` globs the forge dir for the JAR — no more hard-coded version.
- Fixes the ~270 MB-per-bump disk leak.

## App (Sparkle via `auto_updater`)

- `auto_updater` wired in `main.dart`. Check at boot + every hour.
- New `worker_flutter/appcast.xml` seeded with the v0.1.0 entry. Each future release appends one item (instructions in the file header).
- `Info.plist` gets `SUFeedURL`, `SUEnableAutomaticChecks`, `SUEnableInstallerLauncherService`.

## How to bump from here

- **Forge**: edit `forge-manifest.json`, push to `main`. Done.
- **App**: bump pubspec version, tag `worker-v*`, push. CI signs/notarizes. Then add an `<item>` to `appcast.xml`, push to `main`. Done.

## ⚠️ Pre-go-live TODO

Sparkle currently relies on Developer ID code-signing as the only verification (no EdDSA appcast signature). The recommended hardening — `sign_update` in CI + `SUPublicEDKey` in Info.plist — is documented in `worker_flutter/macos/fastlane/SETUP.md` under "Auto-update flow → ⚠️ Pre-go-live TODO".

For solo-dev this is fine; for distributing widely it should be done first.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` 18/18 pass
- [ ] Once merged: build a v0.2.0 with a small visible change, tag `worker-v0.2.0`, update appcast, confirm v0.1.0 installs see the offer within an hour
- [ ] Bump `forge-manifest.json` to a different Forge version, confirm an existing install re-downloads + cleans up old jar on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)