### PR TITLE
fix(rules): allow collectionGroup('simulations') reads

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -107,6 +107,19 @@ service cloud.firestore {
       allow delete: if isAllowedUser();
     }
 
+    // Allow `collectionGroup('simulations')` reads for the Flutter worker.
+    // Firestore looks up rules by the top-level path for collection-group
+    // queries, so the nested `match /jobs/{jobId}/simulations/{simId}`
+    // rule above doesn't apply to listener queries. Without this match,
+    // the Flutter worker's `where state == PENDING` listener silently
+    // returns empty and never picks up jobs.
+    //
+    // Reads only — actual write paths still flow through the nested
+    // rule's stricter state-transition checks.
+    match /{path=**}/simulations/{simId} {
+      allow read: if true;
+    }
+
     // Catch-all: deny everything else not explicitly matched
     match /{document=**} {
       allow read, write: if false;


### PR DESCRIPTION
## Summary

Firestore evaluates collection-group queries against rules attached to the top-level path, not nested matches. Our nested `match /jobs/{jobId}/simulations/{simId}` rule didn't apply to the Flutter worker's listener (`firestore.collectionGroup('simulations').where('state', '==', 'PENDING').snapshots()`), so it returned empty and the worker sat idle even with new jobs queued.

Adding `match /{path=**}/simulations/{simId}` with `allow read: if true` opts collectionGroup queries in (matches the public-read intent already on the nested rule). Writes still flow through the nested rule's stricter state-transition checks.

## Test plan

- [x] Workspace `flutter analyze` clean
- [ ] After deploy: Flutter worker picks up queued PENDING sims within seconds of launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)