### PR TITLE
feat(offline): real local-mode UI — deck picker, runner, history, results

### DIFF
--- a/worker_flutter/lib/launch/mode_picker_screen.dart
+++ b/worker_flutter/lib/launch/mode_picker_screen.dart
@@ -147,17 +147,20 @@ class _ModeCard extends StatelessWidget {
       borderRadius: BorderRadius.circular(12),
       onTap: onTap,
       child: Container(
-        padding: const EdgeInsets.all(20),
+        padding: const EdgeInsets.fromLTRB(18, 16, 18, 14),
         decoration: BoxDecoration(
           color: const Color(0xFF111827),
           borderRadius: BorderRadius.circular(12),
           border: Border.all(color: const Color(0xFF374151)),
         ),
+        // mainAxisSize.max + Flexible on the bullet list means the card
+        // grows to fill the Row's height but the bullets shrink (with
+        // ellipsis) if the parent ever clips us.
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(icon, color: const Color(0xFF60A5FA), size: 36),
-            const SizedBox(height: 12),
+            Icon(icon, color: const Color(0xFF60A5FA), size: 32),
+            const SizedBox(height: 10),
             Text(
               title,
               style: const TextStyle(
@@ -166,28 +169,38 @@ class _ModeCard extends StatelessWidget {
                 fontWeight: FontWeight.w700,
               ),
             ),
-            const SizedBox(height: 12),
-            ...bullets.map(
-              (b) => Padding(
-                padding: const EdgeInsets.only(bottom: 6),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Text('• ', style: TextStyle(color: Colors.white54)),
-                    Expanded(
-                      child: Text(
-                        b,
-                        style: const TextStyle(
-                          color: Colors.white70,
-                          fontSize: 13,
-                        ),
+            const SizedBox(height: 10),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                padding: EdgeInsets.zero,
+                children: [
+                  for (final b in bullets)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 6),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            '• ',
+                            style: TextStyle(color: Colors.white54),
+                          ),
+                          Expanded(
+                            child: Text(
+                              b,
+                              style: const TextStyle(
+                                color: Colors.white70,
+                                fontSize: 13,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                  ],
-                ),
+                ],
               ),
             ),
-            const Spacer(),
+            const SizedBox(height: 8),
             SizedBox(
               width: double.infinity,
               child: FilledButton(onPressed: onTap, child: Text(cta)),

--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -183,10 +183,11 @@ Future<void> _bootMode(WorkerConfig config, LaunchMode mode) async {
 }
 
 Future<void> _bootOffline(WorkerConfig config) async {
-  _log('Boot offline: runApp placeholder');
+  _log('Boot offline: launching local-only deck picker + sim runner');
   await windowManager.show();
   runApp(
     OfflineApp(
+      config: config,
       onSwitchMode: () async {
         // Clear the remembered choice (already done by the button) and
         // re-route. The picker will show again.

--- a/worker_flutter/lib/offline/db/app_db.dart
+++ b/worker_flutter/lib/offline/db/app_db.dart
@@ -1,0 +1,219 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+part 'app_db.g.dart';
+
+/// Offline-mode local persistence. One SQLite file per install at
+/// `<app-support>/offline.sqlite`. Schema is intentionally narrow for
+/// v1 — Jobs, Sims, Settings. Storage pruner trims oldest jobs when
+/// the on-disk total exceeds `settings.max_storage_bytes`.
+@DataClassName('Job')
+class Jobs extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get name => text().nullable()();
+  DateTimeColumn get createdAt => dateTime()();
+  IntColumn get totalSims => integer()();
+  IntColumn get completedSims => integer().withDefault(const Constant(0))();
+  TextColumn get state => text().withDefault(const Constant('PENDING'))();
+  TextColumn get deck1Name => text()();
+  TextColumn get deck2Name => text()();
+  TextColumn get deck3Name => text()();
+  TextColumn get deck4Name => text()();
+}
+
+@DataClassName('Sim')
+class Sims extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get jobId => integer().references(Jobs, #id)();
+  IntColumn get simIndex => integer()();
+  TextColumn get state => text().withDefault(const Constant('PENDING'))();
+  TextColumn get winnerDeckName => text().nullable()();
+  IntColumn get winningTurn => integer().nullable()();
+  IntColumn get durationMs => integer().nullable()();
+  TextColumn get errorMessage => text().nullable()();
+  TextColumn get logRelPath => text().nullable()();
+  DateTimeColumn get startedAt => dateTime().nullable()();
+  DateTimeColumn get completedAt => dateTime().nullable()();
+}
+
+class Settings extends Table {
+  TextColumn get key => text()();
+  TextColumn get value => text()();
+
+  @override
+  Set<Column> get primaryKey => {key};
+}
+
+@DriftDatabase(tables: [Jobs, Sims, Settings])
+class AppDb extends _$AppDb {
+  AppDb() : super(_openConnection());
+
+  @override
+  int get schemaVersion => 1;
+
+  /// All jobs newest-first. Drives the history list.
+  Future<List<Job>> recentJobs({int limit = 50}) {
+    return (select(jobs)
+          ..orderBy([(j) => OrderingTerm.desc(j.createdAt)])
+          ..limit(limit))
+        .get();
+  }
+
+  Future<Job?> jobById(int id) =>
+      (select(jobs)..where((j) => j.id.equals(id))).getSingleOrNull();
+
+  Future<List<Sim>> simsForJob(int jobId) =>
+      (select(sims)
+            ..where((s) => s.jobId.equals(jobId))
+            ..orderBy([(s) => OrderingTerm.asc(s.simIndex)]))
+          .get();
+
+  Stream<Job?> watchJob(int jobId) =>
+      (select(jobs)..where((j) => j.id.equals(jobId))).watchSingleOrNull();
+
+  Stream<List<Sim>> watchSimsForJob(int jobId) =>
+      (select(sims)
+            ..where((s) => s.jobId.equals(jobId))
+            ..orderBy([(s) => OrderingTerm.asc(s.simIndex)]))
+          .watch();
+
+  /// Insert a brand-new job + N PENDING sim rows in one transaction.
+  Future<int> createJob({
+    required List<String> deckNames,
+    required int simCount,
+    String? name,
+  }) async {
+    assert(deckNames.length == 4, 'Commander bracket needs exactly 4 decks');
+    return await transaction(() async {
+      final jobId = await into(jobs).insert(
+        JobsCompanion.insert(
+          name: Value(name),
+          createdAt: DateTime.now(),
+          totalSims: simCount,
+          deck1Name: deckNames[0],
+          deck2Name: deckNames[1],
+          deck3Name: deckNames[2],
+          deck4Name: deckNames[3],
+        ),
+      );
+      for (var i = 0; i < simCount; i++) {
+        await into(
+          sims,
+        ).insert(SimsCompanion.insert(jobId: jobId, simIndex: i));
+      }
+      return jobId;
+    });
+  }
+
+  Future<void> updateJobState(int jobId, String state) =>
+      (update(jobs)..where((j) => j.id.equals(jobId))).write(
+        JobsCompanion(state: Value(state)),
+      );
+
+  Future<void> markSimRunning(int simId) =>
+      (update(sims)..where((s) => s.id.equals(simId))).write(
+        SimsCompanion(
+          state: const Value('RUNNING'),
+          startedAt: Value(DateTime.now()),
+        ),
+      );
+
+  Future<void> markSimCompleted(
+    int simId, {
+    required String winnerDeckName,
+    required int? winningTurn,
+    required int durationMs,
+    String? logRelPath,
+  }) async {
+    final sim = await (select(
+      sims,
+    )..where((s) => s.id.equals(simId))).getSingle();
+    await transaction(() async {
+      await (update(sims)..where((s) => s.id.equals(simId))).write(
+        SimsCompanion(
+          state: const Value('COMPLETED'),
+          winnerDeckName: Value(winnerDeckName),
+          winningTurn: Value(winningTurn),
+          durationMs: Value(durationMs),
+          logRelPath: Value(logRelPath),
+          completedAt: Value(DateTime.now()),
+        ),
+      );
+      await _bumpJobCompletedCount(sim.jobId);
+    });
+  }
+
+  Future<void> markSimFailed(
+    int simId, {
+    required String error,
+    required int durationMs,
+    String? logRelPath,
+  }) async {
+    final sim = await (select(
+      sims,
+    )..where((s) => s.id.equals(simId))).getSingle();
+    await transaction(() async {
+      await (update(sims)..where((s) => s.id.equals(simId))).write(
+        SimsCompanion(
+          state: const Value('FAILED'),
+          errorMessage: Value(error),
+          durationMs: Value(durationMs),
+          logRelPath: Value(logRelPath),
+          completedAt: Value(DateTime.now()),
+        ),
+      );
+      await _bumpJobCompletedCount(sim.jobId);
+    });
+  }
+
+  Future<void> _bumpJobCompletedCount(int jobId) async {
+    final job = await (select(
+      jobs,
+    )..where((j) => j.id.equals(jobId))).getSingle();
+    final newCompleted = job.completedSims + 1;
+    final isDone = newCompleted >= job.totalSims;
+    await (update(jobs)..where((j) => j.id.equals(jobId))).write(
+      JobsCompanion(
+        completedSims: Value(newCompleted),
+        state: Value(isDone ? 'COMPLETED' : 'RUNNING'),
+      ),
+    );
+  }
+
+  /// Settings helpers: a thin string-keyed key/value store for things
+  /// that don't justify their own table (storage cap, last-picked decks,
+  /// etc.). Default values live in callers — `getSetting` returns null
+  /// for unknown keys.
+  Future<String?> getSetting(String key) async {
+    final row = await (select(
+      settings,
+    )..where((s) => s.key.equals(key))).getSingleOrNull();
+    return row?.value;
+  }
+
+  Future<void> setSetting(String key, String value) async {
+    await into(
+      settings,
+    ).insertOnConflictUpdate(SettingsCompanion.insert(key: key, value: value));
+  }
+
+  /// Delete a single job and its sims. Used by the storage pruner.
+  Future<void> deleteJob(int jobId) async {
+    await transaction(() async {
+      await (delete(sims)..where((s) => s.jobId.equals(jobId))).go();
+      await (delete(jobs)..where((j) => j.id.equals(jobId))).go();
+    });
+  }
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dir = await getApplicationSupportDirectory();
+    final file = File(p.join(dir.path, 'offline.sqlite'));
+    return NativeDatabase.createInBackground(file);
+  });
+}

--- a/worker_flutter/lib/offline/db/app_db.dart
+++ b/worker_flutter/lib/offline/db/app_db.dart
@@ -63,6 +63,15 @@ class AppDb extends _$AppDb {
         .get();
   }
 
+  /// Reactive variant of [recentJobs] — emits a new list whenever the
+  /// `jobs` table changes. Avoids per-second polling in the history UI.
+  Stream<List<Job>> watchRecentJobs({int limit = 50}) {
+    return (select(jobs)
+          ..orderBy([(j) => OrderingTerm.desc(j.createdAt)])
+          ..limit(limit))
+        .watch();
+  }
+
   Future<Job?> jobById(int id) =>
       (select(jobs)..where((j) => j.id.equals(id))).getSingleOrNull();
 
@@ -129,10 +138,12 @@ class AppDb extends _$AppDb {
     required int durationMs,
     String? logRelPath,
   }) async {
-    final sim = await (select(
-      sims,
-    )..where((s) => s.id.equals(simId))).getSingle();
+    // The read-sim AND its parent-job bump live inside the transaction
+    // so a concurrent caller can't observe a partially-updated state.
     await transaction(() async {
+      final sim = await (select(
+        sims,
+      )..where((s) => s.id.equals(simId))).getSingle();
       await (update(sims)..where((s) => s.id.equals(simId))).write(
         SimsCompanion(
           state: const Value('COMPLETED'),
@@ -153,10 +164,10 @@ class AppDb extends _$AppDb {
     required int durationMs,
     String? logRelPath,
   }) async {
-    final sim = await (select(
-      sims,
-    )..where((s) => s.id.equals(simId))).getSingle();
     await transaction(() async {
+      final sim = await (select(
+        sims,
+      )..where((s) => s.id.equals(simId))).getSingle();
       await (update(sims)..where((s) => s.id.equals(simId))).write(
         SimsCompanion(
           state: const Value('FAILED'),
@@ -170,16 +181,23 @@ class AppDb extends _$AppDb {
     });
   }
 
+  /// Increment the job's `completedSims` counter and only flip the
+  /// `state` if the job is still in a non-terminal state. Without the
+  /// state guard, a late-arriving sim completion could flip a
+  /// user-CANCELLED or precon-FAILED job back to RUNNING/COMPLETED.
   Future<void> _bumpJobCompletedCount(int jobId) async {
     final job = await (select(
       jobs,
     )..where((j) => j.id.equals(jobId))).getSingle();
     final newCompleted = job.completedSims + 1;
+    final canFlipState = job.state == 'PENDING' || job.state == 'RUNNING';
     final isDone = newCompleted >= job.totalSims;
     await (update(jobs)..where((j) => j.id.equals(jobId))).write(
       JobsCompanion(
         completedSims: Value(newCompleted),
-        state: Value(isDone ? 'COMPLETED' : 'RUNNING'),
+        state: canFlipState
+            ? Value(isDone ? 'COMPLETED' : 'RUNNING')
+            : const Value.absent(),
       ),
     );
   }

--- a/worker_flutter/lib/offline/db/app_db.g.dart
+++ b/worker_flutter/lib/offline/db/app_db.g.dart
@@ -1,0 +1,2446 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_db.dart';
+
+// ignore_for_file: type=lint
+class $JobsTable extends Jobs with TableInfo<$JobsTable, Job> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $JobsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _totalSimsMeta = const VerificationMeta(
+    'totalSims',
+  );
+  @override
+  late final GeneratedColumn<int> totalSims = GeneratedColumn<int>(
+    'total_sims',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _completedSimsMeta = const VerificationMeta(
+    'completedSims',
+  );
+  @override
+  late final GeneratedColumn<int> completedSims = GeneratedColumn<int>(
+    'completed_sims',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _stateMeta = const VerificationMeta('state');
+  @override
+  late final GeneratedColumn<String> state = GeneratedColumn<String>(
+    'state',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('PENDING'),
+  );
+  static const VerificationMeta _deck1NameMeta = const VerificationMeta(
+    'deck1Name',
+  );
+  @override
+  late final GeneratedColumn<String> deck1Name = GeneratedColumn<String>(
+    'deck1_name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _deck2NameMeta = const VerificationMeta(
+    'deck2Name',
+  );
+  @override
+  late final GeneratedColumn<String> deck2Name = GeneratedColumn<String>(
+    'deck2_name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _deck3NameMeta = const VerificationMeta(
+    'deck3Name',
+  );
+  @override
+  late final GeneratedColumn<String> deck3Name = GeneratedColumn<String>(
+    'deck3_name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _deck4NameMeta = const VerificationMeta(
+    'deck4Name',
+  );
+  @override
+  late final GeneratedColumn<String> deck4Name = GeneratedColumn<String>(
+    'deck4_name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    name,
+    createdAt,
+    totalSims,
+    completedSims,
+    state,
+    deck1Name,
+    deck2Name,
+    deck3Name,
+    deck4Name,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'jobs';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Job> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('total_sims')) {
+      context.handle(
+        _totalSimsMeta,
+        totalSims.isAcceptableOrUnknown(data['total_sims']!, _totalSimsMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_totalSimsMeta);
+    }
+    if (data.containsKey('completed_sims')) {
+      context.handle(
+        _completedSimsMeta,
+        completedSims.isAcceptableOrUnknown(
+          data['completed_sims']!,
+          _completedSimsMeta,
+        ),
+      );
+    }
+    if (data.containsKey('state')) {
+      context.handle(
+        _stateMeta,
+        state.isAcceptableOrUnknown(data['state']!, _stateMeta),
+      );
+    }
+    if (data.containsKey('deck1_name')) {
+      context.handle(
+        _deck1NameMeta,
+        deck1Name.isAcceptableOrUnknown(data['deck1_name']!, _deck1NameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_deck1NameMeta);
+    }
+    if (data.containsKey('deck2_name')) {
+      context.handle(
+        _deck2NameMeta,
+        deck2Name.isAcceptableOrUnknown(data['deck2_name']!, _deck2NameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_deck2NameMeta);
+    }
+    if (data.containsKey('deck3_name')) {
+      context.handle(
+        _deck3NameMeta,
+        deck3Name.isAcceptableOrUnknown(data['deck3_name']!, _deck3NameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_deck3NameMeta);
+    }
+    if (data.containsKey('deck4_name')) {
+      context.handle(
+        _deck4NameMeta,
+        deck4Name.isAcceptableOrUnknown(data['deck4_name']!, _deck4NameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_deck4NameMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Job map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Job(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      totalSims: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}total_sims'],
+      )!,
+      completedSims: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}completed_sims'],
+      )!,
+      state: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}state'],
+      )!,
+      deck1Name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}deck1_name'],
+      )!,
+      deck2Name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}deck2_name'],
+      )!,
+      deck3Name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}deck3_name'],
+      )!,
+      deck4Name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}deck4_name'],
+      )!,
+    );
+  }
+
+  @override
+  $JobsTable createAlias(String alias) {
+    return $JobsTable(attachedDatabase, alias);
+  }
+}
+
+class Job extends DataClass implements Insertable<Job> {
+  final int id;
+  final String? name;
+  final DateTime createdAt;
+  final int totalSims;
+  final int completedSims;
+  final String state;
+  final String deck1Name;
+  final String deck2Name;
+  final String deck3Name;
+  final String deck4Name;
+  const Job({
+    required this.id,
+    this.name,
+    required this.createdAt,
+    required this.totalSims,
+    required this.completedSims,
+    required this.state,
+    required this.deck1Name,
+    required this.deck2Name,
+    required this.deck3Name,
+    required this.deck4Name,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    if (!nullToAbsent || name != null) {
+      map['name'] = Variable<String>(name);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['total_sims'] = Variable<int>(totalSims);
+    map['completed_sims'] = Variable<int>(completedSims);
+    map['state'] = Variable<String>(state);
+    map['deck1_name'] = Variable<String>(deck1Name);
+    map['deck2_name'] = Variable<String>(deck2Name);
+    map['deck3_name'] = Variable<String>(deck3Name);
+    map['deck4_name'] = Variable<String>(deck4Name);
+    return map;
+  }
+
+  JobsCompanion toCompanion(bool nullToAbsent) {
+    return JobsCompanion(
+      id: Value(id),
+      name: name == null && nullToAbsent ? const Value.absent() : Value(name),
+      createdAt: Value(createdAt),
+      totalSims: Value(totalSims),
+      completedSims: Value(completedSims),
+      state: Value(state),
+      deck1Name: Value(deck1Name),
+      deck2Name: Value(deck2Name),
+      deck3Name: Value(deck3Name),
+      deck4Name: Value(deck4Name),
+    );
+  }
+
+  factory Job.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Job(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String?>(json['name']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      totalSims: serializer.fromJson<int>(json['totalSims']),
+      completedSims: serializer.fromJson<int>(json['completedSims']),
+      state: serializer.fromJson<String>(json['state']),
+      deck1Name: serializer.fromJson<String>(json['deck1Name']),
+      deck2Name: serializer.fromJson<String>(json['deck2Name']),
+      deck3Name: serializer.fromJson<String>(json['deck3Name']),
+      deck4Name: serializer.fromJson<String>(json['deck4Name']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String?>(name),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'totalSims': serializer.toJson<int>(totalSims),
+      'completedSims': serializer.toJson<int>(completedSims),
+      'state': serializer.toJson<String>(state),
+      'deck1Name': serializer.toJson<String>(deck1Name),
+      'deck2Name': serializer.toJson<String>(deck2Name),
+      'deck3Name': serializer.toJson<String>(deck3Name),
+      'deck4Name': serializer.toJson<String>(deck4Name),
+    };
+  }
+
+  Job copyWith({
+    int? id,
+    Value<String?> name = const Value.absent(),
+    DateTime? createdAt,
+    int? totalSims,
+    int? completedSims,
+    String? state,
+    String? deck1Name,
+    String? deck2Name,
+    String? deck3Name,
+    String? deck4Name,
+  }) => Job(
+    id: id ?? this.id,
+    name: name.present ? name.value : this.name,
+    createdAt: createdAt ?? this.createdAt,
+    totalSims: totalSims ?? this.totalSims,
+    completedSims: completedSims ?? this.completedSims,
+    state: state ?? this.state,
+    deck1Name: deck1Name ?? this.deck1Name,
+    deck2Name: deck2Name ?? this.deck2Name,
+    deck3Name: deck3Name ?? this.deck3Name,
+    deck4Name: deck4Name ?? this.deck4Name,
+  );
+  Job copyWithCompanion(JobsCompanion data) {
+    return Job(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      totalSims: data.totalSims.present ? data.totalSims.value : this.totalSims,
+      completedSims: data.completedSims.present
+          ? data.completedSims.value
+          : this.completedSims,
+      state: data.state.present ? data.state.value : this.state,
+      deck1Name: data.deck1Name.present ? data.deck1Name.value : this.deck1Name,
+      deck2Name: data.deck2Name.present ? data.deck2Name.value : this.deck2Name,
+      deck3Name: data.deck3Name.present ? data.deck3Name.value : this.deck3Name,
+      deck4Name: data.deck4Name.present ? data.deck4Name.value : this.deck4Name,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Job(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('totalSims: $totalSims, ')
+          ..write('completedSims: $completedSims, ')
+          ..write('state: $state, ')
+          ..write('deck1Name: $deck1Name, ')
+          ..write('deck2Name: $deck2Name, ')
+          ..write('deck3Name: $deck3Name, ')
+          ..write('deck4Name: $deck4Name')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    name,
+    createdAt,
+    totalSims,
+    completedSims,
+    state,
+    deck1Name,
+    deck2Name,
+    deck3Name,
+    deck4Name,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Job &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.createdAt == this.createdAt &&
+          other.totalSims == this.totalSims &&
+          other.completedSims == this.completedSims &&
+          other.state == this.state &&
+          other.deck1Name == this.deck1Name &&
+          other.deck2Name == this.deck2Name &&
+          other.deck3Name == this.deck3Name &&
+          other.deck4Name == this.deck4Name);
+}
+
+class JobsCompanion extends UpdateCompanion<Job> {
+  final Value<int> id;
+  final Value<String?> name;
+  final Value<DateTime> createdAt;
+  final Value<int> totalSims;
+  final Value<int> completedSims;
+  final Value<String> state;
+  final Value<String> deck1Name;
+  final Value<String> deck2Name;
+  final Value<String> deck3Name;
+  final Value<String> deck4Name;
+  const JobsCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.totalSims = const Value.absent(),
+    this.completedSims = const Value.absent(),
+    this.state = const Value.absent(),
+    this.deck1Name = const Value.absent(),
+    this.deck2Name = const Value.absent(),
+    this.deck3Name = const Value.absent(),
+    this.deck4Name = const Value.absent(),
+  });
+  JobsCompanion.insert({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    required DateTime createdAt,
+    required int totalSims,
+    this.completedSims = const Value.absent(),
+    this.state = const Value.absent(),
+    required String deck1Name,
+    required String deck2Name,
+    required String deck3Name,
+    required String deck4Name,
+  }) : createdAt = Value(createdAt),
+       totalSims = Value(totalSims),
+       deck1Name = Value(deck1Name),
+       deck2Name = Value(deck2Name),
+       deck3Name = Value(deck3Name),
+       deck4Name = Value(deck4Name);
+  static Insertable<Job> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<DateTime>? createdAt,
+    Expression<int>? totalSims,
+    Expression<int>? completedSims,
+    Expression<String>? state,
+    Expression<String>? deck1Name,
+    Expression<String>? deck2Name,
+    Expression<String>? deck3Name,
+    Expression<String>? deck4Name,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (createdAt != null) 'created_at': createdAt,
+      if (totalSims != null) 'total_sims': totalSims,
+      if (completedSims != null) 'completed_sims': completedSims,
+      if (state != null) 'state': state,
+      if (deck1Name != null) 'deck1_name': deck1Name,
+      if (deck2Name != null) 'deck2_name': deck2Name,
+      if (deck3Name != null) 'deck3_name': deck3Name,
+      if (deck4Name != null) 'deck4_name': deck4Name,
+    });
+  }
+
+  JobsCompanion copyWith({
+    Value<int>? id,
+    Value<String?>? name,
+    Value<DateTime>? createdAt,
+    Value<int>? totalSims,
+    Value<int>? completedSims,
+    Value<String>? state,
+    Value<String>? deck1Name,
+    Value<String>? deck2Name,
+    Value<String>? deck3Name,
+    Value<String>? deck4Name,
+  }) {
+    return JobsCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      createdAt: createdAt ?? this.createdAt,
+      totalSims: totalSims ?? this.totalSims,
+      completedSims: completedSims ?? this.completedSims,
+      state: state ?? this.state,
+      deck1Name: deck1Name ?? this.deck1Name,
+      deck2Name: deck2Name ?? this.deck2Name,
+      deck3Name: deck3Name ?? this.deck3Name,
+      deck4Name: deck4Name ?? this.deck4Name,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (totalSims.present) {
+      map['total_sims'] = Variable<int>(totalSims.value);
+    }
+    if (completedSims.present) {
+      map['completed_sims'] = Variable<int>(completedSims.value);
+    }
+    if (state.present) {
+      map['state'] = Variable<String>(state.value);
+    }
+    if (deck1Name.present) {
+      map['deck1_name'] = Variable<String>(deck1Name.value);
+    }
+    if (deck2Name.present) {
+      map['deck2_name'] = Variable<String>(deck2Name.value);
+    }
+    if (deck3Name.present) {
+      map['deck3_name'] = Variable<String>(deck3Name.value);
+    }
+    if (deck4Name.present) {
+      map['deck4_name'] = Variable<String>(deck4Name.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('JobsCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('totalSims: $totalSims, ')
+          ..write('completedSims: $completedSims, ')
+          ..write('state: $state, ')
+          ..write('deck1Name: $deck1Name, ')
+          ..write('deck2Name: $deck2Name, ')
+          ..write('deck3Name: $deck3Name, ')
+          ..write('deck4Name: $deck4Name')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $SimsTable extends Sims with TableInfo<$SimsTable, Sim> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SimsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _jobIdMeta = const VerificationMeta('jobId');
+  @override
+  late final GeneratedColumn<int> jobId = GeneratedColumn<int>(
+    'job_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES jobs (id)',
+    ),
+  );
+  static const VerificationMeta _simIndexMeta = const VerificationMeta(
+    'simIndex',
+  );
+  @override
+  late final GeneratedColumn<int> simIndex = GeneratedColumn<int>(
+    'sim_index',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _stateMeta = const VerificationMeta('state');
+  @override
+  late final GeneratedColumn<String> state = GeneratedColumn<String>(
+    'state',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('PENDING'),
+  );
+  static const VerificationMeta _winnerDeckNameMeta = const VerificationMeta(
+    'winnerDeckName',
+  );
+  @override
+  late final GeneratedColumn<String> winnerDeckName = GeneratedColumn<String>(
+    'winner_deck_name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _winningTurnMeta = const VerificationMeta(
+    'winningTurn',
+  );
+  @override
+  late final GeneratedColumn<int> winningTurn = GeneratedColumn<int>(
+    'winning_turn',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _durationMsMeta = const VerificationMeta(
+    'durationMs',
+  );
+  @override
+  late final GeneratedColumn<int> durationMs = GeneratedColumn<int>(
+    'duration_ms',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _errorMessageMeta = const VerificationMeta(
+    'errorMessage',
+  );
+  @override
+  late final GeneratedColumn<String> errorMessage = GeneratedColumn<String>(
+    'error_message',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _logRelPathMeta = const VerificationMeta(
+    'logRelPath',
+  );
+  @override
+  late final GeneratedColumn<String> logRelPath = GeneratedColumn<String>(
+    'log_rel_path',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _startedAtMeta = const VerificationMeta(
+    'startedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> startedAt = GeneratedColumn<DateTime>(
+    'started_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _completedAtMeta = const VerificationMeta(
+    'completedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> completedAt = GeneratedColumn<DateTime>(
+    'completed_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    jobId,
+    simIndex,
+    state,
+    winnerDeckName,
+    winningTurn,
+    durationMs,
+    errorMessage,
+    logRelPath,
+    startedAt,
+    completedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'sims';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Sim> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('job_id')) {
+      context.handle(
+        _jobIdMeta,
+        jobId.isAcceptableOrUnknown(data['job_id']!, _jobIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_jobIdMeta);
+    }
+    if (data.containsKey('sim_index')) {
+      context.handle(
+        _simIndexMeta,
+        simIndex.isAcceptableOrUnknown(data['sim_index']!, _simIndexMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_simIndexMeta);
+    }
+    if (data.containsKey('state')) {
+      context.handle(
+        _stateMeta,
+        state.isAcceptableOrUnknown(data['state']!, _stateMeta),
+      );
+    }
+    if (data.containsKey('winner_deck_name')) {
+      context.handle(
+        _winnerDeckNameMeta,
+        winnerDeckName.isAcceptableOrUnknown(
+          data['winner_deck_name']!,
+          _winnerDeckNameMeta,
+        ),
+      );
+    }
+    if (data.containsKey('winning_turn')) {
+      context.handle(
+        _winningTurnMeta,
+        winningTurn.isAcceptableOrUnknown(
+          data['winning_turn']!,
+          _winningTurnMeta,
+        ),
+      );
+    }
+    if (data.containsKey('duration_ms')) {
+      context.handle(
+        _durationMsMeta,
+        durationMs.isAcceptableOrUnknown(data['duration_ms']!, _durationMsMeta),
+      );
+    }
+    if (data.containsKey('error_message')) {
+      context.handle(
+        _errorMessageMeta,
+        errorMessage.isAcceptableOrUnknown(
+          data['error_message']!,
+          _errorMessageMeta,
+        ),
+      );
+    }
+    if (data.containsKey('log_rel_path')) {
+      context.handle(
+        _logRelPathMeta,
+        logRelPath.isAcceptableOrUnknown(
+          data['log_rel_path']!,
+          _logRelPathMeta,
+        ),
+      );
+    }
+    if (data.containsKey('started_at')) {
+      context.handle(
+        _startedAtMeta,
+        startedAt.isAcceptableOrUnknown(data['started_at']!, _startedAtMeta),
+      );
+    }
+    if (data.containsKey('completed_at')) {
+      context.handle(
+        _completedAtMeta,
+        completedAt.isAcceptableOrUnknown(
+          data['completed_at']!,
+          _completedAtMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Sim map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Sim(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      jobId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}job_id'],
+      )!,
+      simIndex: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}sim_index'],
+      )!,
+      state: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}state'],
+      )!,
+      winnerDeckName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}winner_deck_name'],
+      ),
+      winningTurn: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}winning_turn'],
+      ),
+      durationMs: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}duration_ms'],
+      ),
+      errorMessage: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}error_message'],
+      ),
+      logRelPath: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}log_rel_path'],
+      ),
+      startedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}started_at'],
+      ),
+      completedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}completed_at'],
+      ),
+    );
+  }
+
+  @override
+  $SimsTable createAlias(String alias) {
+    return $SimsTable(attachedDatabase, alias);
+  }
+}
+
+class Sim extends DataClass implements Insertable<Sim> {
+  final int id;
+  final int jobId;
+  final int simIndex;
+  final String state;
+  final String? winnerDeckName;
+  final int? winningTurn;
+  final int? durationMs;
+  final String? errorMessage;
+  final String? logRelPath;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  const Sim({
+    required this.id,
+    required this.jobId,
+    required this.simIndex,
+    required this.state,
+    this.winnerDeckName,
+    this.winningTurn,
+    this.durationMs,
+    this.errorMessage,
+    this.logRelPath,
+    this.startedAt,
+    this.completedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['job_id'] = Variable<int>(jobId);
+    map['sim_index'] = Variable<int>(simIndex);
+    map['state'] = Variable<String>(state);
+    if (!nullToAbsent || winnerDeckName != null) {
+      map['winner_deck_name'] = Variable<String>(winnerDeckName);
+    }
+    if (!nullToAbsent || winningTurn != null) {
+      map['winning_turn'] = Variable<int>(winningTurn);
+    }
+    if (!nullToAbsent || durationMs != null) {
+      map['duration_ms'] = Variable<int>(durationMs);
+    }
+    if (!nullToAbsent || errorMessage != null) {
+      map['error_message'] = Variable<String>(errorMessage);
+    }
+    if (!nullToAbsent || logRelPath != null) {
+      map['log_rel_path'] = Variable<String>(logRelPath);
+    }
+    if (!nullToAbsent || startedAt != null) {
+      map['started_at'] = Variable<DateTime>(startedAt);
+    }
+    if (!nullToAbsent || completedAt != null) {
+      map['completed_at'] = Variable<DateTime>(completedAt);
+    }
+    return map;
+  }
+
+  SimsCompanion toCompanion(bool nullToAbsent) {
+    return SimsCompanion(
+      id: Value(id),
+      jobId: Value(jobId),
+      simIndex: Value(simIndex),
+      state: Value(state),
+      winnerDeckName: winnerDeckName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(winnerDeckName),
+      winningTurn: winningTurn == null && nullToAbsent
+          ? const Value.absent()
+          : Value(winningTurn),
+      durationMs: durationMs == null && nullToAbsent
+          ? const Value.absent()
+          : Value(durationMs),
+      errorMessage: errorMessage == null && nullToAbsent
+          ? const Value.absent()
+          : Value(errorMessage),
+      logRelPath: logRelPath == null && nullToAbsent
+          ? const Value.absent()
+          : Value(logRelPath),
+      startedAt: startedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(startedAt),
+      completedAt: completedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(completedAt),
+    );
+  }
+
+  factory Sim.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Sim(
+      id: serializer.fromJson<int>(json['id']),
+      jobId: serializer.fromJson<int>(json['jobId']),
+      simIndex: serializer.fromJson<int>(json['simIndex']),
+      state: serializer.fromJson<String>(json['state']),
+      winnerDeckName: serializer.fromJson<String?>(json['winnerDeckName']),
+      winningTurn: serializer.fromJson<int?>(json['winningTurn']),
+      durationMs: serializer.fromJson<int?>(json['durationMs']),
+      errorMessage: serializer.fromJson<String?>(json['errorMessage']),
+      logRelPath: serializer.fromJson<String?>(json['logRelPath']),
+      startedAt: serializer.fromJson<DateTime?>(json['startedAt']),
+      completedAt: serializer.fromJson<DateTime?>(json['completedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'jobId': serializer.toJson<int>(jobId),
+      'simIndex': serializer.toJson<int>(simIndex),
+      'state': serializer.toJson<String>(state),
+      'winnerDeckName': serializer.toJson<String?>(winnerDeckName),
+      'winningTurn': serializer.toJson<int?>(winningTurn),
+      'durationMs': serializer.toJson<int?>(durationMs),
+      'errorMessage': serializer.toJson<String?>(errorMessage),
+      'logRelPath': serializer.toJson<String?>(logRelPath),
+      'startedAt': serializer.toJson<DateTime?>(startedAt),
+      'completedAt': serializer.toJson<DateTime?>(completedAt),
+    };
+  }
+
+  Sim copyWith({
+    int? id,
+    int? jobId,
+    int? simIndex,
+    String? state,
+    Value<String?> winnerDeckName = const Value.absent(),
+    Value<int?> winningTurn = const Value.absent(),
+    Value<int?> durationMs = const Value.absent(),
+    Value<String?> errorMessage = const Value.absent(),
+    Value<String?> logRelPath = const Value.absent(),
+    Value<DateTime?> startedAt = const Value.absent(),
+    Value<DateTime?> completedAt = const Value.absent(),
+  }) => Sim(
+    id: id ?? this.id,
+    jobId: jobId ?? this.jobId,
+    simIndex: simIndex ?? this.simIndex,
+    state: state ?? this.state,
+    winnerDeckName: winnerDeckName.present
+        ? winnerDeckName.value
+        : this.winnerDeckName,
+    winningTurn: winningTurn.present ? winningTurn.value : this.winningTurn,
+    durationMs: durationMs.present ? durationMs.value : this.durationMs,
+    errorMessage: errorMessage.present ? errorMessage.value : this.errorMessage,
+    logRelPath: logRelPath.present ? logRelPath.value : this.logRelPath,
+    startedAt: startedAt.present ? startedAt.value : this.startedAt,
+    completedAt: completedAt.present ? completedAt.value : this.completedAt,
+  );
+  Sim copyWithCompanion(SimsCompanion data) {
+    return Sim(
+      id: data.id.present ? data.id.value : this.id,
+      jobId: data.jobId.present ? data.jobId.value : this.jobId,
+      simIndex: data.simIndex.present ? data.simIndex.value : this.simIndex,
+      state: data.state.present ? data.state.value : this.state,
+      winnerDeckName: data.winnerDeckName.present
+          ? data.winnerDeckName.value
+          : this.winnerDeckName,
+      winningTurn: data.winningTurn.present
+          ? data.winningTurn.value
+          : this.winningTurn,
+      durationMs: data.durationMs.present
+          ? data.durationMs.value
+          : this.durationMs,
+      errorMessage: data.errorMessage.present
+          ? data.errorMessage.value
+          : this.errorMessage,
+      logRelPath: data.logRelPath.present
+          ? data.logRelPath.value
+          : this.logRelPath,
+      startedAt: data.startedAt.present ? data.startedAt.value : this.startedAt,
+      completedAt: data.completedAt.present
+          ? data.completedAt.value
+          : this.completedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Sim(')
+          ..write('id: $id, ')
+          ..write('jobId: $jobId, ')
+          ..write('simIndex: $simIndex, ')
+          ..write('state: $state, ')
+          ..write('winnerDeckName: $winnerDeckName, ')
+          ..write('winningTurn: $winningTurn, ')
+          ..write('durationMs: $durationMs, ')
+          ..write('errorMessage: $errorMessage, ')
+          ..write('logRelPath: $logRelPath, ')
+          ..write('startedAt: $startedAt, ')
+          ..write('completedAt: $completedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    jobId,
+    simIndex,
+    state,
+    winnerDeckName,
+    winningTurn,
+    durationMs,
+    errorMessage,
+    logRelPath,
+    startedAt,
+    completedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Sim &&
+          other.id == this.id &&
+          other.jobId == this.jobId &&
+          other.simIndex == this.simIndex &&
+          other.state == this.state &&
+          other.winnerDeckName == this.winnerDeckName &&
+          other.winningTurn == this.winningTurn &&
+          other.durationMs == this.durationMs &&
+          other.errorMessage == this.errorMessage &&
+          other.logRelPath == this.logRelPath &&
+          other.startedAt == this.startedAt &&
+          other.completedAt == this.completedAt);
+}
+
+class SimsCompanion extends UpdateCompanion<Sim> {
+  final Value<int> id;
+  final Value<int> jobId;
+  final Value<int> simIndex;
+  final Value<String> state;
+  final Value<String?> winnerDeckName;
+  final Value<int?> winningTurn;
+  final Value<int?> durationMs;
+  final Value<String?> errorMessage;
+  final Value<String?> logRelPath;
+  final Value<DateTime?> startedAt;
+  final Value<DateTime?> completedAt;
+  const SimsCompanion({
+    this.id = const Value.absent(),
+    this.jobId = const Value.absent(),
+    this.simIndex = const Value.absent(),
+    this.state = const Value.absent(),
+    this.winnerDeckName = const Value.absent(),
+    this.winningTurn = const Value.absent(),
+    this.durationMs = const Value.absent(),
+    this.errorMessage = const Value.absent(),
+    this.logRelPath = const Value.absent(),
+    this.startedAt = const Value.absent(),
+    this.completedAt = const Value.absent(),
+  });
+  SimsCompanion.insert({
+    this.id = const Value.absent(),
+    required int jobId,
+    required int simIndex,
+    this.state = const Value.absent(),
+    this.winnerDeckName = const Value.absent(),
+    this.winningTurn = const Value.absent(),
+    this.durationMs = const Value.absent(),
+    this.errorMessage = const Value.absent(),
+    this.logRelPath = const Value.absent(),
+    this.startedAt = const Value.absent(),
+    this.completedAt = const Value.absent(),
+  }) : jobId = Value(jobId),
+       simIndex = Value(simIndex);
+  static Insertable<Sim> custom({
+    Expression<int>? id,
+    Expression<int>? jobId,
+    Expression<int>? simIndex,
+    Expression<String>? state,
+    Expression<String>? winnerDeckName,
+    Expression<int>? winningTurn,
+    Expression<int>? durationMs,
+    Expression<String>? errorMessage,
+    Expression<String>? logRelPath,
+    Expression<DateTime>? startedAt,
+    Expression<DateTime>? completedAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (jobId != null) 'job_id': jobId,
+      if (simIndex != null) 'sim_index': simIndex,
+      if (state != null) 'state': state,
+      if (winnerDeckName != null) 'winner_deck_name': winnerDeckName,
+      if (winningTurn != null) 'winning_turn': winningTurn,
+      if (durationMs != null) 'duration_ms': durationMs,
+      if (errorMessage != null) 'error_message': errorMessage,
+      if (logRelPath != null) 'log_rel_path': logRelPath,
+      if (startedAt != null) 'started_at': startedAt,
+      if (completedAt != null) 'completed_at': completedAt,
+    });
+  }
+
+  SimsCompanion copyWith({
+    Value<int>? id,
+    Value<int>? jobId,
+    Value<int>? simIndex,
+    Value<String>? state,
+    Value<String?>? winnerDeckName,
+    Value<int?>? winningTurn,
+    Value<int?>? durationMs,
+    Value<String?>? errorMessage,
+    Value<String?>? logRelPath,
+    Value<DateTime?>? startedAt,
+    Value<DateTime?>? completedAt,
+  }) {
+    return SimsCompanion(
+      id: id ?? this.id,
+      jobId: jobId ?? this.jobId,
+      simIndex: simIndex ?? this.simIndex,
+      state: state ?? this.state,
+      winnerDeckName: winnerDeckName ?? this.winnerDeckName,
+      winningTurn: winningTurn ?? this.winningTurn,
+      durationMs: durationMs ?? this.durationMs,
+      errorMessage: errorMessage ?? this.errorMessage,
+      logRelPath: logRelPath ?? this.logRelPath,
+      startedAt: startedAt ?? this.startedAt,
+      completedAt: completedAt ?? this.completedAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (jobId.present) {
+      map['job_id'] = Variable<int>(jobId.value);
+    }
+    if (simIndex.present) {
+      map['sim_index'] = Variable<int>(simIndex.value);
+    }
+    if (state.present) {
+      map['state'] = Variable<String>(state.value);
+    }
+    if (winnerDeckName.present) {
+      map['winner_deck_name'] = Variable<String>(winnerDeckName.value);
+    }
+    if (winningTurn.present) {
+      map['winning_turn'] = Variable<int>(winningTurn.value);
+    }
+    if (durationMs.present) {
+      map['duration_ms'] = Variable<int>(durationMs.value);
+    }
+    if (errorMessage.present) {
+      map['error_message'] = Variable<String>(errorMessage.value);
+    }
+    if (logRelPath.present) {
+      map['log_rel_path'] = Variable<String>(logRelPath.value);
+    }
+    if (startedAt.present) {
+      map['started_at'] = Variable<DateTime>(startedAt.value);
+    }
+    if (completedAt.present) {
+      map['completed_at'] = Variable<DateTime>(completedAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SimsCompanion(')
+          ..write('id: $id, ')
+          ..write('jobId: $jobId, ')
+          ..write('simIndex: $simIndex, ')
+          ..write('state: $state, ')
+          ..write('winnerDeckName: $winnerDeckName, ')
+          ..write('winningTurn: $winningTurn, ')
+          ..write('durationMs: $durationMs, ')
+          ..write('errorMessage: $errorMessage, ')
+          ..write('logRelPath: $logRelPath, ')
+          ..write('startedAt: $startedAt, ')
+          ..write('completedAt: $completedAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $SettingsTable extends Settings with TableInfo<$SettingsTable, Setting> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SettingsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _keyMeta = const VerificationMeta('key');
+  @override
+  late final GeneratedColumn<String> key = GeneratedColumn<String>(
+    'key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _valueMeta = const VerificationMeta('value');
+  @override
+  late final GeneratedColumn<String> value = GeneratedColumn<String>(
+    'value',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [key, value];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'settings';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Setting> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('key')) {
+      context.handle(
+        _keyMeta,
+        key.isAcceptableOrUnknown(data['key']!, _keyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_keyMeta);
+    }
+    if (data.containsKey('value')) {
+      context.handle(
+        _valueMeta,
+        value.isAcceptableOrUnknown(data['value']!, _valueMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_valueMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {key};
+  @override
+  Setting map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Setting(
+      key: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}key'],
+      )!,
+      value: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}value'],
+      )!,
+    );
+  }
+
+  @override
+  $SettingsTable createAlias(String alias) {
+    return $SettingsTable(attachedDatabase, alias);
+  }
+}
+
+class Setting extends DataClass implements Insertable<Setting> {
+  final String key;
+  final String value;
+  const Setting({required this.key, required this.value});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['key'] = Variable<String>(key);
+    map['value'] = Variable<String>(value);
+    return map;
+  }
+
+  SettingsCompanion toCompanion(bool nullToAbsent) {
+    return SettingsCompanion(key: Value(key), value: Value(value));
+  }
+
+  factory Setting.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Setting(
+      key: serializer.fromJson<String>(json['key']),
+      value: serializer.fromJson<String>(json['value']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'key': serializer.toJson<String>(key),
+      'value': serializer.toJson<String>(value),
+    };
+  }
+
+  Setting copyWith({String? key, String? value}) =>
+      Setting(key: key ?? this.key, value: value ?? this.value);
+  Setting copyWithCompanion(SettingsCompanion data) {
+    return Setting(
+      key: data.key.present ? data.key.value : this.key,
+      value: data.value.present ? data.value.value : this.value,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Setting(')
+          ..write('key: $key, ')
+          ..write('value: $value')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(key, value);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Setting && other.key == this.key && other.value == this.value);
+}
+
+class SettingsCompanion extends UpdateCompanion<Setting> {
+  final Value<String> key;
+  final Value<String> value;
+  final Value<int> rowid;
+  const SettingsCompanion({
+    this.key = const Value.absent(),
+    this.value = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SettingsCompanion.insert({
+    required String key,
+    required String value,
+    this.rowid = const Value.absent(),
+  }) : key = Value(key),
+       value = Value(value);
+  static Insertable<Setting> custom({
+    Expression<String>? key,
+    Expression<String>? value,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (key != null) 'key': key,
+      if (value != null) 'value': value,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SettingsCompanion copyWith({
+    Value<String>? key,
+    Value<String>? value,
+    Value<int>? rowid,
+  }) {
+    return SettingsCompanion(
+      key: key ?? this.key,
+      value: value ?? this.value,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (key.present) {
+      map['key'] = Variable<String>(key.value);
+    }
+    if (value.present) {
+      map['value'] = Variable<String>(value.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SettingsCompanion(')
+          ..write('key: $key, ')
+          ..write('value: $value, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$AppDb extends GeneratedDatabase {
+  _$AppDb(QueryExecutor e) : super(e);
+  $AppDbManager get managers => $AppDbManager(this);
+  late final $JobsTable jobs = $JobsTable(this);
+  late final $SimsTable sims = $SimsTable(this);
+  late final $SettingsTable settings = $SettingsTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [jobs, sims, settings];
+}
+
+typedef $$JobsTableCreateCompanionBuilder =
+    JobsCompanion Function({
+      Value<int> id,
+      Value<String?> name,
+      required DateTime createdAt,
+      required int totalSims,
+      Value<int> completedSims,
+      Value<String> state,
+      required String deck1Name,
+      required String deck2Name,
+      required String deck3Name,
+      required String deck4Name,
+    });
+typedef $$JobsTableUpdateCompanionBuilder =
+    JobsCompanion Function({
+      Value<int> id,
+      Value<String?> name,
+      Value<DateTime> createdAt,
+      Value<int> totalSims,
+      Value<int> completedSims,
+      Value<String> state,
+      Value<String> deck1Name,
+      Value<String> deck2Name,
+      Value<String> deck3Name,
+      Value<String> deck4Name,
+    });
+
+final class $$JobsTableReferences
+    extends BaseReferences<_$AppDb, $JobsTable, Job> {
+  $$JobsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$SimsTable, List<Sim>> _simsRefsTable(
+    _$AppDb db,
+  ) => MultiTypedResultKey.fromTable(
+    db.sims,
+    aliasName: $_aliasNameGenerator(db.jobs.id, db.sims.jobId),
+  );
+
+  $$SimsTableProcessedTableManager get simsRefs {
+    final manager = $$SimsTableTableManager(
+      $_db,
+      $_db.sims,
+    ).filter((f) => f.jobId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_simsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$JobsTableFilterComposer extends Composer<_$AppDb, $JobsTable> {
+  $$JobsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get totalSims => $composableBuilder(
+    column: $table.totalSims,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get completedSims => $composableBuilder(
+    column: $table.completedSims,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get state => $composableBuilder(
+    column: $table.state,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get deck1Name => $composableBuilder(
+    column: $table.deck1Name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get deck2Name => $composableBuilder(
+    column: $table.deck2Name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get deck3Name => $composableBuilder(
+    column: $table.deck3Name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get deck4Name => $composableBuilder(
+    column: $table.deck4Name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> simsRefs(
+    Expression<bool> Function($$SimsTableFilterComposer f) f,
+  ) {
+    final $$SimsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.sims,
+      getReferencedColumn: (t) => t.jobId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$SimsTableFilterComposer(
+            $db: $db,
+            $table: $db.sims,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$JobsTableOrderingComposer extends Composer<_$AppDb, $JobsTable> {
+  $$JobsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get totalSims => $composableBuilder(
+    column: $table.totalSims,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get completedSims => $composableBuilder(
+    column: $table.completedSims,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get state => $composableBuilder(
+    column: $table.state,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get deck1Name => $composableBuilder(
+    column: $table.deck1Name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get deck2Name => $composableBuilder(
+    column: $table.deck2Name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get deck3Name => $composableBuilder(
+    column: $table.deck3Name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get deck4Name => $composableBuilder(
+    column: $table.deck4Name,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$JobsTableAnnotationComposer extends Composer<_$AppDb, $JobsTable> {
+  $$JobsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<int> get totalSims =>
+      $composableBuilder(column: $table.totalSims, builder: (column) => column);
+
+  GeneratedColumn<int> get completedSims => $composableBuilder(
+    column: $table.completedSims,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get state =>
+      $composableBuilder(column: $table.state, builder: (column) => column);
+
+  GeneratedColumn<String> get deck1Name =>
+      $composableBuilder(column: $table.deck1Name, builder: (column) => column);
+
+  GeneratedColumn<String> get deck2Name =>
+      $composableBuilder(column: $table.deck2Name, builder: (column) => column);
+
+  GeneratedColumn<String> get deck3Name =>
+      $composableBuilder(column: $table.deck3Name, builder: (column) => column);
+
+  GeneratedColumn<String> get deck4Name =>
+      $composableBuilder(column: $table.deck4Name, builder: (column) => column);
+
+  Expression<T> simsRefs<T extends Object>(
+    Expression<T> Function($$SimsTableAnnotationComposer a) f,
+  ) {
+    final $$SimsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.sims,
+      getReferencedColumn: (t) => t.jobId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$SimsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.sims,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$JobsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDb,
+          $JobsTable,
+          Job,
+          $$JobsTableFilterComposer,
+          $$JobsTableOrderingComposer,
+          $$JobsTableAnnotationComposer,
+          $$JobsTableCreateCompanionBuilder,
+          $$JobsTableUpdateCompanionBuilder,
+          (Job, $$JobsTableReferences),
+          Job,
+          PrefetchHooks Function({bool simsRefs})
+        > {
+  $$JobsTableTableManager(_$AppDb db, $JobsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$JobsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$JobsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$JobsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String?> name = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<int> totalSims = const Value.absent(),
+                Value<int> completedSims = const Value.absent(),
+                Value<String> state = const Value.absent(),
+                Value<String> deck1Name = const Value.absent(),
+                Value<String> deck2Name = const Value.absent(),
+                Value<String> deck3Name = const Value.absent(),
+                Value<String> deck4Name = const Value.absent(),
+              }) => JobsCompanion(
+                id: id,
+                name: name,
+                createdAt: createdAt,
+                totalSims: totalSims,
+                completedSims: completedSims,
+                state: state,
+                deck1Name: deck1Name,
+                deck2Name: deck2Name,
+                deck3Name: deck3Name,
+                deck4Name: deck4Name,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String?> name = const Value.absent(),
+                required DateTime createdAt,
+                required int totalSims,
+                Value<int> completedSims = const Value.absent(),
+                Value<String> state = const Value.absent(),
+                required String deck1Name,
+                required String deck2Name,
+                required String deck3Name,
+                required String deck4Name,
+              }) => JobsCompanion.insert(
+                id: id,
+                name: name,
+                createdAt: createdAt,
+                totalSims: totalSims,
+                completedSims: completedSims,
+                state: state,
+                deck1Name: deck1Name,
+                deck2Name: deck2Name,
+                deck3Name: deck3Name,
+                deck4Name: deck4Name,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) =>
+                    (e.readTable(table), $$JobsTableReferences(db, table, e)),
+              )
+              .toList(),
+          prefetchHooksCallback: ({simsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [if (simsRefs) db.sims],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (simsRefs)
+                    await $_getPrefetchedData<Job, $JobsTable, Sim>(
+                      currentTable: table,
+                      referencedTable: $$JobsTableReferences._simsRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$JobsTableReferences(db, table, p0).simsRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.jobId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$JobsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDb,
+      $JobsTable,
+      Job,
+      $$JobsTableFilterComposer,
+      $$JobsTableOrderingComposer,
+      $$JobsTableAnnotationComposer,
+      $$JobsTableCreateCompanionBuilder,
+      $$JobsTableUpdateCompanionBuilder,
+      (Job, $$JobsTableReferences),
+      Job,
+      PrefetchHooks Function({bool simsRefs})
+    >;
+typedef $$SimsTableCreateCompanionBuilder =
+    SimsCompanion Function({
+      Value<int> id,
+      required int jobId,
+      required int simIndex,
+      Value<String> state,
+      Value<String?> winnerDeckName,
+      Value<int?> winningTurn,
+      Value<int?> durationMs,
+      Value<String?> errorMessage,
+      Value<String?> logRelPath,
+      Value<DateTime?> startedAt,
+      Value<DateTime?> completedAt,
+    });
+typedef $$SimsTableUpdateCompanionBuilder =
+    SimsCompanion Function({
+      Value<int> id,
+      Value<int> jobId,
+      Value<int> simIndex,
+      Value<String> state,
+      Value<String?> winnerDeckName,
+      Value<int?> winningTurn,
+      Value<int?> durationMs,
+      Value<String?> errorMessage,
+      Value<String?> logRelPath,
+      Value<DateTime?> startedAt,
+      Value<DateTime?> completedAt,
+    });
+
+final class $$SimsTableReferences
+    extends BaseReferences<_$AppDb, $SimsTable, Sim> {
+  $$SimsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $JobsTable _jobIdTable(_$AppDb db) =>
+      db.jobs.createAlias($_aliasNameGenerator(db.sims.jobId, db.jobs.id));
+
+  $$JobsTableProcessedTableManager get jobId {
+    final $_column = $_itemColumn<int>('job_id')!;
+
+    final manager = $$JobsTableTableManager(
+      $_db,
+      $_db.jobs,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_jobIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$SimsTableFilterComposer extends Composer<_$AppDb, $SimsTable> {
+  $$SimsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get simIndex => $composableBuilder(
+    column: $table.simIndex,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get state => $composableBuilder(
+    column: $table.state,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get winnerDeckName => $composableBuilder(
+    column: $table.winnerDeckName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get winningTurn => $composableBuilder(
+    column: $table.winningTurn,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get errorMessage => $composableBuilder(
+    column: $table.errorMessage,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get logRelPath => $composableBuilder(
+    column: $table.logRelPath,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get startedAt => $composableBuilder(
+    column: $table.startedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$JobsTableFilterComposer get jobId {
+    final $$JobsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.jobId,
+      referencedTable: $db.jobs,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$JobsTableFilterComposer(
+            $db: $db,
+            $table: $db.jobs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$SimsTableOrderingComposer extends Composer<_$AppDb, $SimsTable> {
+  $$SimsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get simIndex => $composableBuilder(
+    column: $table.simIndex,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get state => $composableBuilder(
+    column: $table.state,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get winnerDeckName => $composableBuilder(
+    column: $table.winnerDeckName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get winningTurn => $composableBuilder(
+    column: $table.winningTurn,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get errorMessage => $composableBuilder(
+    column: $table.errorMessage,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get logRelPath => $composableBuilder(
+    column: $table.logRelPath,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get startedAt => $composableBuilder(
+    column: $table.startedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$JobsTableOrderingComposer get jobId {
+    final $$JobsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.jobId,
+      referencedTable: $db.jobs,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$JobsTableOrderingComposer(
+            $db: $db,
+            $table: $db.jobs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$SimsTableAnnotationComposer extends Composer<_$AppDb, $SimsTable> {
+  $$SimsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<int> get simIndex =>
+      $composableBuilder(column: $table.simIndex, builder: (column) => column);
+
+  GeneratedColumn<String> get state =>
+      $composableBuilder(column: $table.state, builder: (column) => column);
+
+  GeneratedColumn<String> get winnerDeckName => $composableBuilder(
+    column: $table.winnerDeckName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get winningTurn => $composableBuilder(
+    column: $table.winningTurn,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get errorMessage => $composableBuilder(
+    column: $table.errorMessage,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get logRelPath => $composableBuilder(
+    column: $table.logRelPath,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get startedAt =>
+      $composableBuilder(column: $table.startedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => column,
+  );
+
+  $$JobsTableAnnotationComposer get jobId {
+    final $$JobsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.jobId,
+      referencedTable: $db.jobs,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$JobsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.jobs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$SimsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDb,
+          $SimsTable,
+          Sim,
+          $$SimsTableFilterComposer,
+          $$SimsTableOrderingComposer,
+          $$SimsTableAnnotationComposer,
+          $$SimsTableCreateCompanionBuilder,
+          $$SimsTableUpdateCompanionBuilder,
+          (Sim, $$SimsTableReferences),
+          Sim,
+          PrefetchHooks Function({bool jobId})
+        > {
+  $$SimsTableTableManager(_$AppDb db, $SimsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$SimsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$SimsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$SimsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<int> jobId = const Value.absent(),
+                Value<int> simIndex = const Value.absent(),
+                Value<String> state = const Value.absent(),
+                Value<String?> winnerDeckName = const Value.absent(),
+                Value<int?> winningTurn = const Value.absent(),
+                Value<int?> durationMs = const Value.absent(),
+                Value<String?> errorMessage = const Value.absent(),
+                Value<String?> logRelPath = const Value.absent(),
+                Value<DateTime?> startedAt = const Value.absent(),
+                Value<DateTime?> completedAt = const Value.absent(),
+              }) => SimsCompanion(
+                id: id,
+                jobId: jobId,
+                simIndex: simIndex,
+                state: state,
+                winnerDeckName: winnerDeckName,
+                winningTurn: winningTurn,
+                durationMs: durationMs,
+                errorMessage: errorMessage,
+                logRelPath: logRelPath,
+                startedAt: startedAt,
+                completedAt: completedAt,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required int jobId,
+                required int simIndex,
+                Value<String> state = const Value.absent(),
+                Value<String?> winnerDeckName = const Value.absent(),
+                Value<int?> winningTurn = const Value.absent(),
+                Value<int?> durationMs = const Value.absent(),
+                Value<String?> errorMessage = const Value.absent(),
+                Value<String?> logRelPath = const Value.absent(),
+                Value<DateTime?> startedAt = const Value.absent(),
+                Value<DateTime?> completedAt = const Value.absent(),
+              }) => SimsCompanion.insert(
+                id: id,
+                jobId: jobId,
+                simIndex: simIndex,
+                state: state,
+                winnerDeckName: winnerDeckName,
+                winningTurn: winningTurn,
+                durationMs: durationMs,
+                errorMessage: errorMessage,
+                logRelPath: logRelPath,
+                startedAt: startedAt,
+                completedAt: completedAt,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) =>
+                    (e.readTable(table), $$SimsTableReferences(db, table, e)),
+              )
+              .toList(),
+          prefetchHooksCallback: ({jobId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (jobId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.jobId,
+                                referencedTable: $$SimsTableReferences
+                                    ._jobIdTable(db),
+                                referencedColumn: $$SimsTableReferences
+                                    ._jobIdTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$SimsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDb,
+      $SimsTable,
+      Sim,
+      $$SimsTableFilterComposer,
+      $$SimsTableOrderingComposer,
+      $$SimsTableAnnotationComposer,
+      $$SimsTableCreateCompanionBuilder,
+      $$SimsTableUpdateCompanionBuilder,
+      (Sim, $$SimsTableReferences),
+      Sim,
+      PrefetchHooks Function({bool jobId})
+    >;
+typedef $$SettingsTableCreateCompanionBuilder =
+    SettingsCompanion Function({
+      required String key,
+      required String value,
+      Value<int> rowid,
+    });
+typedef $$SettingsTableUpdateCompanionBuilder =
+    SettingsCompanion Function({
+      Value<String> key,
+      Value<String> value,
+      Value<int> rowid,
+    });
+
+class $$SettingsTableFilterComposer extends Composer<_$AppDb, $SettingsTable> {
+  $$SettingsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get key => $composableBuilder(
+    column: $table.key,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get value => $composableBuilder(
+    column: $table.value,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$SettingsTableOrderingComposer
+    extends Composer<_$AppDb, $SettingsTable> {
+  $$SettingsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get key => $composableBuilder(
+    column: $table.key,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get value => $composableBuilder(
+    column: $table.value,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$SettingsTableAnnotationComposer
+    extends Composer<_$AppDb, $SettingsTable> {
+  $$SettingsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get key =>
+      $composableBuilder(column: $table.key, builder: (column) => column);
+
+  GeneratedColumn<String> get value =>
+      $composableBuilder(column: $table.value, builder: (column) => column);
+}
+
+class $$SettingsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDb,
+          $SettingsTable,
+          Setting,
+          $$SettingsTableFilterComposer,
+          $$SettingsTableOrderingComposer,
+          $$SettingsTableAnnotationComposer,
+          $$SettingsTableCreateCompanionBuilder,
+          $$SettingsTableUpdateCompanionBuilder,
+          (Setting, BaseReferences<_$AppDb, $SettingsTable, Setting>),
+          Setting,
+          PrefetchHooks Function()
+        > {
+  $$SettingsTableTableManager(_$AppDb db, $SettingsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$SettingsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$SettingsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$SettingsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> key = const Value.absent(),
+                Value<String> value = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => SettingsCompanion(key: key, value: value, rowid: rowid),
+          createCompanionCallback:
+              ({
+                required String key,
+                required String value,
+                Value<int> rowid = const Value.absent(),
+              }) => SettingsCompanion.insert(
+                key: key,
+                value: value,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$SettingsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDb,
+      $SettingsTable,
+      Setting,
+      $$SettingsTableFilterComposer,
+      $$SettingsTableOrderingComposer,
+      $$SettingsTableAnnotationComposer,
+      $$SettingsTableCreateCompanionBuilder,
+      $$SettingsTableUpdateCompanionBuilder,
+      (Setting, BaseReferences<_$AppDb, $SettingsTable, Setting>),
+      Setting,
+      PrefetchHooks Function()
+    >;
+
+class $AppDbManager {
+  final _$AppDb _db;
+  $AppDbManager(this._db);
+  $$JobsTableTableManager get jobs => $$JobsTableTableManager(_db, _db.jobs);
+  $$SimsTableTableManager get sims => $$SimsTableTableManager(_db, _db.sims);
+  $$SettingsTableTableManager get settings =>
+      $$SettingsTableTableManager(_db, _db.settings);
+}

--- a/worker_flutter/lib/offline/deck_source.dart
+++ b/worker_flutter/lib/offline/deck_source.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+/// One bundled-precon deck on disk. We read these from Forge's own
+/// data dir (`<forgePath>/res/Decks/Commander/*.dck`) — the installer
+/// already extracts them as part of the first-run Forge download, so
+/// offline mode gets the same ~30+ commander precons that the
+/// simulation engine knows how to run.
+class PreconDeck {
+  PreconDeck({
+    required this.displayName,
+    required this.filename,
+    required this.path,
+  });
+
+  /// Filename without the .dck extension. Used as `displayName` in UIs.
+  final String displayName;
+
+  /// Full filename including .dck (matches Forge's expected `-d` arg).
+  final String filename;
+
+  /// Absolute path to the .dck on disk.
+  final String path;
+}
+
+/// Loads precons from the Forge installation directory.
+///
+/// `forgePath` is the same value the WorkerConfig carries —
+/// `<app-support>/forge`. Forge unpacks its bundled commander precons
+/// under `forgePath/res/Decks/Commander/` (verified with Forge 2.0.10).
+/// The directory may be deep so we walk recursively and pick `.dck`
+/// files only.
+Future<List<PreconDeck>> loadBundledPrecons(String forgePath) async {
+  final commanderDir = Directory('$forgePath/res/Decks/Commander');
+  if (!commanderDir.existsSync()) {
+    return const [];
+  }
+  final out = <PreconDeck>[];
+  await for (final entity in commanderDir.list(recursive: true)) {
+    if (entity is! File) continue;
+    final name = entity.path.split(Platform.pathSeparator).last;
+    if (!name.toLowerCase().endsWith('.dck')) continue;
+    out.add(
+      PreconDeck(
+        displayName: _humanize(name.substring(0, name.length - 4)),
+        filename: name,
+        path: entity.path,
+      ),
+    );
+  }
+  out.sort(
+    (a, b) =>
+        a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase()),
+  );
+  return out;
+}
+
+/// "Marchesa-control-upgraded" → "Marchesa Control Upgraded".
+String _humanize(String raw) {
+  return raw
+      .replaceAll(RegExp(r'[_-]+'), ' ')
+      .split(' ')
+      .where((w) => w.isNotEmpty)
+      .map((w) => '${w[0].toUpperCase()}${w.substring(1)}')
+      .join(' ');
+}

--- a/worker_flutter/lib/offline/offline_app.dart
+++ b/worker_flutter/lib/offline/offline_app.dart
@@ -1,15 +1,46 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
+import '../config.dart';
 import '../launch/mode_picker_screen.dart';
+import 'db/app_db.dart';
+import 'deck_source.dart';
+import 'offline_runner.dart';
 
-/// Placeholder shell for offline mode. The real implementation lands in
-/// Phase 2 of the desktop-app-evolution spec (drift schema + deck picker
-/// + job runner + history). For now this screen explains the state and
-/// gives the user a way back to the mode picker.
-class OfflineApp extends StatelessWidget {
-  const OfflineApp({super.key, required this.onSwitchMode});
+/// Top-level offline-mode shell. Owns the AppDb + WorkerConfig and
+/// hosts a Navigator with the home, deck picker, progress, and
+/// results screens.
+class OfflineApp extends StatefulWidget {
+  const OfflineApp({
+    super.key,
+    required this.config,
+    required this.onSwitchMode,
+  });
 
+  final WorkerConfig config;
   final VoidCallback onSwitchMode;
+
+  @override
+  State<OfflineApp> createState() => _OfflineAppState();
+}
+
+class _OfflineAppState extends State<OfflineApp> {
+  late final AppDb _db;
+  late final OfflineRunner _runner;
+
+  @override
+  void initState() {
+    super.initState();
+    _db = AppDb();
+    _runner = OfflineRunner(db: _db, config: widget.config);
+  }
+
+  @override
+  void dispose() {
+    _db.close();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,52 +54,545 @@ class OfflineApp extends StatelessWidget {
           surface: Color(0xFF111827),
         ),
       ),
-      home: Scaffold(
-        body: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 480),
-            child: Padding(
-              padding: const EdgeInsets.all(32),
+      home: _HomeScreen(
+        db: _db,
+        runner: _runner,
+        config: widget.config,
+        onSwitchMode: widget.onSwitchMode,
+      ),
+    );
+  }
+}
+
+// ── Home: new run + history ──────────────────────────────────────
+
+class _HomeScreen extends StatelessWidget {
+  const _HomeScreen({
+    required this.db,
+    required this.runner,
+    required this.config,
+    required this.onSwitchMode,
+  });
+
+  final AppDb db;
+  final OfflineRunner runner;
+  final WorkerConfig config;
+  final VoidCallback onSwitchMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Magic Bracket — Offline'),
+        backgroundColor: const Color(0xFF111827),
+        actions: [
+          IconButton(
+            tooltip: 'Switch to Cloud Sync',
+            icon: const Icon(Icons.cloud_sync_outlined),
+            onPressed: () async {
+              await clearRememberedLaunchMode();
+              onSwitchMode();
+            },
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SizedBox(
+              height: 52,
+              child: FilledButton.icon(
+                icon: const Icon(Icons.add),
+                label: const Text('New simulation run'),
+                onPressed: () => _startNewRun(context),
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'Recent runs',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: _HistoryList(db: db, runner: runner, config: config),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _startNewRun(BuildContext context) async {
+    final precons = await loadBundledPrecons(config.forgePath);
+    if (!context.mounted) return;
+    if (precons.length < 4) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Only ${precons.length} precons found in ${config.forgePath}/res/Decks/Commander. Need at least 4.',
+          ),
+        ),
+      );
+      return;
+    }
+    final picked = await Navigator.of(context).push<List<PreconDeck>>(
+      MaterialPageRoute(builder: (_) => _DeckPickerScreen(precons: precons)),
+    );
+    if (picked == null || picked.length != 4) return;
+    if (!context.mounted) return;
+    final simCount = await Navigator.of(context).push<int>(
+      MaterialPageRoute(builder: (_) => _NewJobScreen(decks: picked)),
+    );
+    if (simCount == null || simCount <= 0) return;
+    final jobId = await db.createJob(
+      deckNames: picked.map((d) => d.displayName).toList(),
+      simCount: simCount,
+    );
+    // Fire-and-forget the run; the progress screen streams from the DB.
+    unawaited(runner.run(jobId));
+    if (!context.mounted) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => _JobScreen(db: db, jobId: jobId),
+      ),
+    );
+  }
+}
+
+class _HistoryList extends StatelessWidget {
+  const _HistoryList({
+    required this.db,
+    required this.runner,
+    required this.config,
+  });
+
+  final AppDb db;
+  final OfflineRunner runner;
+  final WorkerConfig config;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<Job>>(
+      // A 1-second poll is plenty for a small history list — drift
+      // doesn't expose a `watchAll` shortcut on `recentJobs` and we
+      // don't need true reactivity here.
+      stream: Stream.periodic(
+        const Duration(seconds: 1),
+      ).asyncMap((_) => db.recentJobs(limit: 50)),
+      initialData: const [],
+      builder: (context, snap) {
+        final jobs = snap.data ?? const [];
+        if (jobs.isEmpty) {
+          return const Center(
+            child: Text(
+              'No runs yet — kick off one above.',
+              style: TextStyle(color: Colors.white54),
+            ),
+          );
+        }
+        return ListView.separated(
+          itemCount: jobs.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 6),
+          itemBuilder: (context, i) => _JobRow(
+            job: jobs[i],
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => _JobScreen(db: db, jobId: jobs[i].id),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _JobRow extends StatelessWidget {
+  const _JobRow({required this.job, required this.onTap});
+
+  final Job job;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = job.totalSims == 0
+        ? 0.0
+        : job.completedSims / job.totalSims;
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: const Color(0xFF111827),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(
+                color: switch (job.state) {
+                  'COMPLETED' => const Color(0xFF34D399),
+                  'FAILED' => const Color(0xFFF87171),
+                  'RUNNING' => const Color(0xFF60A5FA),
+                  _ => const Color(0xFF6B7280),
+                },
+                borderRadius: BorderRadius.circular(5),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
               child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Icon(
-                    Icons.construction_outlined,
-                    color: Color(0xFF60A5FA),
-                    size: 48,
+                  Text(
+                    '#${job.id} • ${job.completedSims}/${job.totalSims} sims',
+                    style: const TextStyle(color: Colors.white, fontSize: 14),
                   ),
-                  const SizedBox(height: 16),
-                  const Text(
-                    'Offline mode is coming soon',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 22,
-                      fontWeight: FontWeight.w700,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 12),
-                  const Text(
-                    'A fully local deck picker, simulation runner, and '
-                    'results view are in active development. For now, '
-                    'switch to Cloud Sync to use the worker.',
-                    style: TextStyle(color: Colors.white70),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 32),
-                  FilledButton(
-                    onPressed: () async {
-                      await clearRememberedLaunchMode();
-                      onSwitchMode();
-                    },
-                    child: const Text('Switch to Cloud Sync'),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${job.deck1Name} · ${job.deck2Name} · ${job.deck3Name} · ${job.deck4Name}',
+                    style: const TextStyle(color: Colors.white54, fontSize: 11),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ],
               ),
             ),
-          ),
+            SizedBox(
+              width: 60,
+              child: LinearProgressIndicator(value: progress.clamp(0.0, 1.0)),
+            ),
+          ],
         ),
+      ),
+    );
+  }
+}
+
+// ── Deck picker (multi-select 4) ─────────────────────────────────
+
+class _DeckPickerScreen extends StatefulWidget {
+  const _DeckPickerScreen({required this.precons});
+
+  final List<PreconDeck> precons;
+
+  @override
+  State<_DeckPickerScreen> createState() => _DeckPickerScreenState();
+}
+
+class _DeckPickerScreenState extends State<_DeckPickerScreen> {
+  final Set<String> _picked = {};
+  String _search = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final filtered = widget.precons
+        .where(
+          (d) => d.displayName.toLowerCase().contains(_search.toLowerCase()),
+        )
+        .toList(growable: false);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Pick 4 decks (${_picked.length}/4)'),
+        backgroundColor: const Color(0xFF111827),
+        actions: [
+          TextButton(
+            onPressed: _picked.length == 4
+                ? () {
+                    final result = widget.precons
+                        .where((d) => _picked.contains(d.displayName))
+                        .toList(growable: false);
+                    Navigator.of(context).pop(result);
+                  }
+                : null,
+            child: const Text('Next'),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: TextField(
+              decoration: const InputDecoration(
+                hintText: 'Search precons',
+                prefixIcon: Icon(Icons.search),
+                isDense: true,
+              ),
+              onChanged: (v) => setState(() => _search = v),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: filtered.length,
+              itemBuilder: (context, i) {
+                final d = filtered[i];
+                final picked = _picked.contains(d.displayName);
+                return CheckboxListTile(
+                  value: picked,
+                  title: Text(d.displayName),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  onChanged: (v) {
+                    setState(() {
+                      if (v == true && _picked.length < 4) {
+                        _picked.add(d.displayName);
+                      } else {
+                        _picked.remove(d.displayName);
+                      }
+                    });
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── New job confirm (sim count) ──────────────────────────────────
+
+class _NewJobScreen extends StatefulWidget {
+  const _NewJobScreen({required this.decks});
+
+  final List<PreconDeck> decks;
+
+  @override
+  State<_NewJobScreen> createState() => _NewJobScreenState();
+}
+
+class _NewJobScreenState extends State<_NewJobScreen> {
+  int _sims = 10;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Confirm run'),
+        backgroundColor: const Color(0xFF111827),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Decks',
+              style: TextStyle(color: Colors.white70, fontSize: 13),
+            ),
+            const SizedBox(height: 6),
+            for (final d in widget.decks)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  '• ${d.displayName}',
+                  style: const TextStyle(color: Colors.white, fontSize: 15),
+                ),
+              ),
+            const SizedBox(height: 24),
+            Text(
+              'Simulations: $_sims',
+              style: const TextStyle(color: Colors.white70, fontSize: 13),
+            ),
+            Slider(
+              value: _sims.toDouble(),
+              min: 1,
+              max: 200,
+              divisions: 199,
+              label: '$_sims',
+              onChanged: (v) => setState(() => _sims = v.round()),
+            ),
+            const Spacer(),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(_sims),
+              child: const Text('Start'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Live progress + results for one job ──────────────────────────
+
+class _JobScreen extends StatelessWidget {
+  const _JobScreen({required this.db, required this.jobId});
+
+  final AppDb db;
+  final int jobId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Run #$jobId'),
+        backgroundColor: const Color(0xFF111827),
+      ),
+      body: StreamBuilder<Job?>(
+        stream: db.watchJob(jobId),
+        builder: (context, jobSnap) {
+          final job = jobSnap.data;
+          if (job == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return StreamBuilder<List<Sim>>(
+            stream: db.watchSimsForJob(jobId),
+            initialData: const [],
+            builder: (context, simsSnap) {
+              final sims = simsSnap.data ?? const [];
+              return _JobBody(job: job, sims: sims);
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _JobBody extends StatelessWidget {
+  const _JobBody({required this.job, required this.sims});
+
+  final Job job;
+  final List<Sim> sims;
+
+  @override
+  Widget build(BuildContext context) {
+    final decks = [job.deck1Name, job.deck2Name, job.deck3Name, job.deck4Name];
+    final wins = <String, int>{for (final d in decks) d: 0};
+    final winTurns = <String, List<int>>{for (final d in decks) d: []};
+    var failures = 0;
+    for (final s in sims) {
+      if (s.state == 'COMPLETED' && s.winnerDeckName != null) {
+        wins[s.winnerDeckName!] = (wins[s.winnerDeckName!] ?? 0) + 1;
+        if (s.winningTurn != null) {
+          winTurns[s.winnerDeckName!]!.add(s.winningTurn!);
+        }
+      } else if (s.state == 'FAILED') {
+        failures++;
+      }
+    }
+    final completed = sims
+        .where((s) => s.state == 'COMPLETED' || s.state == 'FAILED')
+        .length;
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              _StateBadge(state: job.state),
+              const SizedBox(width: 8),
+              Text(
+                '$completed / ${job.totalSims} sims complete'
+                '${failures > 0 ? "  •  $failures failed" : ""}',
+                style: const TextStyle(color: Colors.white, fontSize: 14),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          LinearProgressIndicator(
+            value: job.totalSims == 0 ? 0 : completed / job.totalSims,
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            'Win rate by deck',
+            style: TextStyle(color: Colors.white70, fontSize: 13),
+          ),
+          const SizedBox(height: 8),
+          for (final d in decks)
+            _DeckResultRow(
+              name: d,
+              wins: wins[d] ?? 0,
+              completed: completed - failures,
+              winTurns: winTurns[d] ?? const [],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StateBadge extends StatelessWidget {
+  const _StateBadge({required this.state});
+
+  final String state;
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = switch (state) {
+      'COMPLETED' => ('Done', const Color(0xFF34D399)),
+      'FAILED' => ('Failed', const Color(0xFFF87171)),
+      'RUNNING' => ('Running', const Color(0xFF60A5FA)),
+      _ => ('Pending', const Color(0xFF6B7280)),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.18),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(label, style: TextStyle(color: color, fontSize: 12)),
+    );
+  }
+}
+
+class _DeckResultRow extends StatelessWidget {
+  const _DeckResultRow({
+    required this.name,
+    required this.wins,
+    required this.completed,
+    required this.winTurns,
+  });
+
+  final String name;
+  final int wins;
+  final int completed;
+  final List<int> winTurns;
+
+  @override
+  Widget build(BuildContext context) {
+    final rate = completed == 0 ? 0.0 : wins / completed;
+    final avgTurn = winTurns.isEmpty
+        ? null
+        : winTurns.reduce((a, b) => a + b) / winTurns.length;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  name,
+                  style: const TextStyle(color: Colors.white, fontSize: 15),
+                ),
+              ),
+              Text(
+                '$wins win${wins == 1 ? "" : "s"}'
+                '${avgTurn != null ? "  •  avg turn ${avgTurn.toStringAsFixed(1)}" : ""}',
+                style: const TextStyle(color: Colors.white70, fontSize: 13),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(value: rate, minHeight: 6),
+          ),
+        ],
       ),
     );
   }

--- a/worker_flutter/lib/offline/offline_app.dart
+++ b/worker_flutter/lib/offline/offline_app.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 
 import '../config.dart';
 import '../launch/mode_picker_screen.dart';
@@ -34,6 +37,9 @@ class _OfflineAppState extends State<OfflineApp> {
     super.initState();
     _db = AppDb();
     _runner = OfflineRunner(db: _db, config: widget.config);
+    // Pick up any job that was mid-run last session. Sequentially-
+    // queued, runs in the background; the UI doesn't block on it.
+    unawaited(_runner.resumeInFlightJobs());
   }
 
   @override
@@ -120,7 +126,7 @@ class _HomeScreen extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             Expanded(
-              child: _HistoryList(db: db, runner: runner, config: config),
+              child: _HistoryList(db: db, runner: runner),
             ),
           ],
         ),
@@ -159,32 +165,24 @@ class _HomeScreen extends StatelessWidget {
     if (!context.mounted) return;
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (_) => _JobScreen(db: db, jobId: jobId),
+        builder: (_) => _JobScreen(db: db, runner: runner, jobId: jobId),
       ),
     );
   }
 }
 
 class _HistoryList extends StatelessWidget {
-  const _HistoryList({
-    required this.db,
-    required this.runner,
-    required this.config,
-  });
+  const _HistoryList({required this.db, required this.runner});
 
   final AppDb db;
   final OfflineRunner runner;
-  final WorkerConfig config;
 
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<List<Job>>(
-      // A 1-second poll is plenty for a small history list — drift
-      // doesn't expose a `watchAll` shortcut on `recentJobs` and we
-      // don't need true reactivity here.
-      stream: Stream.periodic(
-        const Duration(seconds: 1),
-      ).asyncMap((_) => db.recentJobs(limit: 50)),
+      // Drift's table watch fires on every relevant write — no polling,
+      // no 1-second staleness.
+      stream: db.watchRecentJobs(limit: 50),
       initialData: const [],
       builder: (context, snap) {
         final jobs = snap.data ?? const [];
@@ -203,7 +201,8 @@ class _HistoryList extends StatelessWidget {
             job: jobs[i],
             onTap: () => Navigator.of(context).push(
               MaterialPageRoute(
-                builder: (_) => _JobScreen(db: db, jobId: jobs[i].id),
+                builder: (_) =>
+                    _JobScreen(db: db, runner: runner, jobId: jobs[i].id),
               ),
             ),
           ),
@@ -427,9 +426,14 @@ class _NewJobScreenState extends State<_NewJobScreen> {
 // ── Live progress + results for one job ──────────────────────────
 
 class _JobScreen extends StatelessWidget {
-  const _JobScreen({required this.db, required this.jobId});
+  const _JobScreen({
+    required this.db,
+    required this.runner,
+    required this.jobId,
+  });
 
   final AppDb db;
+  final OfflineRunner runner;
   final int jobId;
 
   @override
@@ -438,6 +442,48 @@ class _JobScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text('Run #$jobId'),
         backgroundColor: const Color(0xFF111827),
+        actions: [
+          StreamBuilder<Job?>(
+            stream: db.watchJob(jobId),
+            builder: (context, snap) {
+              final job = snap.data;
+              if (job == null) return const SizedBox.shrink();
+              final canCancel =
+                  job.state == 'PENDING' || job.state == 'RUNNING';
+              if (!canCancel) return const SizedBox.shrink();
+              return TextButton.icon(
+                icon: const Icon(Icons.cancel_outlined),
+                label: const Text('Cancel'),
+                onPressed: () async {
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: const Text('Cancel run?'),
+                      content: const Text(
+                        'Any sim currently running will be killed; '
+                        'remaining queued sims will be marked cancelled.',
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(ctx).pop(false),
+                          child: const Text('Keep running'),
+                        ),
+                        TextButton(
+                          style: TextButton.styleFrom(
+                            foregroundColor: const Color(0xFFF87171),
+                          ),
+                          onPressed: () => Navigator.of(ctx).pop(true),
+                          child: const Text('Cancel run'),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (confirmed == true) await runner.cancel(jobId);
+                },
+              );
+            },
+          ),
+        ],
       ),
       body: StreamBuilder<Job?>(
         stream: db.watchJob(jobId),
@@ -471,7 +517,7 @@ class _JobBody extends StatelessWidget {
     final decks = [job.deck1Name, job.deck2Name, job.deck3Name, job.deck4Name];
     final wins = <String, int>{for (final d in decks) d: 0};
     final winTurns = <String, List<int>>{for (final d in decks) d: []};
-    var failures = 0;
+    final failedSims = <Sim>[];
     for (final s in sims) {
       if (s.state == 'COMPLETED' && s.winnerDeckName != null) {
         wins[s.winnerDeckName!] = (wins[s.winnerDeckName!] ?? 0) + 1;
@@ -479,46 +525,168 @@ class _JobBody extends StatelessWidget {
           winTurns[s.winnerDeckName!]!.add(s.winningTurn!);
         }
       } else if (s.state == 'FAILED') {
-        failures++;
+        failedSims.add(s);
       }
     }
     final completed = sims
         .where((s) => s.state == 'COMPLETED' || s.state == 'FAILED')
         .length;
-    return Padding(
+    final failures = failedSims.length;
+    return ListView(
       padding: const EdgeInsets.all(20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            children: [
-              _StateBadge(state: job.state),
-              const SizedBox(width: 8),
-              Text(
+      children: [
+        Row(
+          children: [
+            _StateBadge(state: job.state),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
                 '$completed / ${job.totalSims} sims complete'
                 '${failures > 0 ? "  •  $failures failed" : ""}',
                 style: const TextStyle(color: Colors.white, fontSize: 14),
               ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          LinearProgressIndicator(
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(3),
+          child: LinearProgressIndicator(
             value: job.totalSims == 0 ? 0 : completed / job.totalSims,
+            minHeight: 6,
           ),
-          const SizedBox(height: 24),
-          const Text(
-            'Win rate by deck',
-            style: TextStyle(color: Colors.white70, fontSize: 13),
+        ),
+        const SizedBox(height: 24),
+        const Text(
+          'Win rate by deck',
+          style: TextStyle(color: Colors.white70, fontSize: 13),
+        ),
+        const SizedBox(height: 8),
+        for (final d in decks)
+          _DeckResultRow(
+            name: d,
+            wins: wins[d] ?? 0,
+            completed: completed - failures,
+            winTurns: winTurns[d] ?? const [],
           ),
-          const SizedBox(height: 8),
-          for (final d in decks)
-            _DeckResultRow(
-              name: d,
-              wins: wins[d] ?? 0,
-              completed: completed - failures,
-              winTurns: winTurns[d] ?? const [],
+        if (failedSims.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          _FailedSimsCard(failedSims: failedSims),
+        ],
+      ],
+    );
+  }
+}
+
+/// Collapsible card that lists each failed sim's error message + a
+/// "View log" button if the runner persisted stdout. Without this the
+/// user only sees "$N failed" with no path to root-cause.
+class _FailedSimsCard extends StatelessWidget {
+  const _FailedSimsCard({required this.failedSims});
+
+  final List<Sim> failedSims;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: const Color(0xFF111827),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: const BorderSide(color: Color(0xFF374151)),
+      ),
+      child: ExpansionTile(
+        iconColor: Colors.white70,
+        collapsedIconColor: Colors.white70,
+        title: Text(
+          '${failedSims.length} failed sim${failedSims.length == 1 ? "" : "s"}',
+          style: const TextStyle(color: Colors.white, fontSize: 14),
+        ),
+        children: [
+          for (final s in failedSims)
+            ListTile(
+              dense: true,
+              title: Text(
+                'Sim #${s.simIndex}',
+                style: const TextStyle(color: Colors.white, fontSize: 13),
+              ),
+              subtitle: Text(
+                s.errorMessage ?? '(no error message)',
+                style: const TextStyle(color: Color(0xFFFCA5A5), fontSize: 12),
+              ),
+              trailing: s.logRelPath == null
+                  ? null
+                  : TextButton(
+                      onPressed: () =>
+                          _showLog(context, sim: s, relPath: s.logRelPath!),
+                      child: const Text('View log'),
+                    ),
             ),
         ],
+      ),
+    );
+  }
+
+  Future<void> _showLog(
+    BuildContext context, {
+    required Sim sim,
+    required String relPath,
+  }) async {
+    // The logs dir lives at `config.logsPath` — we look it up via the
+    // app-support directory the same way the installer does. Keeps
+    // this widget independent of WorkerConfig.
+    final appSupport = (await getApplicationSupportDirectory()).path;
+    final path = p.join(appSupport, 'sim-logs', relPath);
+    String body;
+    try {
+      body = await File(path).readAsString();
+    } catch (e) {
+      body = 'Failed to read log at $path: $e';
+    }
+    if (!context.mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => Dialog(
+        backgroundColor: const Color(0xFF111827),
+        child: Container(
+          width: 800,
+          height: 600,
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Sim #${sim.simIndex} log',
+                      style: const TextStyle(color: Colors.white, fontSize: 16),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    color: Colors.white70,
+                    onPressed: () => Navigator.of(ctx).pop(),
+                  ),
+                ],
+              ),
+              const Divider(color: Color(0xFF374151)),
+              Expanded(
+                child: Scrollbar(
+                  child: SingleChildScrollView(
+                    child: SelectableText(
+                      body,
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontFamily: 'Menlo',
+                        fontSize: 11,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/worker_flutter/lib/offline/offline_runner.dart
+++ b/worker_flutter/lib/offline/offline_runner.dart
@@ -1,18 +1,22 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+
 import '../config.dart';
 import '../models/sim.dart';
 import '../worker/sim_runner.dart';
 import 'db/app_db.dart';
 import 'deck_source.dart';
 
-/// Drives a single offline job from PENDING through COMPLETED.
+/// Drives offline jobs from PENDING through COMPLETED. Local mirror of
+/// the cloud-mode `WorkerEngine` — talks to the on-disk `AppDb`
+/// instead of Firestore and uses bundled precons from
+/// `<forgePath>/res/Decks/Commander/`.
 ///
-/// Mirrors the structure of the cloud-mode `WorkerEngine` but talks to
-/// the local `AppDb` instead of Firestore, and uses bundled precons
-/// from `forgePath/res/Decks/Commander/` rather than staging deck
-/// content into `decksPath` from a job document.
+/// One `OfflineRunner` per app instance; tracks in-flight jobs in a
+/// `_cancels` map keyed by jobId so the UI can cancel a long run.
 class OfflineRunner {
   OfflineRunner({
     required this.db,
@@ -26,48 +30,119 @@ class OfflineRunner {
   final WorkerConfig config;
   final SimRunner _runner;
 
+  /// Cancel signals keyed by jobId. Cleared when the run loop exits.
+  final Map<int, Completer<void>> _cancels = {};
+
+  /// Trigger cancellation of `jobId` if currently running.
+  /// Marks any remaining PENDING sims as CANCELLED and flips the job
+  /// state. SimRunner's already-running Java child gets a SIGTERM and
+  /// returns a `'cancelled'` `SimResult`.
+  Future<void> cancel(int jobId) async {
+    final completer = _cancels[jobId];
+    if (completer != null && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
+  /// True if `jobId` is currently being driven by this runner.
+  bool isRunning(int jobId) => _cancels.containsKey(jobId);
+
+  /// Find any jobs left RUNNING (or with PENDING sims) from a prior
+  /// session and re-drive them. Called on app launch — without this,
+  /// closing the app mid-run permanently strands those jobs.
+  Future<void> resumeInFlightJobs() async {
+    final all = await db.recentJobs(limit: 100);
+    for (final job in all) {
+      if (job.state == 'RUNNING' ||
+          (job.completedSims < job.totalSims &&
+              job.state != 'CANCELLED' &&
+              job.state != 'FAILED')) {
+        // Don't await — start each in parallel-ish (the actual sim
+        // runs are sequential per job, but multiple jobs interleave).
+        unawaited(run(job.id));
+      }
+    }
+  }
+
   /// Run every PENDING sim of `jobId` sequentially. Returns when the
-  /// job is COMPLETED (or marked FAILED on a hard error). UI watches
-  /// the AppDb stream for per-sim progress.
+  /// job is COMPLETED / CANCELLED / FAILED. UI watches the AppDb
+  /// stream for per-sim progress.
   Future<void> run(int jobId) async {
+    if (_cancels.containsKey(jobId)) return; // already running
+    final cancel = Completer<void>();
+    _cancels[jobId] = cancel;
+    try {
+      await _drive(jobId, cancel);
+    } finally {
+      _cancels.remove(jobId);
+    }
+  }
+
+  Future<void> _drive(int jobId, Completer<void> cancel) async {
     final job = await db.jobById(jobId);
     if (job == null) return;
 
     await db.updateJobState(jobId, 'RUNNING');
 
-    // Resolve the bundled precon paths once. The .dck files live under
-    // Forge's data dir; SimRunner expects filenames it can pass to
-    // forge.jar with `-d`, so we copy/symlink into `config.decksPath`
-    // (Forge's user decks dir) if they're not already present.
     final precons = await loadBundledPrecons(config.forgePath);
     final byName = {for (final d in precons) d.displayName: d};
-    final deckFilenames = <String>[];
-    for (final name in [
+
+    // Resolve all four decks first so a missing precon fails the whole
+    // job atomically rather than producing partial results.
+    final picked = <PreconDeck>[];
+    final declared = [
       job.deck1Name,
       job.deck2Name,
       job.deck3Name,
       job.deck4Name,
-    ]) {
+    ];
+    for (final name in declared) {
       final precon = byName[name];
       if (precon == null) {
-        await db.updateJobState(jobId, 'FAILED');
+        await _failJob(jobId, 'precon not installed: $name');
         return;
       }
+      picked.add(precon);
+    }
+
+    // Stage decks into Forge's user decks dir (idempotent).
+    final deckFilenames = <String>[];
+    for (final precon in picked) {
       deckFilenames.add(await _stageDeck(precon));
     }
+    final filenameToDisplay = {
+      for (var i = 0; i < picked.length; i++)
+        deckFilenames[i].replaceAll(
+          RegExp(r'\.dck$', caseSensitive: false),
+          '',
+        ): picked[i].displayName,
+    };
 
     final sims = await db.simsForJob(jobId);
     for (final sim in sims.where((s) => s.state == 'PENDING')) {
-      await _runSim(sim, deckFilenames);
+      if (cancel.isCompleted) {
+        await _cancelRemaining(jobId);
+        return;
+      }
+      await _runSim(sim, deckFilenames, filenameToDisplay, cancel.future);
     }
 
     final fresh = await db.jobById(jobId);
-    if (fresh != null && fresh.completedSims >= fresh.totalSims) {
-      await db.updateJobState(jobId, 'COMPLETED');
+    if (fresh != null &&
+        fresh.state != 'CANCELLED' &&
+        fresh.state != 'FAILED') {
+      if (fresh.completedSims >= fresh.totalSims) {
+        await db.updateJobState(jobId, 'COMPLETED');
+      }
     }
   }
 
-  Future<void> _runSim(Sim sim, List<String> deckFilenames) async {
+  Future<void> _runSim(
+    Sim sim,
+    List<String> deckFilenames,
+    Map<String, String> filenameToDisplay,
+    Future<void> cancel,
+  ) async {
     await db.markSimRunning(sim.id);
     final result = await _runner.runOne(
       job: JobInfo(
@@ -75,15 +150,15 @@ class OfflineRunner {
         deckFilenames: deckFilenames,
         simulationsPerJob: 1,
       ),
+      cancelSignal: cancel,
     );
 
     final logRelPath = await _maybePersistLog(sim, result.logText);
 
     if (result.success && result.winners.isNotEmpty) {
-      // Forge's "Ai(N)-<deck-name>" winner format. Map it back to the
-      // job's deck names by matching the suffix.
-      final winnerRaw = result.winners.first;
-      final winnerDeck = _matchDeck(winnerRaw, deckFilenames) ?? winnerRaw;
+      final winnerDeck =
+          _matchDeck(result.winners.first, filenameToDisplay) ??
+          result.winners.first;
       await db.markSimCompleted(
         sim.id,
         winnerDeckName: winnerDeck,
@@ -103,47 +178,74 @@ class OfflineRunner {
     }
   }
 
-  /// Map "Ai(2)-Marchesa-control-upgraded" → "Marchesa-control-upgraded.dck"
-  /// → the deck name we displayed in the picker. Falls back to the raw
-  /// Forge string if nothing matches.
-  String? _matchDeck(String forgeWinnerName, List<String> deckFilenames) {
-    final stripped = forgeWinnerName
+  /// Map `"Ai(2)-Marchesa-control-upgraded"` back to the picker's
+  /// display name (e.g. `"Marchesa Control Upgraded"`). Without this
+  /// round-trip the win-rate UI keys on the Forge-internal name and
+  /// the deck rows stay at zero.
+  String? _matchDeck(
+    String forgeWinner,
+    Map<String, String> filenameToDisplay,
+  ) {
+    final stripped = forgeWinner
         .replaceFirst(RegExp(r'^Ai\(\d+\)-'), '')
         .replaceAll(' ', '-');
-    for (final f in deckFilenames) {
-      final base = f.endsWith('.dck') ? f.substring(0, f.length - 4) : f;
-      if (base == stripped || base.toLowerCase() == stripped.toLowerCase()) {
-        return base;
-      }
+    // Direct hit on the filename base.
+    if (filenameToDisplay.containsKey(stripped)) {
+      return filenameToDisplay[stripped];
+    }
+    // Case-insensitive fallback.
+    final low = stripped.toLowerCase();
+    for (final entry in filenameToDisplay.entries) {
+      if (entry.key.toLowerCase() == low) return entry.value;
     }
     return null;
   }
 
-  /// Stage a precon .dck into `config.decksPath` (Forge's user decks
-  /// dir) if it isn't already there. Returns the filename SimRunner
-  /// should pass to `-d`.
+  /// Stage a precon .dck into `config.decksPath` (idempotent).
   Future<String> _stageDeck(PreconDeck precon) async {
-    final dest = File(
-      '${config.decksPath}${Platform.pathSeparator}${precon.filename}',
-    );
+    final dest = File(p.join(config.decksPath, precon.filename));
     if (!dest.existsSync()) {
       dest.parent.createSync(recursive: true);
-      dest.writeAsStringSync(File(precon.path).readAsStringSync());
+      File(precon.path).copySync(dest.path);
     }
     return precon.filename;
   }
 
-  /// Write the sim's stdout to `<logsPath>/offline-<simId>.log` and
-  /// return the path relative to the logs dir. Skipped on empty logs.
+  /// Persist a sim's stdout to `<logsPath>/offline-<jobId>-<idx>.log`.
+  /// Returns the filename relative to `logsPath`. Errors are logged
+  /// (debug-only) and return null so the run continues.
   Future<String?> _maybePersistLog(Sim sim, String logText) async {
     if (logText.isEmpty) return null;
     final relName = 'offline-${sim.jobId}-${sim.simIndex}.log';
-    final path = '${config.logsPath}${Platform.pathSeparator}$relName';
+    final path = p.join(config.logsPath, relName);
     try {
       File(path).writeAsStringSync(logText);
       return relName;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('OfflineRunner: failed to persist log for sim ${sim.id}: $e');
       return null;
     }
+  }
+
+  /// Mark every still-PENDING sim of `jobId` as FAILED with the given
+  /// reason, then flip the job to FAILED. Used when a job can't run
+  /// at all (e.g. missing precon).
+  Future<void> _failJob(int jobId, String reason) async {
+    final sims = await db.simsForJob(jobId);
+    for (final sim in sims.where((s) => s.state == 'PENDING')) {
+      await db.markSimFailed(sim.id, error: reason, durationMs: 0);
+    }
+    await db.updateJobState(jobId, 'FAILED');
+  }
+
+  /// Cancel-path equivalent of `_failJob`: mark PENDING sims as
+  /// CANCELLED (not FAILED — distinguishes user-initiated stops from
+  /// crashes) and flip the job to CANCELLED.
+  Future<void> _cancelRemaining(int jobId) async {
+    final sims = await db.simsForJob(jobId);
+    for (final sim in sims.where((s) => s.state == 'PENDING')) {
+      await db.markSimFailed(sim.id, error: 'cancelled', durationMs: 0);
+    }
+    await db.updateJobState(jobId, 'CANCELLED');
   }
 }

--- a/worker_flutter/lib/offline/offline_runner.dart
+++ b/worker_flutter/lib/offline/offline_runner.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../config.dart';
+import '../models/sim.dart';
+import '../worker/sim_runner.dart';
+import 'db/app_db.dart';
+import 'deck_source.dart';
+
+/// Drives a single offline job from PENDING through COMPLETED.
+///
+/// Mirrors the structure of the cloud-mode `WorkerEngine` but talks to
+/// the local `AppDb` instead of Firestore, and uses bundled precons
+/// from `forgePath/res/Decks/Commander/` rather than staging deck
+/// content into `decksPath` from a job document.
+class OfflineRunner {
+  OfflineRunner({
+    required this.db,
+    required this.config,
+    SimRunner? runnerOverride,
+  }) : _runner =
+           runnerOverride ??
+           SimRunner(javaPath: config.javaPath, forgePath: config.forgePath);
+
+  final AppDb db;
+  final WorkerConfig config;
+  final SimRunner _runner;
+
+  /// Run every PENDING sim of `jobId` sequentially. Returns when the
+  /// job is COMPLETED (or marked FAILED on a hard error). UI watches
+  /// the AppDb stream for per-sim progress.
+  Future<void> run(int jobId) async {
+    final job = await db.jobById(jobId);
+    if (job == null) return;
+
+    await db.updateJobState(jobId, 'RUNNING');
+
+    // Resolve the bundled precon paths once. The .dck files live under
+    // Forge's data dir; SimRunner expects filenames it can pass to
+    // forge.jar with `-d`, so we copy/symlink into `config.decksPath`
+    // (Forge's user decks dir) if they're not already present.
+    final precons = await loadBundledPrecons(config.forgePath);
+    final byName = {for (final d in precons) d.displayName: d};
+    final deckFilenames = <String>[];
+    for (final name in [
+      job.deck1Name,
+      job.deck2Name,
+      job.deck3Name,
+      job.deck4Name,
+    ]) {
+      final precon = byName[name];
+      if (precon == null) {
+        await db.updateJobState(jobId, 'FAILED');
+        return;
+      }
+      deckFilenames.add(await _stageDeck(precon));
+    }
+
+    final sims = await db.simsForJob(jobId);
+    for (final sim in sims.where((s) => s.state == 'PENDING')) {
+      await _runSim(sim, deckFilenames);
+    }
+
+    final fresh = await db.jobById(jobId);
+    if (fresh != null && fresh.completedSims >= fresh.totalSims) {
+      await db.updateJobState(jobId, 'COMPLETED');
+    }
+  }
+
+  Future<void> _runSim(Sim sim, List<String> deckFilenames) async {
+    await db.markSimRunning(sim.id);
+    final result = await _runner.runOne(
+      job: JobInfo(
+        jobId: 'offline-${sim.jobId}',
+        deckFilenames: deckFilenames,
+        simulationsPerJob: 1,
+      ),
+    );
+
+    final logRelPath = await _maybePersistLog(sim, result.logText);
+
+    if (result.success && result.winners.isNotEmpty) {
+      // Forge's "Ai(N)-<deck-name>" winner format. Map it back to the
+      // job's deck names by matching the suffix.
+      final winnerRaw = result.winners.first;
+      final winnerDeck = _matchDeck(winnerRaw, deckFilenames) ?? winnerRaw;
+      await db.markSimCompleted(
+        sim.id,
+        winnerDeckName: winnerDeck,
+        winningTurn: result.winningTurns.isEmpty
+            ? null
+            : result.winningTurns.first,
+        durationMs: result.durationMs,
+        logRelPath: logRelPath,
+      );
+    } else {
+      await db.markSimFailed(
+        sim.id,
+        error: result.errorMessage ?? 'no winner detected',
+        durationMs: result.durationMs,
+        logRelPath: logRelPath,
+      );
+    }
+  }
+
+  /// Map "Ai(2)-Marchesa-control-upgraded" → "Marchesa-control-upgraded.dck"
+  /// → the deck name we displayed in the picker. Falls back to the raw
+  /// Forge string if nothing matches.
+  String? _matchDeck(String forgeWinnerName, List<String> deckFilenames) {
+    final stripped = forgeWinnerName
+        .replaceFirst(RegExp(r'^Ai\(\d+\)-'), '')
+        .replaceAll(' ', '-');
+    for (final f in deckFilenames) {
+      final base = f.endsWith('.dck') ? f.substring(0, f.length - 4) : f;
+      if (base == stripped || base.toLowerCase() == stripped.toLowerCase()) {
+        return base;
+      }
+    }
+    return null;
+  }
+
+  /// Stage a precon .dck into `config.decksPath` (Forge's user decks
+  /// dir) if it isn't already there. Returns the filename SimRunner
+  /// should pass to `-d`.
+  Future<String> _stageDeck(PreconDeck precon) async {
+    final dest = File(
+      '${config.decksPath}${Platform.pathSeparator}${precon.filename}',
+    );
+    if (!dest.existsSync()) {
+      dest.parent.createSync(recursive: true);
+      dest.writeAsStringSync(File(precon.path).readAsStringSync());
+    }
+    return precon.filename;
+  }
+
+  /// Write the sim's stdout to `<logsPath>/offline-<simId>.log` and
+  /// return the path relative to the logs dir. Skipped on empty logs.
+  Future<String?> _maybePersistLog(Sim sim, String logText) async {
+    if (logText.isEmpty) return null;
+    final relName = 'offline-${sim.jobId}-${sim.simIndex}.log';
+    final path = '${config.logsPath}${Platform.pathSeparator}$relName';
+    try {
+      File(path).writeAsStringSync(logText);
+      return relName;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/worker_flutter/lib/worker/worker_engine.dart
+++ b/worker_flutter/lib/worker/worker_engine.dart
@@ -124,20 +124,31 @@ class WorkerEngine {
     // Listen to PENDING sims across all jobs. Every time the listener
     // fires (a new PENDING sim appears, or an existing one's state
     // changes) we try to claim if we have capacity.
+    //
+    // Listener errors get printed AND surfaced via lastError on the
+    // engine state. Without the print, a firestore.rules misconfig
+    // shows up as "worker mysteriously idle" with no log trail.
     try {
       _pendingSub = firestore
           .collectionGroup('simulations')
           .where('state', isEqualTo: 'PENDING')
           .snapshots()
           .listen(
-            (_) => _tryClaimLoop(),
+            (snap) {
+              debugPrint(
+                'WorkerEngine: PENDING listener fired with ${snap.docs.length} doc(s)',
+              );
+              _tryClaimLoop();
+            },
             onError: (Object err) {
+              debugPrint('WorkerEngine: PENDING listener error: $err');
               _stateSubject.add(
                 currentState.copyWith(lastError: err.toString()),
               );
             },
           );
     } catch (e) {
+      debugPrint('WorkerEngine: listener setup failed: $e');
       _stateSubject.add(currentState.copyWith(lastError: 'listener setup: $e'));
     }
   }

--- a/worker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/worker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import firebase_core
 import firebase_storage
 import screen_retriever_macos
 import shared_preferences_foundation
+import sqlite3_flutter_libs
 import tray_manager
 import window_manager
 
@@ -23,6 +24,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/worker_flutter/macos/Podfile.lock
+++ b/worker_flutter/macos/Podfile.lock
@@ -1188,6 +1188,9 @@ PODS:
     - abseil/meta/type_traits
     - abseil/xcprivacy
   - abseil/xcprivacy (1.20240722.0)
+  - auto_updater_macos (0.0.1):
+    - FlutterMacOS
+    - Sparkle
   - BoringSSL-GRPC (0.0.37):
     - BoringSSL-GRPC/Implementation (= 0.0.37)
     - BoringSSL-GRPC/Interface (= 0.0.37)
@@ -1396,12 +1399,39 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - Sparkle (2.9.1)
+  - sqlite3 (3.52.0):
+    - sqlite3/common (= 3.52.0)
+  - sqlite3/common (3.52.0)
+  - sqlite3/dbstatvtab (3.52.0):
+    - sqlite3/common
+  - sqlite3/fts5 (3.52.0):
+    - sqlite3/common
+  - sqlite3/math (3.52.0):
+    - sqlite3/common
+  - sqlite3/perf-threadsafe (3.52.0):
+    - sqlite3/common
+  - sqlite3/rtree (3.52.0):
+    - sqlite3/common
+  - sqlite3/session (3.52.0):
+    - sqlite3/common
+  - sqlite3_flutter_libs (0.0.1):
+    - Flutter
+    - FlutterMacOS
+    - sqlite3 (~> 3.52.0)
+    - sqlite3/dbstatvtab
+    - sqlite3/fts5
+    - sqlite3/math
+    - sqlite3/perf-threadsafe
+    - sqlite3/rtree
+    - sqlite3/session
   - tray_manager (0.0.1):
     - FlutterMacOS
   - window_manager (0.2.0):
     - FlutterMacOS
 
 DEPENDENCIES:
+  - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
   - cloud_firestore (from `Flutter/ephemeral/.symlinks/plugins/cloud_firestore/macos`)
   - firebase_auth (from `Flutter/ephemeral/.symlinks/plugins/firebase_auth/macos`)
   - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
@@ -1409,6 +1439,7 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
@@ -1433,8 +1464,12 @@ SPEC REPOS:
     - GTMSessionFetcher
     - leveldb-library
     - nanopb
+    - Sparkle
+    - sqlite3
 
 EXTERNAL SOURCES:
+  auto_updater_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos
   cloud_firestore:
     :path: Flutter/ephemeral/.symlinks/plugins/cloud_firestore/macos
   firebase_auth:
@@ -1449,6 +1484,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  sqlite3_flutter_libs:
+    :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin
   tray_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/tray_manager/macos
   window_manager:
@@ -1456,6 +1493,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
+  auto_updater_macos: 3a42f1a06be6981f1a18be37e6e7bf86aa732118
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
   cloud_firestore: 92bf414ac4a12c1008efa35a70ffe988f90cf740
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
@@ -1481,6 +1519,9 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
+  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
+  sqlite3_flutter_libs: b3e120efe9a82017e5552a620f696589ed4f62ab
   tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166
   window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 

--- a/worker_flutter/pubspec.lock
+++ b/worker_flutter/pubspec.lock
@@ -153,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -161,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -257,6 +273,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
+  drift:
+    dependency: "direct main"
+    description:
+      name: drift
+      sha256: "8033500116b24398fba0cca0369cc31678cd627c01e41753a61186911cea743e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.33.0"
+  drift_dev:
+    dependency: "direct dev"
+    description:
+      name: drift_dev
+      sha256: b3dd5b75e30522a91da8abda9f5bb17230cb038097f6d15fa75d42bb563428aa
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.33.0"
   equatable:
     dependency: transitive
     description:
@@ -633,7 +665,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -744,6 +776,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   record_use:
     dependency: transitive
     description:
@@ -909,6 +949,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: "56da3e13ed7d28a66f930aa2b2b29db6736a233f08283326e96321dd812030f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  sqlite3_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlite3_flutter_libs
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.42"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: ecdc06d4a7d79dcbc928d99afd2f7f5b0f98a637c46f89be83d911617f759978
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.44.4"
   stack_trace:
     dependency: transitive
     description:

--- a/worker_flutter/pubspec.yaml
+++ b/worker_flutter/pubspec.yaml
@@ -38,12 +38,18 @@ dependencies:
   # macOS app self-update (Sparkle wrapper).
   auto_updater: ^1.0.0
 
+  # Offline-mode local persistence (drift = type-safe SQLite for Flutter).
+  drift: ^2.20.0
+  sqlite3_flutter_libs: ^0.5.24
+  path: ^1.9.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
   mockito: ^5.4.5
   build_runner: ^2.4.13
+  drift_dev: ^2.20.0
   fake_cloud_firestore: ^3.1.0
   firebase_auth_mocks: ^0.14.1
 

--- a/worker_flutter/windows/flutter/generated_plugin_registrant.cc
+++ b/worker_flutter/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_storage/firebase_storage_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   TrayManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("TrayManagerPlugin"));
   WindowManagerPluginRegisterWithRegistrar(

--- a/worker_flutter/windows/flutter/generated_plugins.cmake
+++ b/worker_flutter/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   firebase_storage
   screen_retriever_windows
+  sqlite3_flutter_libs
   tray_manager
   window_manager
 )


### PR DESCRIPTION
## Summary

Replaces the "coming soon" offline-mode placeholder with a working local-only client. Pick precons → set sim count → watch live results, all from a single screen flow.

## What's new

| Layer | What |
|---|---|
| `lib/offline/db/app_db.dart` | drift schema (Jobs / Sims / Settings) + atomic state-machine helpers |
| `lib/offline/deck_source.dart` | reads bundled precons from `<forgePath>/res/Decks/Commander/*.dck` |
| `lib/offline/offline_runner.dart` | local equivalent of `WorkerEngine` — drives PENDING sims through `SimRunner`, writes back to `AppDb` |
| `lib/offline/offline_app.dart` | full UI: home + deck picker + confirm + live job + results |

## Side fixes in this PR

- Mode picker RenderFlex overflow (the yellow stripes you saw on both cards) — tightened paddings + wrapped bullets in `Flexible` so cards size safely.
- `WorkerEngine` listener: now `debugPrint`s on every tick + on error, so the next time the worker doesn't pick up jobs we have a log trail to follow (separately, see PR #195 for the rules-side root cause).

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` 18/18 pass (no DB-touching tests yet)
- [ ] Manual: launch offline mode, pick 4 precons, set sim count to 5, watch results stream in

🤖 Generated with [Claude Code](https://claude.com/claude-code)