### PR TITLE
feat(cloud): browse + drill into jobs from the desktop app

### DIFF
--- a/worker_flutter/lib/cloud/cloud_job_detail_screen.dart
+++ b/worker_flutter/lib/cloud/cloud_job_detail_screen.dart
@@ -1,0 +1,304 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+/// Read-only view of one cloud job. Mirrors the spine of the web
+/// frontend's `JobStatus.tsx` — job metadata, progress, per-deck win
+/// counts, and the per-sim grid. Skips actions (cancel / delete /
+/// resubmit) because they all require an authenticated user.
+class CloudJobDetailScreen extends StatelessWidget {
+  const CloudJobDetailScreen({super.key, required this.jobId});
+
+  final String jobId;
+
+  @override
+  Widget build(BuildContext context) {
+    final jobRef = FirebaseFirestore.instance.collection('jobs').doc(jobId);
+    final simsQuery = jobRef.collection('simulations').orderBy('index');
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Job ${jobId.substring(0, 8)}…'),
+        backgroundColor: const Color(0xFF111827),
+      ),
+      body: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+        stream: jobRef.snapshots(),
+        builder: (context, jobSnap) {
+          if (jobSnap.hasError) {
+            return _ErrorMessage(error: jobSnap.error.toString());
+          }
+          if (!jobSnap.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final job = jobSnap.data!.data();
+          if (job == null) {
+            return const _ErrorMessage(error: 'Job not found.');
+          }
+          return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+            stream: simsQuery.snapshots(),
+            builder: (context, simsSnap) {
+              final sims = (simsSnap.data?.docs ?? const [])
+                  .map((d) => d.data())
+                  .toList(growable: false);
+              return _Body(job: job, sims: sims);
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.job, required this.sims});
+
+  final Map<String, dynamic> job;
+  final List<Map<String, dynamic>> sims;
+
+  @override
+  Widget build(BuildContext context) {
+    final status = (job['status'] as String?) ?? 'QUEUED';
+    final deckNames = _deckNames(job);
+    final completed = (job['completedSimCount'] as num?)?.toInt() ?? 0;
+    final total = (job['totalSimCount'] as num?)?.toInt() ?? sims.length;
+    final progress = total == 0 ? 0.0 : (completed / total).clamp(0.0, 1.0);
+
+    // Aggregate per-deck win counts + win turns from finished sims.
+    final wins = <String, int>{for (final d in deckNames) d: 0};
+    final winTurns = <String, List<int>>{for (final d in deckNames) d: []};
+    var failed = 0;
+    for (final s in sims) {
+      final state = (s['state'] as String?) ?? '';
+      if (state == 'COMPLETED') {
+        final winner = (s['winner'] as String?) ?? '';
+        final match = _matchDeck(winner, deckNames);
+        if (match != null) {
+          wins[match] = (wins[match] ?? 0) + 1;
+          final t = (s['winningTurn'] as num?)?.toInt();
+          if (t != null) winTurns[match]!.add(t);
+        }
+      } else if (state == 'FAILED') {
+        failed++;
+      }
+    }
+    final completedSims = sims
+        .where((s) => s['state'] == 'COMPLETED' || s['state'] == 'FAILED')
+        .length;
+
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        Row(
+          children: [
+            _StatusBadge(status: status),
+            const SizedBox(width: 10),
+            Text(
+              '$completedSims / $total sims'
+              '${failed > 0 ? "  •  $failed failed" : ""}',
+              style: const TextStyle(color: Colors.white70),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(3),
+          child: LinearProgressIndicator(value: progress, minHeight: 6),
+        ),
+        const SizedBox(height: 24),
+        const Text(
+          'Win rate by deck',
+          style: TextStyle(color: Colors.white70, fontSize: 13),
+        ),
+        const SizedBox(height: 8),
+        for (final d in deckNames)
+          _DeckRow(
+            name: d,
+            wins: wins[d] ?? 0,
+            // exclude failures from rate denominator
+            completed: completedSims - failed,
+            winTurns: winTurns[d] ?? const [],
+          ),
+        const SizedBox(height: 24),
+        Text(
+          'Simulations (${sims.length})',
+          style: const TextStyle(color: Colors.white70, fontSize: 13),
+        ),
+        const SizedBox(height: 8),
+        _SimulationGrid(sims: sims),
+      ],
+    );
+  }
+}
+
+class _DeckRow extends StatelessWidget {
+  const _DeckRow({
+    required this.name,
+    required this.wins,
+    required this.completed,
+    required this.winTurns,
+  });
+
+  final String name;
+  final int wins;
+  final int completed;
+  final List<int> winTurns;
+
+  @override
+  Widget build(BuildContext context) {
+    final rate = completed == 0 ? 0.0 : wins / completed;
+    final avgTurn = winTurns.isEmpty
+        ? null
+        : winTurns.reduce((a, b) => a + b) / winTurns.length;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  name,
+                  style: const TextStyle(color: Colors.white, fontSize: 15),
+                ),
+              ),
+              Text(
+                '$wins win${wins == 1 ? "" : "s"} '
+                '(${(rate * 100).toStringAsFixed(0)}%)'
+                '${avgTurn != null ? "  •  avg turn ${avgTurn.toStringAsFixed(1)}" : ""}',
+                style: const TextStyle(color: Colors.white70, fontSize: 13),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(value: rate, minHeight: 6),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SimulationGrid extends StatelessWidget {
+  const _SimulationGrid({required this.sims});
+
+  final List<Map<String, dynamic>> sims;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 4,
+      runSpacing: 4,
+      children: [
+        for (final s in sims)
+          Tooltip(
+            message: _simTooltip(s),
+            child: Container(
+              width: 16,
+              height: 16,
+              decoration: BoxDecoration(
+                color: _simColor(s['state'] as String? ?? ''),
+                borderRadius: BorderRadius.circular(3),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+Color _simColor(String state) {
+  return switch (state) {
+    'COMPLETED' => const Color(0xFF34D399),
+    'FAILED' => const Color(0xFFF87171),
+    'CANCELLED' => const Color(0xFFFB923C),
+    'RUNNING' => const Color(0xFF60A5FA),
+    _ => const Color(0xFF374151),
+  };
+}
+
+String _simTooltip(Map<String, dynamic> s) {
+  final state = s['state'] as String? ?? '';
+  final idx = (s['index'] as num?)?.toInt() ?? 0;
+  final winner = s['winner'] as String?;
+  final dur = (s['durationMs'] as num?)?.toInt();
+  final parts = <String>['#$idx', state];
+  if (winner != null) parts.add(winner);
+  if (dur != null) parts.add('${(dur / 1000).toStringAsFixed(1)}s');
+  return parts.join(' · ');
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = switch (status) {
+      'COMPLETED' => ('Completed', const Color(0xFF34D399)),
+      'FAILED' => ('Failed', const Color(0xFFF87171)),
+      'CANCELLED' => ('Cancelled', const Color(0xFFFB923C)),
+      'RUNNING' => ('Running', const Color(0xFF60A5FA)),
+      _ => ('Queued', const Color(0xFF6B7280)),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorMessage extends StatelessWidget {
+  const _ErrorMessage({required this.error});
+
+  final String error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Text(error, style: const TextStyle(color: Colors.redAccent)),
+      ),
+    );
+  }
+}
+
+List<String> _deckNames(Map<String, dynamic> data) {
+  final raw = data['decks'];
+  if (raw is! List) return const [];
+  return raw
+      .whereType<Map>()
+      .map((d) => d['name'] as String?)
+      .whereType<String>()
+      .toList(growable: false);
+}
+
+/// Forge winners come back as `"Ai(N)-deckName"` or just `"deckName"`.
+/// Match either form against the job's declared decks.
+String? _matchDeck(String forgeWinner, List<String> deckNames) {
+  final stripped = forgeWinner.replaceFirst(RegExp(r'^Ai\(\d+\)-'), '');
+  for (final d in deckNames) {
+    if (d == stripped || d == forgeWinner) return d;
+  }
+  // Fuzzy: forge sometimes lowercases / hyphenates. Try a normalized
+  // compare.
+  final norm = stripped.replaceAll(RegExp(r'[^A-Za-z0-9]'), '').toLowerCase();
+  for (final d in deckNames) {
+    final dnorm = d.replaceAll(RegExp(r'[^A-Za-z0-9]'), '').toLowerCase();
+    if (dnorm == norm) return d;
+  }
+  return null;
+}

--- a/worker_flutter/lib/cloud/cloud_jobs_screen.dart
+++ b/worker_flutter/lib/cloud/cloud_jobs_screen.dart
@@ -1,0 +1,209 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import 'cloud_job_detail_screen.dart';
+
+/// Cloud-mode jobs browser — a read-only port of the web frontend's
+/// `Browse.tsx`. Mirrors the same Firestore query (recent jobs, ordered
+/// by createdAt descending) and the same lifecycle badges.
+///
+/// Stays read-only for now: creates / cancels / deletes all require
+/// auth, which the Flutter worker doesn't have yet (Plan 3).
+class CloudJobsScreen extends StatelessWidget {
+  const CloudJobsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final query = FirebaseFirestore.instance
+        .collection('jobs')
+        .orderBy('createdAt', descending: true)
+        .limit(100);
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: query.snapshots(),
+      builder: (context, snap) {
+        if (snap.hasError) {
+          return _CenterMessage(
+            icon: Icons.cloud_off,
+            text: 'Couldn\'t reach Firestore: ${snap.error}',
+          );
+        }
+        if (!snap.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final docs = snap.data!.docs;
+        if (docs.isEmpty) {
+          return const _CenterMessage(
+            icon: Icons.inbox,
+            text: 'No jobs yet — submit one from the web app.',
+          );
+        }
+        return ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemCount: docs.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 8),
+          itemBuilder: (context, i) => _JobRow(doc: docs[i]),
+        );
+      },
+    );
+  }
+}
+
+class _JobRow extends StatelessWidget {
+  const _JobRow({required this.doc});
+
+  final QueryDocumentSnapshot<Map<String, dynamic>> doc;
+
+  @override
+  Widget build(BuildContext context) {
+    final data = doc.data();
+    final status = (data['status'] as String?) ?? 'QUEUED';
+    final completed = (data['completedSimCount'] as num?)?.toInt() ?? 0;
+    final total = (data['totalSimCount'] as num?)?.toInt() ?? 0;
+    final progress = total == 0 ? 0.0 : (completed / total).clamp(0.0, 1.0);
+    final deckNames = _deckNames(data);
+    final createdAt = _toDate(data['createdAt']);
+    return InkWell(
+      borderRadius: BorderRadius.circular(10),
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(builder: (_) => CloudJobDetailScreen(jobId: doc.id)),
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        decoration: BoxDecoration(
+          color: const Color(0xFF111827),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: const Color(0xFF374151)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                _StatusBadge(status: status),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    deckNames.isEmpty ? '(no decks)' : deckNames.join(' vs '),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  _relativeTime(createdAt),
+                  style: const TextStyle(color: Colors.white54, fontSize: 12),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(3),
+                    child: LinearProgressIndicator(
+                      value: progress,
+                      minHeight: 4,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '$completed / $total sims',
+                  style: const TextStyle(color: Colors.white70, fontSize: 12),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = switch (status) {
+      'COMPLETED' => ('Completed', const Color(0xFF34D399)),
+      'FAILED' => ('Failed', const Color(0xFFF87171)),
+      'CANCELLED' => ('Cancelled', const Color(0xFFFB923C)),
+      'RUNNING' => ('Running', const Color(0xFF60A5FA)),
+      _ => ('Queued', const Color(0xFF6B7280)),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _CenterMessage extends StatelessWidget {
+  const _CenterMessage({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: Colors.white38, size: 40),
+            const SizedBox(height: 12),
+            Text(text, style: const TextStyle(color: Colors.white54)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+List<String> _deckNames(Map<String, dynamic> data) {
+  final raw = data['decks'];
+  if (raw is! List) return const [];
+  return raw
+      .whereType<Map>()
+      .map((d) => d['name'] as String?)
+      .whereType<String>()
+      .toList(growable: false);
+}
+
+DateTime? _toDate(Object? raw) {
+  if (raw is Timestamp) return raw.toDate();
+  if (raw is DateTime) return raw;
+  return null;
+}
+
+String _relativeTime(DateTime? when) {
+  if (when == null) return '';
+  final diff = DateTime.now().difference(when);
+  if (diff.inMinutes < 1) return 'just now';
+  if (diff.inHours < 1) return '${diff.inMinutes}m ago';
+  if (diff.inDays < 1) return '${diff.inHours}h ago';
+  if (diff.inDays < 7) return '${diff.inDays}d ago';
+  return '${when.year}-${when.month.toString().padLeft(2, '0')}-${when.day.toString().padLeft(2, '0')}';
+}

--- a/worker_flutter/lib/ui/dashboard.dart
+++ b/worker_flutter/lib/ui/dashboard.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../cloud/cloud_jobs_screen.dart';
 import '../config.dart';
 import '../models/sim.dart';
 import '../worker/worker_engine.dart';
@@ -11,11 +12,7 @@ import '../worker/worker_engine.dart';
 /// visibility (the macOS app has `LSUIElement=true`, so no Dock icon and
 /// no main window unless the user opens one).
 class Dashboard extends StatefulWidget {
-  const Dashboard({
-    super.key,
-    required this.engine,
-    required this.config,
-  });
+  const Dashboard({super.key, required this.engine, required this.config});
 
   final WorkerEngine engine;
   final WorkerConfig config;
@@ -35,44 +32,69 @@ class _DashboardState extends State<Dashboard> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFF1F2937),
-      appBar: AppBar(
-        backgroundColor: const Color(0xFF111827),
-        foregroundColor: Colors.white,
-        title: const Text('Magic Bracket Worker'),
-        centerTitle: false,
-        elevation: 0,
-      ),
-      body: StreamBuilder<EngineState>(
-        stream: widget.engine.stateStream,
-        initialData: widget.engine.currentState,
-        builder: (context, snapshot) {
-          final state = snapshot.data!;
-          return Padding(
-            padding: const EdgeInsets.all(20),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _StatusCard(state: state, workerName: widget.config.workerName),
-                const SizedBox(height: 16),
-                _CapacityRow(
-                  current: _capacity,
-                  onChanged: (v) => setState(() => _capacity = v),
-                  onChangeEnd: (v) => widget.config.setCapacity(v),
-                ),
-                const SizedBox(height: 16),
-                Expanded(child: _ActiveSimsList(active: state.activeSims)),
-                const SizedBox(height: 8),
-                _ControlRow(
-                  running: state.running,
-                  onStart: widget.engine.start,
-                  onStop: widget.engine.stop,
-                ),
-              ],
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        backgroundColor: const Color(0xFF1F2937),
+        appBar: AppBar(
+          backgroundColor: const Color(0xFF111827),
+          foregroundColor: Colors.white,
+          title: const Text('Magic Bracket Worker'),
+          centerTitle: false,
+          elevation: 0,
+          bottom: const TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.memory), text: 'Worker'),
+              Tab(icon: Icon(Icons.cloud_queue), text: 'Jobs'),
+            ],
+            labelColor: Color(0xFF60A5FA),
+            unselectedLabelColor: Colors.white70,
+            indicatorColor: Color(0xFF60A5FA),
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            // Worker tab — engine status / capacity / active sims.
+            StreamBuilder<EngineState>(
+              stream: widget.engine.stateStream,
+              initialData: widget.engine.currentState,
+              builder: (context, snapshot) {
+                final state = snapshot.data!;
+                return Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      _StatusCard(
+                        state: state,
+                        workerName: widget.config.workerName,
+                      ),
+                      const SizedBox(height: 16),
+                      _CapacityRow(
+                        current: _capacity,
+                        onChanged: (v) => setState(() => _capacity = v),
+                        onChangeEnd: (v) => widget.config.setCapacity(v),
+                      ),
+                      const SizedBox(height: 16),
+                      Expanded(
+                        child: _ActiveSimsList(active: state.activeSims),
+                      ),
+                      const SizedBox(height: 8),
+                      _ControlRow(
+                        running: state.running,
+                        onStart: widget.engine.start,
+                        onStop: widget.engine.stop,
+                      ),
+                    ],
+                  ),
+                );
+              },
             ),
-          );
-        },
+            // Jobs tab — Firestore-backed browser of all jobs (read-only
+            // for now; mutations need auth which the worker lacks).
+            const CloudJobsScreen(),
+          ],
+        ),
       ),
     );
   }
@@ -89,13 +111,13 @@ class _StatusCard extends StatelessWidget {
     final color = !state.running
         ? Colors.grey
         : state.activeSims.isEmpty
-            ? Colors.green
-            : Colors.blue;
+        ? Colors.green
+        : Colors.blue;
     final label = !state.running
         ? 'Stopped'
         : state.activeSims.isEmpty
-            ? 'Idle'
-            : 'Running ${state.activeSims.length} sim(s)';
+        ? 'Idle'
+        : 'Running ${state.activeSims.length} sim(s)';
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -157,7 +179,10 @@ class _CapacityRow extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const Text('Max parallel sims', style: TextStyle(color: Colors.white70)),
+          const Text(
+            'Max parallel sims',
+            style: TextStyle(color: Colors.white70),
+          ),
           Expanded(
             child: Slider(
               value: current.toDouble(),
@@ -173,7 +198,10 @@ class _CapacityRow extends StatelessWidget {
             width: 24,
             child: Text(
               '$current',
-              style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
               textAlign: TextAlign.right,
             ),
           ),
@@ -200,7 +228,8 @@ class _ActiveSimsList extends StatelessWidget {
     }
     return ListView.separated(
       itemCount: active.length,
-      separatorBuilder: (_, __) => const Divider(color: Colors.white12, height: 1),
+      separatorBuilder: (_, __) =>
+          const Divider(color: Colors.white12, height: 1),
       itemBuilder: (_, i) {
         final sim = active[i];
         return ListTile(
@@ -240,7 +269,9 @@ class _ControlRow extends StatelessWidget {
           icon: Icon(running ? Icons.stop : Icons.play_arrow),
           label: Text(running ? 'Stop worker' : 'Start worker'),
           style: ElevatedButton.styleFrom(
-            backgroundColor: running ? Colors.red.shade700 : Colors.green.shade700,
+            backgroundColor: running
+                ? Colors.red.shade700
+                : Colors.green.shade700,
             foregroundColor: Colors.white,
           ),
           onPressed: running ? onStop : onStart,


### PR DESCRIPTION
## Summary

Adds a **Jobs** tab to the cloud-mode dashboard that mirrors the web frontend's job browser. The desktop app is now usable for reviewing past runs without opening the browser.

## What's new

- `lib/cloud/cloud_jobs_screen.dart` — Firestore-streamed list of recent jobs. Status badge, progress bar, deck names, relative timestamp per row.
- `lib/cloud/cloud_job_detail_screen.dart` — read-only port of `JobStatus.tsx`: job metadata, progress, per-deck win rate + avg winning turn, per-sim grid with tooltips.
- `lib/ui/dashboard.dart` — wraps existing worker view in a `DefaultTabController`. Worker stays first tab; Jobs is new.

## Read-only

Creates / cancels / deletes all require auth. The worker doesn't have it yet (Plan 3 Google Sign-In). UI deliberately exposes no mutation surface.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` 18/18 pass
- [ ] Manual: open cloud mode, switch to Jobs tab, see queued jobs from the web frontend, tap a row, see live progress + win-rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)