### PR TITLE
test: substantial test suite for the Flutter worker

### DIFF
--- a/worker_flutter/lib/offline/db/app_db.dart
+++ b/worker_flutter/lib/offline/db/app_db.dart
@@ -52,13 +52,28 @@ class Settings extends Table {
 class AppDb extends _$AppDb {
   AppDb() : super(_openConnection());
 
+  /// Open the schema against an arbitrary `QueryExecutor`. Used by the
+  /// test suite with `NativeDatabase.memory()` for hermetic, fast
+  /// integration tests that exercise the same SQL the app does at
+  /// runtime — but without touching disk.
+  AppDb.forTesting(QueryExecutor e) : super(e);
+
   @override
   int get schemaVersion => 1;
 
   /// All jobs newest-first. Drives the history list.
+  ///
+  /// Sorted by `createdAt DESC` with `id DESC` as a tiebreaker — two
+  /// jobs created in the same millisecond (rare but possible during
+  /// scripted bulk-import) still resolve to a stable, monotonically-
+  /// newest-first order rather than relying on SQLite's row-storage
+  /// order.
   Future<List<Job>> recentJobs({int limit = 50}) {
     return (select(jobs)
-          ..orderBy([(j) => OrderingTerm.desc(j.createdAt)])
+          ..orderBy([
+            (j) => OrderingTerm.desc(j.createdAt),
+            (j) => OrderingTerm.desc(j.id),
+          ])
           ..limit(limit))
         .get();
   }
@@ -67,7 +82,10 @@ class AppDb extends _$AppDb {
   /// `jobs` table changes. Avoids per-second polling in the history UI.
   Stream<List<Job>> watchRecentJobs({int limit = 50}) {
     return (select(jobs)
-          ..orderBy([(j) => OrderingTerm.desc(j.createdAt)])
+          ..orderBy([
+            (j) => OrderingTerm.desc(j.createdAt),
+            (j) => OrderingTerm.desc(j.id),
+          ])
           ..limit(limit))
         .watch();
   }

--- a/worker_flutter/test/installer/forge_manifest_test.dart
+++ b/worker_flutter/test/installer/forge_manifest_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:worker_flutter/installer/forge_manifest.dart';
+
+void main() {
+  group('ForgeManifest.fromJson', () {
+    test('reads all required fields', () {
+      final m = ForgeManifest.fromJson({
+        'version': '2.0.10',
+        'url': 'https://example.com/forge.tar.bz2',
+        'sha256': 'abc123',
+        'size': 286557618,
+        'jarName': 'forge-gui-desktop-2.0.10-jar-with-dependencies.jar',
+      });
+      expect(m.version, '2.0.10');
+      expect(m.url, 'https://example.com/forge.tar.bz2');
+      expect(m.sha256, 'abc123');
+      expect(m.size, 286557618);
+      expect(m.jarName, contains('2.0.10'));
+    });
+  });
+
+  group('ForgeManifestClient.fetch', () {
+    test('returns parsed manifest on 200', () async {
+      final client = ForgeManifestClient(
+        url: 'https://test.example/forge-manifest.json',
+        client: MockClient((req) async {
+          return http.Response(
+            '{"version":"2.1.0","url":"https://x/y.tar.bz2",'
+            '"sha256":"deadbeef","size":42,'
+            '"jarName":"forge-gui-desktop-2.1.0-jar-with-dependencies.jar"}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }),
+      );
+      final m = await client.fetch();
+      expect(m, isNotNull);
+      expect(m!.version, '2.1.0');
+      expect(m.size, 42);
+    });
+
+    test('returns null on non-200 (offline-friendly fallback)', () async {
+      // The installer's `isReady()` accepts whatever JAR is on disk
+      // when the manifest is unreachable — never blocking a launch
+      // because GitHub is rate-limiting raw fetches or the user has
+      // no network. This test pins that contract.
+      final client = ForgeManifestClient(
+        url: 'https://test.example/forge-manifest.json',
+        client: MockClient((req) async => http.Response('not found', 404)),
+      );
+      final m = await client.fetch();
+      expect(m, isNull);
+    });
+
+    test('returns null on malformed JSON', () async {
+      final client = ForgeManifestClient(
+        url: 'https://test.example/forge-manifest.json',
+        client: MockClient((req) async => http.Response('{not json', 200)),
+      );
+      final m = await client.fetch();
+      expect(m, isNull);
+    });
+
+    test('returns null on network error', () async {
+      final client = ForgeManifestClient(
+        url: 'https://test.example/forge-manifest.json',
+        client: MockClient((req) async => throw Exception('DNS fail')),
+      );
+      final m = await client.fetch();
+      expect(m, isNull);
+    });
+
+    test('respects timeout argument', () async {
+      final client = ForgeManifestClient(
+        url: 'https://test.example/forge-manifest.json',
+        client: MockClient((req) async {
+          await Future.delayed(const Duration(seconds: 2));
+          return http.Response('{}', 200);
+        }),
+      );
+      final m = await client.fetch(timeout: const Duration(milliseconds: 200));
+      expect(m, isNull, reason: 'timed-out fetch must return null');
+    });
+  });
+}

--- a/worker_flutter/test/offline/app_db_test.dart
+++ b/worker_flutter/test/offline/app_db_test.dart
@@ -1,0 +1,254 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:worker_flutter/offline/db/app_db.dart';
+
+/// Drift schema tests. In-memory SQLite, hermetic.
+///
+/// These are tight, mechanical guarantees the offline-mode UI relies
+/// on — atomic counter bumps, terminal-state preservation, and the
+/// reactive table watch that drives the live job screen.
+void main() {
+  late AppDb db;
+
+  setUp(() {
+    db = AppDb.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  const decks = ['One', 'Two', 'Three', 'Four'];
+
+  group('createJob', () {
+    test('inserts job + N PENDING sims atomically', () async {
+      final id = await db.createJob(deckNames: decks, simCount: 5);
+      final job = await db.jobById(id);
+      expect(job, isNotNull);
+      expect(job!.state, 'PENDING');
+      expect(job.totalSims, 5);
+      expect(job.completedSims, 0);
+
+      final sims = await db.simsForJob(id);
+      expect(sims.length, 5);
+      expect(sims.every((s) => s.state == 'PENDING'), isTrue);
+      expect(sims.map((s) => s.simIndex).toList(), [0, 1, 2, 3, 4]);
+    });
+
+    test('refuses brackets that are not exactly 4 decks', () async {
+      // The assert lives on the public API to enforce the Commander
+      // 4-player invariant. Test in debug-mode (assertions on).
+      expect(
+        () => db.createJob(deckNames: const ['Only', 'Three'], simCount: 1),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('markSimCompleted', () {
+    test('bumps completedSims atomically with the sim state update', () async {
+      final jobId = await db.createJob(deckNames: decks, simCount: 3);
+      final sims = await db.simsForJob(jobId);
+
+      await db.markSimCompleted(
+        sims[0].id,
+        winnerDeckName: 'One',
+        winningTurn: 12,
+        durationMs: 1500,
+      );
+
+      final job = await db.jobById(jobId);
+      expect(job!.completedSims, 1);
+      expect(job.state, 'RUNNING');
+
+      final refreshed = await db.simsForJob(jobId);
+      expect(refreshed[0].state, 'COMPLETED');
+      expect(refreshed[0].winnerDeckName, 'One');
+      expect(refreshed[0].winningTurn, 12);
+      expect(refreshed[0].durationMs, 1500);
+    });
+
+    test('flips job to COMPLETED on the last sim completion', () async {
+      final jobId = await db.createJob(deckNames: decks, simCount: 2);
+      final sims = await db.simsForJob(jobId);
+
+      await db.markSimCompleted(
+        sims[0].id,
+        winnerDeckName: 'One',
+        winningTurn: 5,
+        durationMs: 100,
+      );
+      var job = await db.jobById(jobId);
+      expect(job!.state, 'RUNNING');
+
+      await db.markSimCompleted(
+        sims[1].id,
+        winnerDeckName: 'Two',
+        winningTurn: 11,
+        durationMs: 200,
+      );
+      job = await db.jobById(jobId);
+      expect(job!.state, 'COMPLETED');
+      expect(job.completedSims, 2);
+    });
+  });
+
+  group('markSimFailed', () {
+    test('counts as completion for progress purposes', () async {
+      final jobId = await db.createJob(deckNames: decks, simCount: 2);
+      final sims = await db.simsForJob(jobId);
+
+      await db.markSimFailed(sims[0].id, error: 'java crashed', durationMs: 0);
+      await db.markSimFailed(sims[1].id, error: 'java crashed', durationMs: 0);
+
+      final job = await db.jobById(jobId);
+      expect(
+        job!.completedSims,
+        2,
+        reason:
+            'failed sims still increment the counter so the job '
+            'finalizes rather than hanging on the 2h stale-sweeper',
+      );
+      expect(job.state, 'COMPLETED');
+    });
+  });
+
+  group('terminal-state preservation', () {
+    test('late sim completion does NOT resurrect a CANCELLED job', () async {
+      // Regression guard: an earlier bug in `_bumpJobCompletedCount`
+      // unconditionally rewrote `state` on every increment, which
+      // could flip a user-cancelled (or precon-failed) job back to
+      // RUNNING/COMPLETED when a stale in-flight sim finally landed.
+      final jobId = await db.createJob(deckNames: decks, simCount: 3);
+      final sims = await db.simsForJob(jobId);
+
+      // Simulate the runner cancelling the job mid-run.
+      await db.updateJobState(jobId, 'CANCELLED');
+
+      // A sim that was already running at cancel time finalizes.
+      await db.markSimCompleted(
+        sims[0].id,
+        winnerDeckName: 'One',
+        winningTurn: 8,
+        durationMs: 500,
+      );
+
+      final job = await db.jobById(jobId);
+      expect(
+        job!.state,
+        'CANCELLED',
+        reason: 'sim completion must not flip the job out of CANCELLED',
+      );
+      expect(
+        job.completedSims,
+        1,
+        reason:
+            'the counter still increments — only the state field is preserved',
+      );
+    });
+
+    test('late sim completion does NOT resurrect a FAILED job', () async {
+      final jobId = await db.createJob(deckNames: decks, simCount: 3);
+      final sims = await db.simsForJob(jobId);
+
+      await db.updateJobState(jobId, 'FAILED');
+      await db.markSimCompleted(
+        sims[0].id,
+        winnerDeckName: 'One',
+        winningTurn: 8,
+        durationMs: 500,
+      );
+
+      final job = await db.jobById(jobId);
+      expect(job!.state, 'FAILED');
+    });
+  });
+
+  group('reactive watches', () {
+    test('watchSimsForJob emits on every sim write', () async {
+      final jobId = await db.createJob(deckNames: decks, simCount: 2);
+      final stream = db.watchSimsForJob(jobId);
+      final received = <int>[];
+      final sub = stream.listen(
+        (sims) =>
+            received.add(sims.where((s) => s.state == 'COMPLETED').length),
+      );
+
+      // The history list + live job screen depend on this stream
+      // updating after each `markSim*` call.
+      final sims = await db.simsForJob(jobId);
+      await db.markSimCompleted(
+        sims[0].id,
+        winnerDeckName: 'One',
+        winningTurn: 5,
+        durationMs: 100,
+      );
+      await db.markSimCompleted(
+        sims[1].id,
+        winnerDeckName: 'Two',
+        winningTurn: 11,
+        durationMs: 200,
+      );
+      // Drift batches notifications; give them a turn to flush.
+      await Future.delayed(const Duration(milliseconds: 50));
+      await sub.cancel();
+
+      // First emission is the initial state (0 completed); subsequent
+      // emissions reflect 1 then 2 completed.
+      expect(
+        received,
+        containsAllInOrder([0, 1, 2]),
+        reason:
+            'each completion must produce a stream emission so the '
+            'live job screen updates in real time',
+      );
+    });
+
+    test('watchRecentJobs emits on every new job', () async {
+      final stream = db.watchRecentJobs();
+      var lastCount = 0;
+      final sub = stream.listen((jobs) => lastCount = jobs.length);
+
+      await db.createJob(deckNames: decks, simCount: 1);
+      await db.createJob(deckNames: decks, simCount: 1);
+      await Future.delayed(const Duration(milliseconds: 50));
+      await sub.cancel();
+
+      expect(
+        lastCount,
+        2,
+        reason: 'history list must show new runs without a refresh',
+      );
+    });
+  });
+
+  group('recentJobs ordering', () {
+    test('returns jobs newest-first', () async {
+      final a = await db.createJob(deckNames: decks, simCount: 1, name: 'a');
+      await Future.delayed(const Duration(milliseconds: 5));
+      final b = await db.createJob(deckNames: decks, simCount: 1, name: 'b');
+      await Future.delayed(const Duration(milliseconds: 5));
+      final c = await db.createJob(deckNames: decks, simCount: 1, name: 'c');
+
+      final jobs = await db.recentJobs();
+      expect(jobs.map((j) => j.id).toList(), [c, b, a]);
+    });
+
+    test('honors the limit argument', () async {
+      for (var i = 0; i < 5; i++) {
+        await db.createJob(deckNames: decks, simCount: 1);
+      }
+      final jobs = await db.recentJobs(limit: 3);
+      expect(jobs.length, 3);
+    });
+  });
+
+  group('deleteJob', () {
+    test('cascades to all sims for the job', () async {
+      final id = await db.createJob(deckNames: decks, simCount: 5);
+      await db.deleteJob(id);
+      expect(await db.jobById(id), isNull);
+      expect(await db.simsForJob(id), isEmpty);
+    });
+  });
+}

--- a/worker_flutter/test/offline/deck_source_test.dart
+++ b/worker_flutter/test/offline/deck_source_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:worker_flutter/offline/deck_source.dart';
+
+void main() {
+  group('loadBundledPrecons', () {
+    late Directory tempForge;
+
+    setUp(() async {
+      tempForge = await Directory.systemTemp.createTemp('deck_source_test_');
+    });
+
+    tearDown(() async {
+      if (tempForge.existsSync()) tempForge.deleteSync(recursive: true);
+    });
+
+    test('returns empty when the Commander dir is missing', () async {
+      // No `res/Decks/Commander` subtree — represents a fresh install
+      // before the user has run the first-launch installer.
+      final precons = await loadBundledPrecons(tempForge.path);
+      expect(precons, isEmpty);
+    });
+
+    test('reads .dck files, humanizes names, sorts alphabetically', () async {
+      final commander = Directory(
+        p.join(tempForge.path, 'res', 'Decks', 'Commander'),
+      );
+      commander.createSync(recursive: true);
+      File(
+        p.join(commander.path, 'marchesa-control-upgraded.dck'),
+      ).writeAsStringSync('[Main]\n');
+      File(
+        p.join(commander.path, 'Alpha_Two_Words.dck'),
+      ).writeAsStringSync('[Main]\n');
+      // Also drop a non-.dck file to verify we skip it.
+      File(p.join(commander.path, 'README.txt')).writeAsStringSync('ignore me');
+
+      final precons = await loadBundledPrecons(tempForge.path);
+
+      expect(precons.length, 2);
+      // Alphabetical case-insensitive ordering.
+      expect(precons[0].displayName, 'Alpha Two Words');
+      expect(precons[1].displayName, 'Marchesa Control Upgraded');
+      // Filenames preserved unchanged for SimRunner's `-d` arg.
+      expect(precons[0].filename, 'Alpha_Two_Words.dck');
+      expect(precons[1].filename, 'marchesa-control-upgraded.dck');
+    });
+
+    test('recurses into subdirs (Forge groups precons by set/year)', () async {
+      // Forge bundles precons in nested subdirs like
+      // `res/Decks/Commander/2023/Eldritch.dck`. The picker should
+      // surface them flatly.
+      final nested = Directory(
+        p.join(tempForge.path, 'res', 'Decks', 'Commander', '2023'),
+      );
+      nested.createSync(recursive: true);
+      File(p.join(nested.path, 'Eldritch.dck')).writeAsStringSync('[Main]\n');
+
+      final precons = await loadBundledPrecons(tempForge.path);
+      expect(precons.length, 1);
+      expect(precons.first.displayName, 'Eldritch');
+    });
+
+    test('humanizes hyphens, underscores, and mixed-case filenames', () async {
+      final commander = Directory(
+        p.join(tempForge.path, 'res', 'Decks', 'Commander'),
+      )..createSync(recursive: true);
+      final cases = {
+        'doran-big-butts': 'Doran Big Butts',
+        'temur_roar_upgraded': 'Temur Roar Upgraded',
+        'BANT-Spirits': 'BANT Spirits',
+        'single': 'Single',
+      };
+      for (final filename in cases.keys) {
+        File(
+          p.join(commander.path, '$filename.dck'),
+        ).writeAsStringSync('[Main]\n');
+      }
+      final precons = await loadBundledPrecons(tempForge.path);
+      for (final entry in cases.entries) {
+        expect(
+          precons.any((d) => d.displayName == entry.value),
+          isTrue,
+          reason: '${entry.key} should humanize to "${entry.value}"',
+        );
+      }
+    });
+  });
+}

--- a/worker_flutter/test/offline/offline_runner_test.dart
+++ b/worker_flutter/test/offline/offline_runner_test.dart
@@ -1,0 +1,395 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:worker_flutter/config.dart';
+import 'package:worker_flutter/models/sim.dart';
+import 'package:worker_flutter/offline/db/app_db.dart';
+import 'package:worker_flutter/offline/offline_runner.dart';
+import 'package:worker_flutter/worker/sim_runner.dart';
+
+/// End-to-end-ish tests of `OfflineRunner`. We stand up:
+///   - An in-memory drift `AppDb`
+///   - A temp dir laid out like a real Forge install (with `.dck` files
+///     under `<forgePath>/res/Decks/Commander/`)
+///   - A stub `SimRunner` that returns predetermined `SimResult`s and
+///     records what it was asked to do (deck filenames, cancel signal)
+///
+/// Each test runs the real `OfflineRunner` against this rig and asserts
+/// on the resulting AppDb state — the same SQL the offline-mode UI
+/// streams from.
+void main() {
+  late Directory tempRoot;
+  late WorkerConfig config;
+  late AppDb db;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('offline_runner_test_');
+    final forgeDir = Directory(
+      p.join(tempRoot.path, 'forge', 'res', 'Decks', 'Commander'),
+    );
+    forgeDir.createSync(recursive: true);
+
+    // Five fake precons so tests can pick any 4 + verify "all 4 play".
+    // Forge's CLI is mocked by StubSimRunner so the file contents don't
+    // matter — only the filenames do.
+    for (final name in [
+      'Alpha-Test',
+      'Beta-Test',
+      'Gamma-Test',
+      'Delta-Test',
+      'Epsilon-Test',
+    ]) {
+      File(p.join(forgeDir.path, '$name.dck')).writeAsStringSync('[Main]\n');
+    }
+
+    final decksDir = Directory(p.join(tempRoot.path, 'staged-decks'))
+      ..createSync(recursive: true);
+    final logsDir = Directory(p.join(tempRoot.path, 'sim-logs'))
+      ..createSync(recursive: true);
+
+    config = WorkerConfig(
+      workerId: 'test-worker',
+      workerName: 'test',
+      maxCapacity: 1,
+      forgePath: p.join(tempRoot.path, 'forge'),
+      javaPath: '/usr/bin/java',
+      decksPath: decksDir.path,
+      logsPath: logsDir.path,
+      apiUrl: 'http://localhost',
+      workerSecret: null,
+    );
+    db = AppDb.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+  });
+
+  group('OfflineRunner.run', () {
+    test('runs all PENDING sims and flips the job to COMPLETED', () async {
+      final runner = OfflineRunner(
+        db: db,
+        config: config,
+        runnerOverride: _StubSimRunner.successAll(
+          winnerForgeName: 'Ai(1)-Alpha-Test',
+        ),
+      );
+
+      final jobId = await db.createJob(
+        deckNames: const [
+          'Alpha Test',
+          'Beta Test',
+          'Gamma Test',
+          'Delta Test',
+        ],
+        simCount: 3,
+      );
+
+      await runner.run(jobId);
+
+      final job = await db.jobById(jobId);
+      expect(job!.state, 'COMPLETED');
+      expect(job.completedSims, 3);
+
+      final sims = await db.simsForJob(jobId);
+      expect(sims.length, 3);
+      expect(sims.every((s) => s.state == 'COMPLETED'), isTrue);
+      expect(sims.first.winnerDeckName, 'Alpha Test');
+    });
+
+    test('passes all 4 deck filenames to SimRunner on every sim', () async {
+      // "All 4 decks play at least once" is enforced at the runOne boundary:
+      // SimRunner's argv expects `-d d1 d2 d3 d4`. We assert that.
+      final stub = _StubSimRunner.successAll(
+        winnerForgeName: 'Ai(2)-Beta-Test',
+      );
+      final runner = OfflineRunner(
+        db: db,
+        config: config,
+        runnerOverride: stub,
+      );
+
+      final jobId = await db.createJob(
+        deckNames: const [
+          'Alpha Test',
+          'Beta Test',
+          'Gamma Test',
+          'Delta Test',
+        ],
+        simCount: 2,
+      );
+      await runner.run(jobId);
+
+      expect(stub.calls.length, 2, reason: 'two sims expected');
+      for (final call in stub.calls) {
+        expect(
+          call.deckFilenames.length,
+          4,
+          reason: 'every sim must invoke Forge with 4 decks',
+        );
+        expect(
+          call.deckFilenames.toSet(),
+          {
+            'Alpha-Test.dck',
+            'Beta-Test.dck',
+            'Gamma-Test.dck',
+            'Delta-Test.dck',
+          },
+          reason: 'all four picked decks must be present',
+        );
+      }
+    });
+
+    test(
+      'missing precon fails the whole job + marks PENDING sims FAILED',
+      () async {
+        final runner = OfflineRunner(
+          db: db,
+          config: config,
+          runnerOverride: _StubSimRunner.successAll(
+            winnerForgeName: 'Ai(1)-Alpha-Test',
+          ),
+        );
+
+        final jobId = await db.createJob(
+          // "Phantom Test" doesn't exist on disk.
+          deckNames: const [
+            'Alpha Test',
+            'Phantom Test',
+            'Gamma Test',
+            'Delta Test',
+          ],
+          simCount: 4,
+        );
+        await runner.run(jobId);
+
+        final job = await db.jobById(jobId);
+        expect(job!.state, 'FAILED');
+
+        final sims = await db.simsForJob(jobId);
+        expect(
+          sims.every((s) => s.state == 'FAILED'),
+          isTrue,
+          reason: 'all sims should be marked FAILED, not orphaned in PENDING',
+        );
+        expect(sims.first.errorMessage, contains('Phantom Test'));
+      },
+    );
+
+    test(
+      'Forge winner name "Ai(N)-Deck-Name" maps back to display name',
+      () async {
+        // Forge writes winners as "Ai(2)-Marchesa-control-upgraded"; the
+        // round-trip must produce the picker's display name
+        // ("Marchesa Control Upgraded") so the win-rate UI keys match.
+        File(
+          p.join(
+            config.forgePath,
+            'res',
+            'Decks',
+            'Commander',
+            'Marchesa-control-upgraded.dck',
+          ),
+        ).writeAsStringSync('[Main]\n');
+
+        final stub = _StubSimRunner.successAll(
+          winnerForgeName: 'Ai(2)-Marchesa-control-upgraded',
+        );
+        final runner = OfflineRunner(
+          db: db,
+          config: config,
+          runnerOverride: stub,
+        );
+
+        final jobId = await db.createJob(
+          deckNames: const [
+            'Alpha Test',
+            'Marchesa Control Upgraded',
+            'Gamma Test',
+            'Delta Test',
+          ],
+          simCount: 1,
+        );
+        await runner.run(jobId);
+
+        final sims = await db.simsForJob(jobId);
+        expect(
+          sims.first.winnerDeckName,
+          'Marchesa Control Upgraded',
+          reason: 'winner must round-trip to the picker display name',
+        );
+      },
+    );
+  });
+
+  group('OfflineRunner.cancel', () {
+    test('cancel during a run stops new sims immediately', () async {
+      // The stub holds open the FIRST sim until `release` is signaled
+      // so we can race a cancel into the loop and watch only one sim
+      // get to COMPLETED.
+      final stub = _StubSimRunner.gated();
+      final runner = OfflineRunner(
+        db: db,
+        config: config,
+        runnerOverride: stub,
+      );
+
+      final jobId = await db.createJob(
+        deckNames: const [
+          'Alpha Test',
+          'Beta Test',
+          'Gamma Test',
+          'Delta Test',
+        ],
+        simCount: 5,
+      );
+
+      // Kick off; first sim will block at runOne until we release it.
+      final runFuture = runner.run(jobId);
+
+      // Wait until the runner has actually entered the first sim.
+      await stub.firstCallStarted.future;
+
+      // Cancel mid-run. The cancellation completer fires; the in-flight
+      // call's `cancelSignal` resolves so SimRunner would normally
+      // SIGTERM the Java child. Then the run loop short-circuits.
+      await runner.cancel(jobId);
+
+      // Release the first sim so it can finalize with its 'cancelled'
+      // result (mirrors what SimRunner does when the signal fires).
+      stub.releaseFirstAsCancelled();
+      await runFuture;
+
+      final job = await db.jobById(jobId);
+      expect(job!.state, 'CANCELLED', reason: 'job must end in CANCELLED');
+
+      final sims = await db.simsForJob(jobId);
+      // First sim got far enough to be marked RUNNING then FAILED (with
+      // 'cancelled' errorMessage). The remaining four never started.
+      expect(sims.first.state, 'FAILED');
+      expect(sims.first.errorMessage, 'cancelled');
+      // The remaining sims should be marked FAILED with reason 'cancelled'
+      // by `_cancelRemaining` rather than left in PENDING.
+      for (final s in sims.skip(1)) {
+        expect(
+          s.state,
+          'FAILED',
+          reason: 'cancel must finalize remaining sims, not orphan them',
+        );
+        expect(s.errorMessage, 'cancelled');
+      }
+      expect(
+        stub.calls.length,
+        1,
+        reason: 'only the first sim should ever reach SimRunner',
+      );
+    });
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────
+
+class _RunOneCall {
+  _RunOneCall({required this.deckFilenames});
+  final List<String> deckFilenames;
+}
+
+/// A stand-in `SimRunner` we drive from tests. Captures the deck list
+/// for every invocation so we can assert "all 4 decks were passed".
+class _StubSimRunner extends SimRunner {
+  _StubSimRunner._(this._respond)
+    : super(javaPath: '/usr/bin/java', forgePath: '/tmp');
+
+  /// Always returns a successful sim with the given Forge-format winner.
+  factory _StubSimRunner.successAll({required String winnerForgeName}) {
+    return _StubSimRunner._(
+      (_, __) async => SimResult(
+        success: true,
+        durationMs: 10,
+        winners: [winnerForgeName],
+        winningTurns: const [7],
+        logText: 'stub',
+        errorMessage: null,
+      ),
+    );
+  }
+
+  /// First call blocks until the test releases it; subsequent calls
+  /// (which shouldn't happen if cancel works) return immediately as
+  /// 'cancelled' results.
+  factory _StubSimRunner.gated() {
+    final firstCallStarted = Completer<void>();
+    final firstCallGate = Completer<SimResult>();
+    var first = true;
+    final stub = _StubSimRunner._((call, cancel) {
+      if (first) {
+        first = false;
+        firstCallStarted.complete();
+        // Wait for either the gate to be released OR the cancelSignal
+        // to fire (which the test triggers by calling runner.cancel).
+        cancel?.then((_) {
+          if (!firstCallGate.isCompleted) {
+            firstCallGate.complete(
+              SimResult(
+                success: false,
+                durationMs: 5,
+                winners: const [],
+                winningTurns: const [],
+                logText: 'cancelled by signal',
+                errorMessage: 'cancelled',
+              ),
+            );
+          }
+        });
+        return firstCallGate.future;
+      }
+      return Future.value(
+        SimResult(
+          success: false,
+          durationMs: 1,
+          winners: const [],
+          winningTurns: const [],
+          logText: '',
+          errorMessage: 'unexpected — cancel should have prevented this call',
+        ),
+      );
+    });
+    stub._firstCallStarted = firstCallStarted;
+    stub._firstCallGate = firstCallGate;
+    return stub;
+  }
+
+  final Future<SimResult> Function(_RunOneCall, Future<void>?) _respond;
+  final calls = <_RunOneCall>[];
+  Completer<void>? _firstCallStarted;
+  Completer<SimResult>? _firstCallGate;
+
+  Completer<void> get firstCallStarted => _firstCallStarted!;
+  void releaseFirstAsCancelled() {
+    if (_firstCallGate != null && !_firstCallGate!.isCompleted) {
+      _firstCallGate!.complete(
+        SimResult(
+          success: false,
+          durationMs: 5,
+          winners: const [],
+          winningTurns: const [],
+          logText: '',
+          errorMessage: 'cancelled',
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<SimResult> runOne({required JobInfo job, Future<void>? cancelSignal}) {
+    final call = _RunOneCall(deckFilenames: List.of(job.deckFilenames));
+    calls.add(call);
+    return _respond(call, cancelSignal);
+  }
+}

--- a/worker_flutter/test/worker/sim_runner_test.dart
+++ b/worker_flutter/test/worker/sim_runner_test.dart
@@ -84,5 +84,58 @@ Game Result: Game 1 ended in 16984 ms. Ai(4)-Doran Big Butts has won!
       expect(parsed.winners, ['Ai(4)-Doran Big Butts']);
       expect(parsed.winningTurns, [23]);
     });
+
+    test('turn count is NOT multiplied by 4 — single game with turn 12', () {
+      // Regression guard: a previous bug had us multiplying the turn
+      // count by the player count (4) when aggregating. For one game
+      // ending on turn 12, winningTurns must be [12], never [48].
+      const log = '''
+Game outcome: Turn 12
+Game Result: Game 1 ended in 5000 ms. Ai(2)-Beta has won!
+''';
+      final parsed = parseGameLog(log);
+      expect(parsed.winningTurns, [12]);
+      expect(parsed.winningTurns.first, lessThan(48));
+    });
+
+    test('multi-game logs keep per-game turns independent', () {
+      // Each "has won" line should consume the most recent preceding
+      // turn marker and reset — without that reset, game 2 below
+      // would inherit game 1's turn.
+      const log = '''
+Game outcome: Turn 5
+Game Result: Game 1 ended in 1000 ms. Ai(1)-Alpha has won!
+Game outcome: Turn 11
+Game Result: Game 2 ended in 2000 ms. Ai(2)-Beta has won!
+Game outcome: Turn 19
+Game Result: Game 3 ended in 3000 ms. Ai(3)-Charlie has won!
+''';
+      final parsed = parseGameLog(log);
+      expect(parsed.winners, ['Ai(1)-Alpha', 'Ai(2)-Beta', 'Ai(3)-Charlie']);
+      expect(parsed.winningTurns, [5, 11, 19]);
+    });
+
+    test('winning turns from realistic Commander logs land in turn 4–24', () {
+      // Commander games regularly resolve between turns 4 and 24 in
+      // 4-player random AI play. This test mirrors that band and
+      // doubles as a sanity check that the parser doesn't truncate
+      // single-digit turns or drop the leading "Turn ".
+      final realTurns = [4, 7, 12, 15, 19, 22, 24];
+      for (final t in realTurns) {
+        final log =
+            '''
+Game outcome: Turn $t
+Game Result: Game 1 ended in 1000 ms. Ai(1)-Test has won!
+''';
+        final parsed = parseGameLog(log);
+        expect(parsed.winningTurns, [t], reason: 'expected turn=$t to parse');
+        expect(
+          parsed.winningTurns.first,
+          inInclusiveRange(1, 100),
+          reason:
+              'a 4× multiplication bug would push turn=$t into the hundreds',
+        );
+      }
+    });
   });
 }

--- a/worker_flutter/test/worker/worker_engine_test.dart
+++ b/worker_flutter/test/worker/worker_engine_test.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:worker_flutter/config.dart';
+import 'package:worker_flutter/models/sim.dart';
+import 'package:worker_flutter/worker/sim_runner.dart';
+import 'package:worker_flutter/worker/worker_engine.dart';
+
+/// Integration tests for the cloud-mode `WorkerEngine` against an
+/// in-memory fake Firestore. Covers the same code path the real
+/// worker takes when the web frontend queues a new bracket — the
+/// `collectionGroup('simulations')` listener firing on a PENDING
+/// state change drives the claim loop.
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late _StubSimRunner stubRunner;
+  late WorkerEngine engine;
+  late WorkerConfig config;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    stubRunner = _StubSimRunner();
+    config = WorkerConfig(
+      workerId: 'test-engine-worker',
+      workerName: 'engine-test',
+      maxCapacity: 2,
+      forgePath: '/tmp/forge',
+      javaPath: '/usr/bin/java',
+      decksPath: '/tmp/decks',
+      logsPath: '/tmp/logs',
+      apiUrl: 'http://localhost',
+      workerSecret: null,
+    );
+    engine = WorkerEngine(
+      config: config,
+      firestore: firestore,
+      runnerOverride: stubRunner,
+    );
+  });
+
+  tearDown(() async {
+    await engine.dispose();
+  });
+
+  /// Build a JOB doc + its `simulations` subcollection. Returns the
+  /// jobId so tests can also read it back.
+  Future<String> seedJob({
+    required String jobId,
+    required int simCount,
+    List<Map<String, String>> decks = const [
+      {'name': 'Alpha', 'dck': '[Main]\n'},
+      {'name': 'Beta', 'dck': '[Main]\n'},
+      {'name': 'Gamma', 'dck': '[Main]\n'},
+      {'name': 'Delta', 'dck': '[Main]\n'},
+    ],
+  }) async {
+    final jobRef = firestore.collection('jobs').doc(jobId);
+    await jobRef.set({
+      'status': 'QUEUED',
+      'decks': decks,
+      'createdAt': DateTime.now().toIso8601String(),
+      'completedSimCount': 0,
+      'totalSimCount': simCount,
+      'simulations': simCount,
+    });
+    final now = DateTime.now();
+    for (var i = 0; i < simCount; i++) {
+      await jobRef.collection('simulations').doc('sim-$i').set({
+        'simId': 'sim-$i',
+        'index': i,
+        'state': 'PENDING',
+        'createdAt': now.add(Duration(microseconds: i)),
+      });
+    }
+    return jobId;
+  }
+
+  group('PENDING listener', () {
+    test('claims and runs sims as soon as they appear', () async {
+      // The listener fires on subscription too (initial snapshot), so
+      // pre-seeded data is picked up.
+      await seedJob(jobId: 'job1', simCount: 2);
+      await engine.start();
+
+      // Give the listener + claim transactions a moment to flow.
+      await _waitForCondition(
+        () async => stubRunner.invocations >= 2,
+        timeout: const Duration(seconds: 3),
+      );
+
+      expect(
+        stubRunner.invocations,
+        2,
+        reason: 'both PENDING sims should be claimed and run',
+      );
+
+      // Verify the sims terminated in Firestore with the right shape.
+      final sims = await firestore
+          .collection('jobs')
+          .doc('job1')
+          .collection('simulations')
+          .get();
+      expect(sims.docs.length, 2);
+      final states = sims.docs.map((d) => d.data()['state']).toSet();
+      expect(states, {
+        'COMPLETED',
+      }, reason: 'every sim should land in COMPLETED');
+    });
+
+    // NOTE: A "new PENDING sim arrives AFTER engine.start()" test
+    // belongs here in principle — that's the actual cloud-mode signal
+    // path. We don't have it because fake_cloud_firestore doesn't
+    // re-fire collectionGroup snapshots on subcollection inserts; the
+    // production Firestore SDK does. End-to-end coverage of the
+    // reactive path requires the Firebase emulator (separate test
+    // tier) or a real Firestore instance.
+
+    test('claim races: two sims, capacity 2, both processed', () async {
+      // Capacity is 2 so both can run concurrently.
+      await seedJob(jobId: 'job2', simCount: 4);
+      await engine.start();
+      await _waitForCondition(
+        () async => stubRunner.invocations >= 4,
+        timeout: const Duration(seconds: 5),
+      );
+      expect(stubRunner.invocations, 4);
+    });
+  });
+}
+
+/// Block until [check] returns true. Polls every 20ms.
+Future<void> _waitForCondition(
+  Future<bool> Function() check, {
+  required Duration timeout,
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (await check()) return;
+    await Future.delayed(const Duration(milliseconds: 20));
+  }
+  throw TimeoutException('condition not met within $timeout');
+}
+
+/// A SimRunner stand-in that immediately returns success without
+/// spawning Java. Counts invocations so tests can assert on them.
+class _StubSimRunner extends SimRunner {
+  _StubSimRunner() : super(javaPath: '/usr/bin/java', forgePath: '/tmp/forge');
+
+  int invocations = 0;
+
+  @override
+  Future<SimResult> runOne({
+    required JobInfo job,
+    Future<void>? cancelSignal,
+  }) async {
+    invocations++;
+    return SimResult(
+      success: true,
+      durationMs: 10,
+      winners: const ['Ai(1)-Alpha'],
+      winningTurns: const [7],
+      logText: 'stub run',
+      errorMessage: null,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

32 new tests across 5 files. With the 18 existing tests: 50/50 passing.

Covers every critical user journey from the request: deck selection, run a sim, all 4 decks play, real-time UI updates, turn count NOT 4×-multiplied, past games viewable, cancel stops immediately. Plus regression guards on the AppDb terminal-state preservation and atomic counter bumps.

See commit message for the journey → test mapping. `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)