### PR TITLE
test(flutter): expand worker suite + fix resume-on-COMPLETED bug

### DIFF
--- a/worker_flutter/lib/offline/offline_runner.dart
+++ b/worker_flutter/lib/offline/offline_runner.dart
@@ -50,13 +50,20 @@ class OfflineRunner {
   /// Find any jobs left RUNNING (or with PENDING sims) from a prior
   /// session and re-drive them. Called on app launch — without this,
   /// closing the app mid-run permanently strands those jobs.
+  ///
+  /// The "incomplete counter" branch also excludes terminal states
+  /// (CANCELLED / FAILED / COMPLETED) — without the COMPLETED guard,
+  /// a finalized job whose `completedSims` somehow trails `totalSims`
+  /// (direct DB edit, future bug, etc.) would get silently re-run and
+  /// overwrite its results.
   Future<void> resumeInFlightJobs() async {
+    const terminal = {'CANCELLED', 'FAILED', 'COMPLETED'};
     final all = await db.recentJobs(limit: 100);
     for (final job in all) {
-      if (job.state == 'RUNNING' ||
-          (job.completedSims < job.totalSims &&
-              job.state != 'CANCELLED' &&
-              job.state != 'FAILED')) {
+      final isRunning = job.state == 'RUNNING';
+      final isIncomplete =
+          job.completedSims < job.totalSims && !terminal.contains(job.state);
+      if (isRunning || isIncomplete) {
         // Don't await — start each in parallel-ish (the actual sim
         // runs are sequential per job, but multiple jobs interleave).
         unawaited(run(job.id));

--- a/worker_flutter/test/launch/mode_picker_test.dart
+++ b/worker_flutter/test/launch/mode_picker_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:worker_flutter/launch/mode_picker_screen.dart';
+
+/// The mode picker is the first screen a brand-new install sees and
+/// the routing decision made here decides whether `WorkerEngine`
+/// (cloud) or `OfflineRunner` boots. The persistence round-trip is
+/// what keeps the picker from re-appearing on every launch once the
+/// user has chosen, so a regression here is silently annoying.
+void main() {
+  setUp(() {
+    // `shared_preferences` has an in-test memory backend; reset between
+    // cases so cross-test leakage doesn't fake a passing round-trip.
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('LaunchMode prefs serialization', () {
+    test('round-trips cloud and offline through prefsValue/fromPrefs', () {
+      for (final mode in LaunchMode.values) {
+        final raw = mode.prefsValue;
+        expect(LaunchModeName.fromPrefs(raw), mode);
+      }
+    });
+
+    test('fromPrefs returns null for unknown / null values', () {
+      expect(LaunchModeName.fromPrefs(null), isNull);
+      expect(LaunchModeName.fromPrefs(''), isNull);
+      expect(
+        LaunchModeName.fromPrefs('hybrid'),
+        isNull,
+        reason:
+            'unknown strings must surface as null so a corrupted prefs '
+            'value falls back to the picker UI instead of throwing',
+      );
+    });
+  });
+
+  group('readRememberedLaunchMode', () {
+    test('returns null when nothing has been saved', () async {
+      expect(await readRememberedLaunchMode(), isNull);
+    });
+
+    test('returns the saved mode after a direct prefs write', () async {
+      // Bypass the widget — the helpers are also called from
+      // `_routeToMode` at boot before any UI is mounted, so they must
+      // work standalone.
+      SharedPreferences.setMockInitialValues({kLaunchModePrefsKey: 'cloud'});
+      expect(await readRememberedLaunchMode(), LaunchMode.cloud);
+
+      SharedPreferences.setMockInitialValues({kLaunchModePrefsKey: 'offline'});
+      expect(await readRememberedLaunchMode(), LaunchMode.offline);
+    });
+  });
+
+  group('clearRememberedLaunchMode', () {
+    test('removes the key so future reads see null', () async {
+      SharedPreferences.setMockInitialValues({kLaunchModePrefsKey: 'cloud'});
+      expect(await readRememberedLaunchMode(), LaunchMode.cloud);
+
+      await clearRememberedLaunchMode();
+      expect(
+        await readRememberedLaunchMode(),
+        isNull,
+        reason:
+            '"Switch to offline" must wipe the cloud preference so the '
+            'next launch re-shows the picker rather than silently '
+            'bouncing back to the prior mode',
+      );
+    });
+
+    test('is a no-op when nothing is set', () async {
+      // Defensive: a first-launch user has nothing to clear, but the
+      // helper might still get called during boot orchestration.
+      await expectLater(clearRememberedLaunchMode(), completes);
+      expect(await readRememberedLaunchMode(), isNull);
+    });
+  });
+}

--- a/worker_flutter/test/offline/resume_test.dart
+++ b/worker_flutter/test/offline/resume_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:worker_flutter/config.dart';
+import 'package:worker_flutter/models/sim.dart';
+import 'package:worker_flutter/offline/db/app_db.dart';
+import 'package:worker_flutter/offline/offline_runner.dart';
+import 'package:worker_flutter/worker/sim_runner.dart';
+
+/// `resumeInFlightJobs` runs on app launch and is the only guard
+/// against permanently stranded sims after a hard quit. Its filter is
+/// "RUNNING, OR (incomplete AND not terminal)". The tests here pin
+/// each branch of that filter so a refactor of the boolean — or of
+/// the terminal-state list — doesn't quietly drop or duplicate work.
+void main() {
+  late Directory tempRoot;
+  late WorkerConfig config;
+  late AppDb db;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('resume_test_');
+    Directory(
+      p.join(tempRoot.path, 'forge', 'res', 'Decks', 'Commander'),
+    ).createSync(recursive: true);
+    final decksDir = Directory(p.join(tempRoot.path, 'staged'))
+      ..createSync(recursive: true);
+    final logsDir = Directory(p.join(tempRoot.path, 'logs'))
+      ..createSync(recursive: true);
+    config = WorkerConfig(
+      workerId: 'w',
+      workerName: 'w',
+      maxCapacity: 1,
+      forgePath: p.join(tempRoot.path, 'forge'),
+      javaPath: '/usr/bin/java',
+      decksPath: decksDir.path,
+      logsPath: logsDir.path,
+      apiUrl: 'http://localhost',
+      workerSecret: null,
+    );
+    db = AppDb.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+  });
+
+  Future<int> insertJob({
+    required String state,
+    required int total,
+    required int completed,
+  }) async {
+    final id = await db
+        .into(db.jobs)
+        .insert(
+          JobsCompanion.insert(
+            createdAt: DateTime.now(),
+            totalSims: total,
+            completedSims: Value(completed),
+            state: Value(state),
+            deck1Name: 'A',
+            deck2Name: 'B',
+            deck3Name: 'C',
+            deck4Name: 'D',
+          ),
+        );
+    return id;
+  }
+
+  test('resumes RUNNING jobs with incomplete sim counts', () async {
+    final id = await insertJob(state: 'RUNNING', total: 3, completed: 1);
+    final stub = _NeverCalledSimRunner();
+    final runner = OfflineRunner(db: db, config: config, runnerOverride: stub);
+
+    await runner.resumeInFlightJobs();
+    // The runner kicks `run()` in unawaited microtasks; wait briefly
+    // for the state flip from PENDING/RUNNING.
+    await _waitFor(
+      () async => (await db.jobById(id))?.state != 'RUNNING',
+      timeout: const Duration(seconds: 2),
+    );
+    // Without bundled precons available, `_drive` will fail the job —
+    // but the key signal is that resumption picked it up at all, which
+    // we prove via the state transitioning out of plain RUNNING.
+    final after = await db.jobById(id);
+    expect(after, isNotNull);
+    expect(
+      after!.state,
+      isNot('RUNNING'),
+      reason:
+          'resumed job must move past plain RUNNING (to FAILED or COMPLETED)',
+    );
+  });
+
+  test('resumes jobs in PENDING state with PENDING sims remaining', () async {
+    final id = await insertJob(state: 'PENDING', total: 5, completed: 2);
+    final runner = OfflineRunner(
+      db: db,
+      config: config,
+      runnerOverride: _NeverCalledSimRunner(),
+    );
+
+    await runner.resumeInFlightJobs();
+    await _waitFor(
+      () async => (await db.jobById(id))?.state != 'PENDING',
+      timeout: const Duration(seconds: 2),
+    );
+    final after = await db.jobById(id);
+    expect(after!.state, isNot('PENDING'));
+  });
+
+  test('does NOT resume CANCELLED jobs', () async {
+    final id = await insertJob(state: 'CANCELLED', total: 5, completed: 1);
+    final runner = OfflineRunner(
+      db: db,
+      config: config,
+      runnerOverride: _NeverCalledSimRunner(),
+    );
+
+    await runner.resumeInFlightJobs();
+    // Give the unawaited runs a chance to misfire if the filter broke.
+    await Future.delayed(const Duration(milliseconds: 150));
+    final after = await db.jobById(id);
+    expect(
+      after!.state,
+      'CANCELLED',
+      reason:
+          'A user-cancelled job must stay cancelled across restarts. '
+          'Resuming it would silently re-run sims the user explicitly '
+          'stopped.',
+    );
+  });
+
+  test('does NOT resume FAILED jobs', () async {
+    final id = await insertJob(state: 'FAILED', total: 5, completed: 3);
+    final runner = OfflineRunner(
+      db: db,
+      config: config,
+      runnerOverride: _NeverCalledSimRunner(),
+    );
+
+    await runner.resumeInFlightJobs();
+    await Future.delayed(const Duration(milliseconds: 150));
+    final after = await db.jobById(id);
+    expect(after!.state, 'FAILED');
+  });
+
+  test('does NOT resume COMPLETED jobs even if counters look off', () async {
+    // Inconsistent-state regression guard: a job ending COMPLETED with
+    // completedSims < totalSims (which can only happen via direct DB
+    // edits or future bugs) must still NOT be resumed. The filter's
+    // "RUNNING OR (incomplete AND not CANCELLED/FAILED)" branch would
+    // pick this up if it didn't also exclude COMPLETED.
+    final id = await insertJob(state: 'COMPLETED', total: 5, completed: 3);
+    final runner = OfflineRunner(
+      db: db,
+      config: config,
+      runnerOverride: _NeverCalledSimRunner(),
+    );
+
+    await runner.resumeInFlightJobs();
+    await Future.delayed(const Duration(milliseconds: 150));
+    final after = await db.jobById(id);
+    expect(
+      after!.state,
+      'COMPLETED',
+      reason:
+          'Inconsistent counters must not resurrect a terminally '
+          'COMPLETED job. Better to keep stale-but-stable state than '
+          'silently overwrite a finalized run.',
+    );
+  });
+}
+
+/// Polls `check` until it returns true or the deadline passes. Used to
+/// wait for the unawaited Futures `resumeInFlightJobs` kicks off.
+Future<void> _waitFor(
+  Future<bool> Function() check, {
+  required Duration timeout,
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (await check()) return;
+    await Future.delayed(const Duration(milliseconds: 25));
+  }
+  // Don't throw — the resume tests assert on terminal state, so a
+  // polling timeout just means the assertion will fail with a clearer
+  // message than a TimeoutException buried in the test harness.
+}
+
+class _NeverCalledSimRunner extends SimRunner {
+  _NeverCalledSimRunner() : super(javaPath: '/usr/bin/java', forgePath: '/tmp');
+
+  @override
+  Future<SimResult> runOne({
+    required JobInfo job,
+    Future<void>? cancelSignal,
+  }) async {
+    // Resume should fail-fast on the missing-precons branch before
+    // ever calling runOne, since the test rig has no .dck files.
+    throw StateError('runOne should not be reached in resume tests');
+  }
+}

--- a/worker_flutter/test/worker/log_uploader_test.dart
+++ b/worker_flutter/test/worker/log_uploader_test.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:worker_flutter/worker/log_uploader.dart';
+
+/// `LogUploader` is intentionally non-throwing — a sim's terminal
+/// state lands in Firestore before the upload runs, so missing logs
+/// are cosmetic. These tests pin that contract so a future "throw on
+/// error" rewrite trips the regression and we'd notice that a 5xx
+/// from the API was silently killing the job's terminal write.
+void main() {
+  group('LogUploader.upload', () {
+    test('posts to the per-sim endpoint with the right shape', () async {
+      late String capturedUrl;
+      late Map<String, String> capturedHeaders;
+      late Map<String, dynamic> capturedBody;
+      final client = MockClient((req) async {
+        capturedUrl = req.url.toString();
+        capturedHeaders = req.headers;
+        capturedBody = jsonDecode(req.body) as Map<String, dynamic>;
+        return http.Response('{"ok":true}', 200);
+      });
+      final uploader = LogUploader(
+        apiUrl: 'https://api.example.com',
+        workerSecret: 'secret123',
+        client: client,
+      );
+      await uploader.upload(
+        jobId: 'job-abc',
+        simIndex: 4,
+        logText: 'sim 5 stdout',
+      );
+
+      expect(
+        capturedUrl,
+        'https://api.example.com/api/jobs/job-abc/logs/simulation',
+      );
+      expect(capturedHeaders['X-Worker-Secret'], 'secret123');
+      expect(capturedHeaders['Content-Type'], contains('application/json'));
+      expect(
+        capturedBody['filename'],
+        'raw/game_005.txt',
+        reason:
+            'simIndex is 0-based but the cloud filename is 1-based + zero '
+            'padded so it sorts naturally next to game_001..N',
+      );
+      expect(capturedBody['logText'], 'sim 5 stdout');
+    });
+
+    test('returns silently when worker secret is empty', () async {
+      var posted = false;
+      final client = MockClient((req) async {
+        posted = true;
+        return http.Response('', 200);
+      });
+      final uploader = LogUploader(
+        apiUrl: 'https://api.example.com',
+        workerSecret: '',
+        client: client,
+      );
+      // Should be a no-op — local-mode workers run without a secret
+      // and shouldn't burn cloud round-trips per sim.
+      await uploader.upload(jobId: 'job', simIndex: 0, logText: 'x');
+      expect(posted, isFalse);
+      expect(uploader.isConfigured, isFalse);
+    });
+
+    test('swallows a 5xx without throwing', () async {
+      final client = MockClient(
+        (req) async => http.Response('upstream down', 503),
+      );
+      final uploader = LogUploader(
+        apiUrl: 'https://api.example.com',
+        workerSecret: 'k',
+        client: client,
+      );
+      // The contract: terminal sim state is written before this runs,
+      // so an upload failure must not bubble and undo that write.
+      await expectLater(
+        uploader.upload(jobId: 'j', simIndex: 0, logText: 'x'),
+        completes,
+      );
+    });
+
+    test('swallows a transport exception without throwing', () async {
+      final client = MockClient(
+        (req) async => throw const SocketExceptionLike('DNS failure'),
+      );
+      final uploader = LogUploader(
+        apiUrl: 'https://api.example.com',
+        workerSecret: 'k',
+        client: client,
+      );
+      await expectLater(
+        uploader.upload(jobId: 'j', simIndex: 0, logText: 'x'),
+        completes,
+      );
+    });
+
+    test(
+      'respects the 30s timeout (returns silently after deadline)',
+      () async {
+        final client = MockClient((req) async {
+          // Block the response far past the uploader's deadline. The
+          // uploader times itself out, returns silently, and the test's
+          // `completes` proves we didn't deadlock.
+          await Future.delayed(const Duration(seconds: 35));
+          return http.Response('', 200);
+        });
+        final uploader = LogUploader(
+          apiUrl: 'https://api.example.com',
+          workerSecret: 'k',
+          client: client,
+        );
+        await expectLater(
+          uploader
+              .upload(jobId: 'j', simIndex: 0, logText: 'x')
+              .timeout(const Duration(seconds: 35)),
+          completes,
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 45)),
+    );
+  });
+}
+
+/// Plain `SocketException` would force dart:io import in tests that
+/// otherwise stay platform-agnostic; this stand-in is enough to drive
+/// the `catch (e)` branch.
+class SocketExceptionLike implements Exception {
+  const SocketExceptionLike(this.message);
+  final String message;
+  @override
+  String toString() => 'SocketExceptionLike: $message';
+}


### PR DESCRIPTION
## Summary

Three new spec files (16 tests) + one production-code fix surfaced by the test-gap audit.

- \`test/worker/log_uploader_test.dart\` (5) — \`LogUploader.upload\` never throws on 5xx, transport errors, or 30s timeout. Terminal sim state lands in Firestore before this runs; a throw would unwind that write.
- \`test/launch/mode_picker_test.dart\` (6) — pins \`readRememberedLaunchMode\` / \`clearRememberedLaunchMode\` round-trip so the picker doesn't silently re-appear (or get stuck) on subsequent boots.
- \`test/offline/resume_test.dart\` (5) — covers every terminal state for the \`resumeInFlightJobs\` filter.

## Bug found by the COMPLETED-state test

The prior filter excluded CANCELLED/FAILED but not COMPLETED, so a finalized job with inconsistent counters (\`completedSims < totalSims\`) would get silently re-run on next boot. Production fix in \`lib/offline/offline_runner.dart\` collapses the terminal-state checks into a single set.

## Audit context

This is the high-value subset from a broader Flutter test-gap audit. Remaining items (installer redirect/SHA mismatch, auth widget tests, dashboard StreamBuilder binding) deferred to follow-up PRs once the \`feat/google-sign-in\` branch lands — those tests want the AuthService seam.

## Test plan

- [x] flutter analyze: clean (only a pre-existing info-level lint in app_db.dart, untouched).
- [x] All 16 new tests pass locally (no flake on three consecutive \`flutter test\` runs).
- [ ] CI re-confirms once merged into the existing test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)