### PR TITLE
chore(auth): wire new Google OAuth client ID for macOS

### DIFF
--- a/worker_flutter/lib/firebase_options.dart
+++ b/worker_flutter/lib/firebase_options.dart
@@ -33,8 +33,13 @@ class DefaultFirebaseOptions {
     projectId: 'magic-bracket-simulator',
     databaseURL: 'https://magic-bracket-simulator-default-rtdb.firebaseio.com',
     storageBucket: 'magic-bracket-simulator.firebasestorage.app',
-    iosClientId: '14286370379-lfs99gcgmrv03rhpbijdev0bfd2r5u6s.apps.googleusercontent.com',
-    iosBundleId: 'com.tytaniumdev.workerFlutter',
+    // OAuth client for Google Sign-In on macOS. Created as an iOS-type
+    // client in GCP Console because Flutter's `google_sign_in` package
+    // routes macOS through the iOS SDK and looks up `iosClientId` by
+    // convention. Bundle ID must match the post-rename identifier.
+    iosClientId:
+        '14286370379-echlkrv6jd11ep7341irajaf8anr3f1i.apps.googleusercontent.com',
+    iosBundleId: 'com.tytaniumdev.magicBracketSimulator',
   );
 
   // The `flutterfire configure` CLI will overwrite this whole file.


### PR DESCRIPTION
## Summary

Wires the freshly-minted OAuth Client ID into \`firebase_options.dart\` and fixes the bundle ID that still pointed at the pre-rename identifier.

- New client: \`14286370379-echlkrv6jd11ep7341irajaf8anr3f1i.apps.googleusercontent.com\` (iOS type, bundle \`com.tytaniumdev.magicBracketSimulator\`).
- Bundle ID corrected from \`com.tytaniumdev.workerFlutter\` (stale) to \`com.tytaniumdev.magicBracketSimulator\` (matches Xcode).

## Test plan

- [x] flutter analyze clean.
- [ ] After merge, sign in via the macOS AuthGate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)