### PR TITLE
fix(worker): trigger job aggregation fast-path on Flutter sim terminal

### DIFF
--- a/api/app/api/jobs/[id]/aggregate-if-done/route.ts
+++ b/api/app/api/jobs/[id]/aggregate-if-done/route.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /api/jobs/:id/aggregate-if-done — Fast-path aggregation trigger
+ * for workers that write sim results directly to Firestore (notably
+ * the Flutter desktop worker).
+ *
+ * The Docker worker reports sim results via PATCH
+ * /api/jobs/:id/simulations/:simId, and that handler fires
+ * `aggregateJobResults` inline. The Flutter worker bypasses the API
+ * for sim writes (direct Firestore for low latency), so it has no
+ * way to trigger aggregation from inside the request — without this
+ * endpoint, Flutter-completed jobs sit in RUNNING until the 15-minute
+ * stale-sweeper catches them.
+ *
+ * This endpoint:
+ *   1. Auths the caller with WORKER_SECRET (same header the Flutter
+ *      LogUploader uses).
+ *   2. Calls `aggregateJobResults(id)`, which itself is idempotent —
+ *      it short-circuits if (a) any sim is non-terminal, or (b) the
+ *      job is already COMPLETED/FAILED. Safe to call from every sim
+ *      terminal report.
+ *
+ * Errors are returned as 5xx so the caller can retry. Real callers
+ * (the Flutter worker) treat failures as non-fatal — the stale
+ * sweeper is still the safety net.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { isWorkerRequest } from '@/lib/auth';
+import { aggregateJobResults } from '@/lib/job-store-factory';
+import { errorResponse } from '@/lib/api-response';
+
+const IS_LOCAL_MODE = !process.env.GOOGLE_CLOUD_PROJECT;
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!IS_LOCAL_MODE && !isWorkerRequest(req)) {
+    return errorResponse('Unauthorized', 401);
+  }
+  const { id } = await params;
+  if (!id) return errorResponse('Missing job id', 400);
+
+  try {
+    await aggregateJobResults(id);
+    return NextResponse.json({ jobId: id, triggered: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResponse(`Aggregation failed: ${message}`, 500);
+  }
+}

--- a/worker_flutter/lib/worker/job_aggregator.dart
+++ b/worker_flutter/lib/worker/job_aggregator.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+/// Calls `POST /api/jobs/:id/aggregate-if-done` after a sim's
+/// terminal write so the API runs `aggregateJobResults` immediately
+/// instead of waiting for the 15-min stale-sweeper.
+///
+/// Failures are non-fatal: the terminal sim state is already in
+/// Firestore by the time this fires, and the stale-sweeper picks up
+/// any jobs whose fast-path call missed.
+class JobAggregator {
+  JobAggregator({
+    required this.apiUrl,
+    required this.workerSecret,
+    http.Client? client,
+  }) : _client = client ?? http.Client();
+
+  final String apiUrl;
+  final String? workerSecret;
+  final http.Client _client;
+
+  bool get isConfigured => workerSecret != null && workerSecret!.isNotEmpty;
+
+  Future<void> triggerIfDone(String jobId) async {
+    if (!isConfigured) return;
+    final uri = Uri.parse('$apiUrl/api/jobs/$jobId/aggregate-if-done');
+    try {
+      final resp = await _client
+          .post(uri, headers: {'X-Worker-Secret': workerSecret!})
+          .timeout(const Duration(seconds: 15));
+      if (resp.statusCode >= 200 && resp.statusCode < 300) {
+        debugPrint('JobAggregator: triggered for $jobId');
+      } else {
+        debugPrint(
+          'JobAggregator: HTTP ${resp.statusCode} for $jobId: ${resp.body}',
+        );
+      }
+    } catch (e) {
+      debugPrint('JobAggregator: trigger failed for $jobId: $e');
+    }
+  }
+
+  void close() => _client.close();
+}

--- a/worker_flutter/lib/worker/worker_engine.dart
+++ b/worker_flutter/lib/worker/worker_engine.dart
@@ -7,6 +7,7 @@ import 'package:rxdart/subjects.dart';
 
 import '../config.dart';
 import '../models/sim.dart';
+import 'job_aggregator.dart';
 import 'lease_writer.dart';
 import 'log_uploader.dart';
 import 'sim_claim.dart';
@@ -78,6 +79,10 @@ class WorkerEngine {
        _logUploader = LogUploader(
          apiUrl: config.apiUrl,
          workerSecret: config.workerSecret,
+       ),
+       _jobAggregator = JobAggregator(
+         apiUrl: config.apiUrl,
+         workerSecret: config.workerSecret,
        );
 
   final WorkerConfig config;
@@ -86,6 +91,7 @@ class WorkerEngine {
   final LeaseWriter _leaseWriter;
   final SimClaimer _claimer;
   final LogUploader _logUploader;
+  final JobAggregator _jobAggregator;
 
   final _stateSubject = BehaviorSubject<EngineState>.seeded(
     EngineState.initial(),
@@ -225,6 +231,7 @@ class WorkerEngine {
             errorMessage: 'job ${sim.jobId} not found',
           ),
         );
+        unawaited(_jobAggregator.triggerIfDone(sim.jobId));
         return;
       }
 
@@ -247,6 +254,7 @@ class WorkerEngine {
             errorMessage: 'missing deck files: ${missingDecks.join(', ')}',
           ),
         );
+        unawaited(_jobAggregator.triggerIfDone(sim.jobId));
         return;
       }
 
@@ -265,6 +273,12 @@ class WorkerEngine {
           logText: result.logText,
         ),
       );
+
+      // Fast-path: ask the API to aggregate the parent job NOW if
+      // every sim is terminal. Without this the job sits in RUNNING
+      // until the 15-minute stale-sweeper picks it up — see
+      // `JobAggregator` docstring. Idempotent + non-fatal.
+      unawaited(_jobAggregator.triggerIfDone(sim.jobId));
 
       if (result.success) {
         _stateSubject.add(
@@ -285,6 +299,7 @@ class WorkerEngine {
           errorMessage: e.toString(),
         ),
       );
+      unawaited(_jobAggregator.triggerIfDone(sim.jobId));
     } finally {
       _semaphoreActive--;
       _cancelByComposite.remove(sim.compositeId);


### PR DESCRIPTION
## Why

The parity audit between Flutter and Docker workers turned up one real cutover blocker. Docker workers POST sim results → API increments \`completedSimCount\` → API fires \`aggregateJobResults\` when \`completedSimCount &gt;= totalSimCount\`. Flutter writes Firestore directly → counter increments → no trigger fires.

The 15-minute stale-sweeper picks these up eventually, but the UX is "all sims show COMPLETED but the job sits in RUNNING for 15 min." Bad.

## What

- **New endpoint** \`POST /api/jobs/:id/aggregate-if-done\` — authed with WORKER_SECRET, calls the existing idempotent \`aggregateJobResults\`. ~30 lines.
- **New Flutter \`JobAggregator\`** — fire-and-forget POST to the new endpoint after each terminal report. Same shape as the existing \`LogUploader\`. ~50 lines.
- **WorkerEngine** fires \`triggerIfDone\` at all four reportTerminal sites (happy path, job-not-found, missing-decks, catch-all). Idempotent so racing calls are harmless.

## Test plan

- [x] API lints clean (\`tsc --noEmit && eslint\`).
- [x] Flutter analyze clean.
- [x] 30/30 worker tests pass.
- [ ] After merge: tag a release, run one cloud-mode sim end-to-end, confirm the job flips RUNNING → COMPLETED within seconds rather than 15 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)