### PR TITLE
fix(worker): wire native launch_at_startup bridge for macOS

### DIFF
--- a/worker_flutter/macos/Podfile.lock
+++ b/worker_flutter/macos/Podfile.lock
@@ -1394,6 +1394,8 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - package_info_plus (0.0.1):
+    - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
@@ -1427,6 +1429,8 @@ PODS:
     - sqlite3/session
   - tray_manager (0.0.1):
     - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
   - window_manager (0.2.0):
     - FlutterMacOS
 
@@ -1437,10 +1441,12 @@ DEPENDENCIES:
   - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
   - firebase_storage (from `Flutter/ephemeral/.symlinks/plugins/firebase_storage/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 SPEC REPOS:
@@ -1480,6 +1486,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/firebase_storage/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   screen_retriever_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
   shared_preferences_foundation:
@@ -1488,6 +1496,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin
   tray_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/tray_manager/macos
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   window_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
@@ -1517,12 +1527,14 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: fc75fc972958dceedee61cb662ae1da7a83a91cf
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   Sparkle: a4115cd9a339b297a61163256e6954d9e35297ce
   sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
   sqlite3_flutter_libs: b3e120efe9a82017e5552a620f696589ed4f62ab
   tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166
+  url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
   window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009

--- a/worker_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/worker_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		44FD91872FB6DC58003D12C3 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 44FD91862FB6DC58003D12C3 /* LaunchAtLogin */; };
 		EC2D53DCED3FFB3674BCA621 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8597895625A89E8B0385E15A /* GoogleService-Info.plist */; };
 		F0EFFC3084AAEFED1E7DF31F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96B92430508EEDC7BC55A55C /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
@@ -105,6 +106,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44FD91872FB6DC58003D12C3 /* LaunchAtLogin in Frameworks */,
 				F0EFFC3084AAEFED1E7DF31F /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -198,7 +200,6 @@
 				C961C1F67E3EBC30C485821E /* Pods-RunnerTests.release.xcconfig */,
 				A212953881FAD46D1D4ED6A7 /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -241,6 +242,7 @@
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
+				44FD91882FB6DCB1003D12C3 /* Run Script */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
 				65B07247CF1C1C02E47E3016 /* [CP] Embed Pods Frameworks */,
@@ -295,6 +297,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				44FD91852FB6DC58003D12C3 /* XCRemoteSwiftPackageReference "LaunchAtLogin" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -364,6 +369,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		44FD91882FB6DCB1003D12C3 /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${BUILT_PRODUCTS_DIR}/LaunchAtLogin_LaunchAtLogin.bundle/Contents/Resources/copy-helper-swiftpm.sh\"\n";
 		};
 		4A2F7CE62A0E37E5EB17BB62 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -809,6 +833,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		44FD91852FB6DC58003D12C3 /* XCRemoteSwiftPackageReference "LaunchAtLogin" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/LaunchAtLogin";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		44FD91862FB6DC58003D12C3 /* LaunchAtLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 44FD91852FB6DC58003D12C3 /* XCRemoteSwiftPackageReference "LaunchAtLogin" */;
+			productName = LaunchAtLogin;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/worker_flutter/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/worker_flutter/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "4ffd020922d5cb1e4bad73064b0d31b058749aa71ce2bf650dc9871b0d3d582e",
+  "pins" : [
+    {
+      "identity" : "launchatlogin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/LaunchAtLogin",
+      "state" : {
+        "revision" : "9a894d799269cb591037f9f9cb0961510d4dca81",
+        "version" : "5.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/worker_flutter/macos/Runner/MainFlutterWindow.swift
+++ b/worker_flutter/macos/Runner/MainFlutterWindow.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import LaunchAtLogin
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
@@ -7,6 +8,29 @@ class MainFlutterWindow: NSWindow {
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)
+
+    // launch_at_startup (the Dart package) is a thin wrapper that expects
+    // the host app to register a MethodChannel handler backed by Apple's
+    // ServiceManagement APIs. The pub package ships no native code on
+    // macOS, so without this bridge every isEnabled/enable/disable call
+    // throws MissingPluginException and the dashboard toggle silently
+    // snaps back to its prior state.
+    FlutterMethodChannel(
+      name: "launch_at_startup",
+      binaryMessenger: flutterViewController.engine.binaryMessenger
+    ).setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "launchAtStartupIsEnabled":
+        result(LaunchAtLogin.isEnabled)
+      case "launchAtStartupSetEnabled":
+        if let arguments = call.arguments as? [String: Any] {
+          LaunchAtLogin.isEnabled = arguments["setEnabledValue"] as! Bool
+        }
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 

--- a/worker_flutter/macos/Runner/MainFlutterWindow.swift
+++ b/worker_flutter/macos/Runner/MainFlutterWindow.swift
@@ -23,9 +23,16 @@ class MainFlutterWindow: NSWindow {
       case "launchAtStartupIsEnabled":
         result(LaunchAtLogin.isEnabled)
       case "launchAtStartupSetEnabled":
-        if let arguments = call.arguments as? [String: Any] {
-          LaunchAtLogin.isEnabled = arguments["setEnabledValue"] as! Bool
+        guard let arguments = call.arguments as? [String: Any],
+              let enabled = arguments["setEnabledValue"] as? Bool else {
+          result(FlutterError(
+            code: "BAD_ARGS",
+            message: "launchAtStartupSetEnabled requires setEnabledValue: Bool",
+            details: nil
+          ))
+          return
         }
+        LaunchAtLogin.isEnabled = enabled
         result(nil)
       default:
         result(FlutterMethodNotImplemented)


### PR DESCRIPTION
## Summary

- `launch_at_startup` 0.5.x ships no native macOS plugin code; the host app must register the `launch_at_startup` `FlutterMethodChannel` handler itself. PR #208 added the Dart/UI layer of the launch-at-login toggle but missed this native bridge, so every `isEnabled`/`enable`/`disable` call threw `MissingPluginException` and the dashboard toggle silently snapped back to its prior state.
- Adds the channel handler in `MainFlutterWindow.swift` backed by `sindresorhus/LaunchAtLogin` (SPM `^5.0.0`). Also adds the Run Script phase that copies the LaunchAtLogin helper bundle (required for macOS <13, no-op on 13+) and disables `ENABLE_USER_SCRIPT_SANDBOXING` on the Runner target so that script runs under Xcode 15+ defaults.
- Brings `Podfile.lock` in sync with the `package_info_plus` / `url_launcher_macos` pods PR #208 introduced (their entries had drifted out of `Podfile.lock`).

## Test plan

- [x] `flutter run -d macos` (debug, doppler-injected secrets) → Launch-at-login toggle changes state and holds it
- [x] Quit and relaunch app → toggle reflects the persisted Login Items state
- [x] No `MissingPluginException` lines in flutter run stdout
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)