### PR TITLE
feat(worker): add Sentry logging to desktop apps

### DIFF
--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -86,7 +86,9 @@ jobs:
             "ASC_ISSUER_ID",
             "ASC_API_KEY_CONTENT",
             "ASC_API_KEY_IS_BASE64",
-            "GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET"
+            "GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET",
+            "SENTRY_DSN_WORKER",
+            "SENTRY_AUTH_TOKEN_WORKER"
           ]'
           echo "$SECRETS" | jq -r --argjson keys "$KEYS" '
             to_entries[] | select(.key | IN($keys[])) | .value
@@ -141,11 +143,28 @@ jobs:
           ASC_API_KEY_IS_BASE64: ${{ env.ASC_API_KEY_IS_BASE64 }}
           # Forwarded into Flutter via --dart-define inside the Fastfile.
           GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET: ${{ env.GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET }}
+          # Sentry build-time wiring. Empty SENTRY_DSN_WORKER → no-op.
+          SENTRY_DSN_WORKER: ${{ env.SENTRY_DSN_WORKER }}
+          SENTRY_RELEASE: worker_flutter@${{ needs.version.outputs.version }}
+          # GITHUB_SHA is already set by Actions; surface it explicitly
+          # so the Fastfile's ENV.fetch is reading the canonical value.
+          GITHUB_SHA: ${{ github.sha }}
           FASTLANE_HIDE_CHANGELOG: "1"
           FASTLANE_SKIP_UPDATE_CHECK: "1"
           FASTLANE_DISABLE_COLORS: "1"
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/match_deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         run: bundle exec fastlane release
+
+      - name: Upload Dart debug symbols to Sentry (macOS)
+        if: env.SENTRY_AUTH_TOKEN_WORKER != ''
+        working-directory: worker_flutter
+        env:
+          SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN_WORKER }}
+          SENTRY_RELEASE: worker_flutter@${{ needs.version.outputs.version }}
+        # continue-on-error: a Sentry outage shouldn't fail the release.
+        # Symbols can be re-uploaded later from build/debug-info/macos.
+        continue-on-error: true
+        run: dart run sentry_dart_plugin
 
       - name: Sign zip for Sparkle (EdDSA)
         env:
@@ -203,22 +222,37 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3
 
-      - name: Load Desktop OAuth secret from Doppler
+      - name: Load secrets from Doppler
         shell: bash
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_BLINKBREAK_TOKEN }}
         run: |
-          # Single-value fetch keeps the surface narrow — the Windows
-          # build only needs the OAuth client_secret. Mask it before
-          # forwarding to subsequent steps via GITHUB_ENV.
-          SECRET=$(doppler secrets get GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET \
-            --project blinkbreak --config prd --plain)
+          # OAuth client_secret is required; Sentry DSN + auth token are
+          # optional (empty DSN → SDK no-ops; empty token → plugin
+          # upload step is skipped).
+          fetch_secret() {
+            doppler secrets get "$1" --project blinkbreak --config prd --plain
+          }
+          SECRET=$(fetch_secret GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET)
           if [ -z "$SECRET" ]; then
             echo "::error::Doppler returned empty GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET" >&2
             exit 1
           fi
           echo "::add-mask::$SECRET"
           echo "GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET=$SECRET" >> "$GITHUB_ENV"
+
+          # || true so a missing Sentry secret (e.g. before the operator
+          # has populated Doppler) doesn't fail the release.
+          SENTRY_DSN=$(fetch_secret SENTRY_DSN_WORKER || true)
+          if [ -n "$SENTRY_DSN" ]; then
+            echo "::add-mask::$SENTRY_DSN"
+            echo "SENTRY_DSN_WORKER=$SENTRY_DSN" >> "$GITHUB_ENV"
+          fi
+          SENTRY_TOKEN=$(fetch_secret SENTRY_AUTH_TOKEN_WORKER || true)
+          if [ -n "$SENTRY_TOKEN" ]; then
+            echo "::add-mask::$SENTRY_TOKEN"
+            echo "SENTRY_AUTH_TOKEN_WORKER=$SENTRY_TOKEN" >> "$GITHUB_ENV"
+          fi
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
@@ -238,9 +272,28 @@ jobs:
           # OAuth token endpoint requires client_secret even with PKCE,
           # so it gets baked into the binary at build time.
           DESKTOP_SECRET: ${{ env.GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET }}
+          # Sentry build-time inputs. SENTRY_DSN_WORKER may be empty (no-op).
+          SENTRY_DSN: ${{ env.SENTRY_DSN_WORKER }}
+          SENTRY_RELEASE: worker_flutter@${{ needs.version.outputs.version }}
+          GIT_SHA: ${{ github.sha }}
         run: |
           flutter build windows --release \
-            --dart-define=GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET="$DESKTOP_SECRET"
+            --obfuscate \
+            --split-debug-info=build/debug-info/windows \
+            --dart-define=GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET="$DESKTOP_SECRET" \
+            --dart-define=SENTRY_DSN="$SENTRY_DSN" \
+            --dart-define=SENTRY_RELEASE="$SENTRY_RELEASE" \
+            --dart-define=GIT_SHA="$GIT_SHA"
+
+      - name: Upload Dart debug symbols to Sentry (Windows)
+        if: env.SENTRY_AUTH_TOKEN_WORKER != ''
+        working-directory: worker_flutter
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN_WORKER }}
+          SENTRY_RELEASE: worker_flutter@${{ needs.version.outputs.version }}
+        continue-on-error: true
+        run: dart run sentry_dart_plugin
 
       - name: Package release as zip
         working-directory: worker_flutter

--- a/docs/superpowers/plans/2026-05-14-flutter-worker-sentry.md
+++ b/docs/superpowers/plans/2026-05-14-flutter-worker-sentry.md
@@ -1,0 +1,1014 @@
+# Flutter Worker Sentry Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `sentry_flutter` into the macOS/Windows desktop worker so unhandled crashes, known failure sites (sign-in, installer, engine start, worker runtime), and release-health sessions report to a new `magic-bracket-worker` Sentry project, with Dart debug symbols uploaded from CI.
+
+**Architecture:** `SentryFlutter.init(appRunner: _appMain)` replaces the manual `FlutterError.onError` / `PlatformDispatcher.onError` / `runZonedGuarded` hooks in `main.dart`. A small `Telemetry` helper centralizes breadcrumb + capture calls with a required `category` tag that downstream alert rules filter on. DSN + symbol-upload auth come from Doppler via `--dart-define` and env in `.github/workflows/release-worker.yml`.
+
+**Tech Stack:** Flutter (Dart 3.11), `sentry_flutter`, `sentry_dart_plugin` (dev), existing Doppler-backed release workflow.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-flutter-worker-sentry-design.md`
+
+---
+
+## File Map
+
+**Create:**
+- `worker_flutter/lib/telemetry.dart` — category enum, `Telemetry.breadcrumb`, `Telemetry.captureError`, `scrubPii` (also exported for the no-DSN-aware `buildSentryOptions`).
+- `worker_flutter/lib/sentry_setup.dart` — `buildSentryOptions(...)` configures `SentryFlutterOptions`. Pure, testable.
+- `worker_flutter/test/telemetry_test.dart`
+- `worker_flutter/test/sentry_options_test.dart`
+- `worker_flutter/docs/sentry-setup.md` — manual setup steps.
+
+**Modify:**
+- `worker_flutter/pubspec.yaml` — add `sentry_flutter` runtime dep + `sentry_dart_plugin` dev dep + `sentry:` config section.
+- `worker_flutter/lib/main.dart` — wrap with `SentryFlutter.init(appRunner: _appMain)`, drop manual hooks, replace `_log()` boot markers with a `_trace()` helper that does both, add `captureError` calls to Firebase-init and engine-start failure paths.
+- `worker_flutter/lib/auth/auth_service.dart` — wrap both sign-in flows' `FirebaseAuthException` and generic catches with `Telemetry.captureError(..., category: signIn)`.
+- `worker_flutter/lib/installer/installer.dart` — capture at each existing failure throw site (download / extract / SHA mismatch / manifest fetch).
+- `worker_flutter/lib/worker/worker_engine.dart` — replace the three existing `catch` blocks' silent logs with captures.
+- `.github/workflows/release-worker.yml` — add Doppler keys, pass `--dart-define`s, add `--obfuscate --split-debug-info`, run `dart run sentry_dart_plugin`.
+
+---
+
+## Task 1: Add Sentry dependencies
+
+**Files:**
+- Modify: `worker_flutter/pubspec.yaml`
+
+- [ ] **Step 1: Add runtime + dev deps**
+
+In `worker_flutter/pubspec.yaml`, under `dependencies:` (alphabetical-ish location, near the other Firebase entries), add:
+
+```yaml
+  # Crash + session reporting. DSN is provided at build time via
+  # --dart-define=SENTRY_DSN=... — empty in dev means no-op.
+  sentry_flutter: ^8.10.0
+```
+
+Under `dev_dependencies:` add:
+
+```yaml
+  # Uploads Dart obfuscation debug-info to Sentry so production stack
+  # traces deobfuscate. Runs in CI only (no-op without SENTRY_AUTH_TOKEN).
+  sentry_dart_plugin: ^2.0.0
+```
+
+At the bottom of the file (sibling of `flutter:`, `dependencies:`), add a top-level `sentry:` section:
+
+```yaml
+sentry:
+  project: magic-bracket-worker
+  org: tytaniumdev
+  upload_debug_symbols: true
+  upload_source_maps: false
+  upload_sources: true
+  log_level: info
+  # release + auth_token come from $SENTRY_RELEASE / $SENTRY_AUTH_TOKEN
+  # exported by the release workflow.
+```
+
+- [ ] **Step 2: Resolve deps**
+
+Run: `cd worker_flutter && flutter pub get`
+Expected: deps resolve, `pubspec.lock` updated, no errors. If `sentry_flutter` requires a Dart SDK constraint bump, note it and skip — the current `^3.11.5` constraint should satisfy `sentry_flutter ^8.x`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add worker_flutter/pubspec.yaml worker_flutter/pubspec.lock
+git commit -m "build(worker): add sentry_flutter + sentry_dart_plugin"
+```
+
+---
+
+## Task 2: Build `Telemetry` helper (TDD)
+
+**Files:**
+- Create: `worker_flutter/lib/telemetry.dart`
+- Create: `worker_flutter/test/telemetry_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+`worker_flutter/test/telemetry_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:worker_flutter/telemetry.dart';
+
+void main() {
+  group('Telemetry.scrubPii', () {
+    test('redacts email-shaped strings in event extra', () {
+      final event = SentryEvent(
+        message: const SentryMessage('hi'),
+        extra: <String, dynamic>{
+          'note': 'user contacted me at someone@example.com about it',
+          'okField': 'no pii here',
+        },
+      );
+      final scrubbed = scrubPii(event);
+      expect(scrubbed!.extra!['note'], contains('[redacted-email]'));
+      expect(scrubbed.extra!['note'], isNot(contains('someone@example.com')));
+      expect(scrubbed.extra!['okField'], 'no pii here');
+    });
+
+    test('redacts known PII keys', () {
+      final event = SentryEvent(
+        message: const SentryMessage('hi'),
+        extra: <String, dynamic>{
+          'email': 'a@b.com',
+          'uid': 'xyz',
+          'displayName': 'Tyler',
+          'safe': 'keep me',
+        },
+      );
+      final scrubbed = scrubPii(event)!;
+      expect(scrubbed.extra!['email'], '[redacted]');
+      expect(scrubbed.extra!['uid'], '[redacted]');
+      expect(scrubbed.extra!['displayName'], '[redacted]');
+      expect(scrubbed.extra!['safe'], 'keep me');
+    });
+
+    test('strips user object', () {
+      final event = SentryEvent(
+        message: const SentryMessage('hi'),
+        user: SentryUser(id: 'abc', email: 'x@y.com'),
+      );
+      final scrubbed = scrubPii(event)!;
+      expect(scrubbed.user, isNull);
+    });
+  });
+
+  group('TelemetryCategory', () {
+    test('snake_case rendering', () {
+      expect(TelemetryCategory.signIn.tagValue, 'sign_in');
+      expect(TelemetryCategory.engineStart.tagValue, 'engine_start');
+      expect(TelemetryCategory.firebaseInit.tagValue, 'firebase_init');
+      expect(TelemetryCategory.boot.tagValue, 'boot');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd worker_flutter && flutter test test/telemetry_test.dart`
+Expected: FAIL — `telemetry.dart` doesn't exist.
+
+- [ ] **Step 3: Write `telemetry.dart`**
+
+`worker_flutter/lib/telemetry.dart`:
+
+```dart
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Stable tag values are written as snake_case so they're easy to
+/// filter on in Sentry alert rules.
+enum TelemetryCategory {
+  boot,
+  firebaseInit,
+  signIn,
+  installer,
+  engineStart,
+  engineRuntime,
+  autoUpdater,
+  tray,
+}
+
+extension TelemetryCategoryTag on TelemetryCategory {
+  String get tagValue {
+    switch (this) {
+      case TelemetryCategory.boot:
+        return 'boot';
+      case TelemetryCategory.firebaseInit:
+        return 'firebase_init';
+      case TelemetryCategory.signIn:
+        return 'sign_in';
+      case TelemetryCategory.installer:
+        return 'installer';
+      case TelemetryCategory.engineStart:
+        return 'engine_start';
+      case TelemetryCategory.engineRuntime:
+        return 'engine_runtime';
+      case TelemetryCategory.autoUpdater:
+        return 'auto_updater';
+      case TelemetryCategory.tray:
+        return 'tray';
+    }
+  }
+}
+
+/// Thin convenience wrapper around `Sentry.addBreadcrumb` and
+/// `Sentry.captureException` so call sites stay readable and the
+/// `category` tag is impossible to forget.
+class Telemetry {
+  Telemetry._();
+
+  static void breadcrumb(
+    TelemetryCategory category,
+    String message, {
+    Map<String, dynamic>? data,
+  }) {
+    Sentry.addBreadcrumb(
+      Breadcrumb(
+        category: category.tagValue,
+        message: message,
+        data: data,
+        level: SentryLevel.info,
+      ),
+    );
+  }
+
+  static Future<void> captureError(
+    Object error,
+    StackTrace? stack, {
+    required TelemetryCategory category,
+    Map<String, String>? tags,
+    Map<String, dynamic>? extra,
+  }) async {
+    await Sentry.captureException(
+      error,
+      stackTrace: stack,
+      withScope: (scope) {
+        scope.setTag('category', category.tagValue);
+        if (tags != null) {
+          tags.forEach(scope.setTag);
+        }
+        if (extra != null) {
+          extra.forEach(scope.setExtra);
+        }
+      },
+    );
+  }
+}
+
+/// Matches typical email addresses. Conservative — we err on the side
+/// of redacting too eagerly rather than leaking PII into Sentry.
+final _emailRegex = RegExp(
+  r'[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,}',
+);
+
+const _piiKeys = <String>{
+  'email',
+  'mail',
+  'displayName',
+  'display_name',
+  'uid',
+  'userId',
+  'user_id',
+};
+
+/// `beforeSend` hook. Drops the user object and redacts known PII in
+/// extras / breadcrumb data. Synchronous — Sentry calls it on the same
+/// isolate as the capture.
+SentryEvent? scrubPii(SentryEvent event, {Hint? hint}) {
+  // event is immutable-ish; copyWith for the user clear, then mutate
+  // the extra/breadcrumb maps in place (they're not frozen).
+  final cleaned = event.copyWith(user: null);
+
+  final extra = cleaned.extra;
+  if (extra != null) {
+    for (final key in extra.keys.toList()) {
+      if (_piiKeys.contains(key)) {
+        extra[key] = '[redacted]';
+        continue;
+      }
+      final value = extra[key];
+      if (value is String && _emailRegex.hasMatch(value)) {
+        extra[key] = value.replaceAll(_emailRegex, '[redacted-email]');
+      }
+    }
+  }
+
+  final breadcrumbs = cleaned.breadcrumbs;
+  if (breadcrumbs != null) {
+    for (final crumb in breadcrumbs) {
+      final data = crumb.data;
+      if (data == null) continue;
+      for (final key in data.keys.toList()) {
+        if (_piiKeys.contains(key)) {
+          data[key] = '[redacted]';
+          continue;
+        }
+        final value = data[key];
+        if (value is String && _emailRegex.hasMatch(value)) {
+          data[key] = value.replaceAll(_emailRegex, '[redacted-email]');
+        }
+      }
+    }
+  }
+
+  return cleaned;
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+Run: `cd worker_flutter && flutter test test/telemetry_test.dart`
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add worker_flutter/lib/telemetry.dart worker_flutter/test/telemetry_test.dart
+git commit -m "feat(worker): add Telemetry helper + PII scrubber"
+```
+
+---
+
+## Task 3: Build `buildSentryOptions` (TDD)
+
+**Files:**
+- Create: `worker_flutter/lib/sentry_setup.dart`
+- Create: `worker_flutter/test/sentry_options_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+`worker_flutter/test/sentry_options_test.dart`:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:worker_flutter/sentry_setup.dart';
+
+void main() {
+  group('configureSentryOptions', () {
+    test('disables performance + profiling, enables session tracking', () {
+      final options = SentryFlutterOptions()..dsn = 'https://example@sentry.io/1';
+      configureSentryOptions(
+        options,
+        dsn: 'https://example@sentry.io/1',
+        release: 'worker_flutter@0.1.0+42',
+        gitSha: 'abc1234',
+      );
+      expect(options.tracesSampleRate, 0);
+      expect(options.profilesSampleRate, 0);
+      expect(options.enableAutoSessionTracking, isTrue);
+      expect(options.sendDefaultPii, isFalse);
+      expect(options.release, 'worker_flutter@0.1.0+42');
+      expect(options.dist, 'abc1234');
+      expect(
+        options.environment,
+        kDebugMode ? 'development' : 'production',
+      );
+    });
+
+    test('empty DSN leaves options safe (no-op mode)', () {
+      final options = SentryFlutterOptions();
+      configureSentryOptions(
+        options,
+        dsn: '',
+        release: 'worker_flutter@dev',
+        gitSha: 'local',
+      );
+      // Empty DSN: SDK treats this as disabled. We still expect the
+      // function to set the safety flags so a misconfigured CI doesn't
+      // accidentally enable perf monitoring.
+      expect(options.tracesSampleRate, 0);
+      expect(options.profilesSampleRate, 0);
+      expect(options.sendDefaultPii, isFalse);
+    });
+
+    test('attaches beforeSend that strips user', () {
+      final options = SentryFlutterOptions();
+      configureSentryOptions(
+        options,
+        dsn: 'https://example@sentry.io/1',
+        release: 'r',
+        gitSha: 's',
+      );
+      final cb = options.beforeSend;
+      expect(cb, isNotNull);
+      final input = SentryEvent(
+        message: const SentryMessage('x'),
+        user: SentryUser(id: 'u', email: 'a@b.com'),
+      );
+      final out = cb!(input);
+      // beforeSend is FutureOr<SentryEvent?>; await to normalize.
+      expect(out, isNotNull);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd worker_flutter && flutter test test/sentry_options_test.dart`
+Expected: FAIL — `sentry_setup.dart` missing.
+
+- [ ] **Step 3: Write `sentry_setup.dart`**
+
+`worker_flutter/lib/sentry_setup.dart`:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'telemetry.dart';
+
+/// Configure a [SentryFlutterOptions] instance with the worker's
+/// crash-reporting policy. Extracted from `main.dart` so it's
+/// unit-testable without booting Flutter.
+///
+/// - No performance / profiling.
+/// - Auto session tracking on (drives release health).
+/// - PII scrubbing via [scrubPii] in `beforeSend`.
+/// - DSN may be empty: the SDK treats that as disabled, which is the
+///   behavior we want for local dev builds that lack `--dart-define`.
+void configureSentryOptions(
+  SentryFlutterOptions options, {
+  required String dsn,
+  required String release,
+  required String gitSha,
+}) {
+  options.dsn = dsn;
+  options.release = release;
+  options.dist = gitSha;
+  options.environment = kDebugMode ? 'development' : 'production';
+  options.tracesSampleRate = 0;
+  options.profilesSampleRate = 0;
+  options.enableAutoSessionTracking = true;
+  options.autoSessionTrackingInterval = const Duration(seconds: 30);
+  options.sendDefaultPii = false;
+  options.beforeSend = (event, {hint}) => scrubPii(event, hint: hint);
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd worker_flutter && flutter test test/sentry_options_test.dart`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add worker_flutter/lib/sentry_setup.dart worker_flutter/test/sentry_options_test.dart
+git commit -m "feat(worker): add configureSentryOptions builder"
+```
+
+---
+
+## Task 4: Wire `SentryFlutter.init` in main.dart
+
+**Files:**
+- Modify: `worker_flutter/lib/main.dart`
+
+- [ ] **Step 1: Replace `main()` body**
+
+In `worker_flutter/lib/main.dart`, replace the existing `main()` function and its three error hooks with:
+
+```dart
+Future<void> main() async {
+  await _initFileLogger();
+  _log('main() started');
+
+  const dsn = String.fromEnvironment('SENTRY_DSN', defaultValue: '');
+  const release = String.fromEnvironment(
+    'SENTRY_RELEASE',
+    defaultValue: 'worker_flutter@dev',
+  );
+  const gitSha = String.fromEnvironment('GIT_SHA', defaultValue: 'local');
+
+  await SentryFlutter.init(
+    (options) {
+      configureSentryOptions(
+        options,
+        dsn: dsn,
+        release: release,
+        gitSha: gitSha,
+      );
+      // Also tee Sentry-captured events into the local file log so
+      // a user grabbing ~/Library/Logs/... still sees them.
+      final upstream = options.beforeSend;
+      options.beforeSend = (event, {hint}) {
+        _log('Sentry capture: ${event.message?.formatted ?? event.throwable}');
+        return upstream != null ? upstream(event, hint: hint) : event;
+      };
+    },
+    appRunner: _appMain,
+  );
+}
+```
+
+Add imports near the top:
+
+```dart
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'sentry_setup.dart';
+import 'telemetry.dart';
+```
+
+- [ ] **Step 2: Remove the redundant error hooks**
+
+The Sentry SDK installs `FlutterError.onError`, `PlatformDispatcher.onError`, and the zone-error handler itself (`appRunner` runs `_appMain` inside its own guarded zone). Delete these three blocks from the OLD `main()` body — they're now redundant. The file logger still logs them because `beforeSend` writes via `_log`.
+
+The old `runZonedGuarded(_appMain, ...)` wrapper is also removed — `appRunner: _appMain` replaces it.
+
+- [ ] **Step 3: Add captures at known failure paths**
+
+In `_appMain`, replace the existing Firebase init catch with:
+
+```dart
+} catch (e, st) {
+  firebaseInitError = e.toString();
+  _log('Firebase init failed: $e');
+  await Telemetry.captureError(
+    e,
+    st,
+    category: TelemetryCategory.firebaseInit,
+    extra: {'projectId': fbOpts.projectId},
+  );
+}
+```
+
+In `_startEngineSafe`, replace the silent catch:
+
+```dart
+} catch (e, st) {
+  _log('Engine start FAILED (caught): $e\n$st');
+  await Telemetry.captureError(
+    e,
+    st,
+    category: TelemetryCategory.engineStart,
+  );
+}
+```
+
+In `_initAutoUpdater`'s catch, add a breadcrumb (not a capture — offline is normal):
+
+```dart
+} catch (e, st) {
+  _log('AutoUpdater init failed (non-fatal): $e\n$st');
+  Telemetry.breadcrumb(
+    TelemetryCategory.autoUpdater,
+    'AutoUpdater init failed',
+    data: {'error': e.toString()},
+  );
+}
+```
+
+In the tray-init try/catch (`_bootEngine`), add a breadcrumb only:
+
+```dart
+} catch (e, st) {
+  _log('Boot: tray init failed (non-fatal): $e\n$st');
+  Telemetry.breadcrumb(
+    TelemetryCategory.tray,
+    'Tray init failed',
+    data: {'error': e.toString()},
+  );
+}
+```
+
+- [ ] **Step 4: Add a `_trace` boot-phase helper**
+
+Replace the small number of boot-phase `_log('Boot: ...')` calls in `_bootEngine`, `_appMain`, `_routeToMode`, `_bootMode`, `_bootOffline` with a helper that adds a breadcrumb:
+
+```dart
+void _trace(String message) {
+  _log(message);
+  Telemetry.breadcrumb(TelemetryCategory.boot, message);
+}
+```
+
+Then update the boot-phase `_log` call sites in `main.dart` (those that describe phase transitions: `'Initializing window_manager'`, `'window ready, shown'`, `'Boot: deferring auth to AuthGate'`, `'Boot: constructing WorkerEngine'`, `'Boot: tray initialized'`, `'Boot: runApp'`, `'Boot: runApp returned'`, `'Routing to remembered mode: ...'`, `'No remembered mode; showing picker'`, `'Boot offline: ...'`) to call `_trace(...)` instead. Leave non-phase `_log` calls (installer progress, etc.) untouched — those are noisy and don't need breadcrumbs.
+
+- [ ] **Step 5: Run analyzer + tests**
+
+Run: `cd worker_flutter && flutter analyze`
+Expected: no errors. (Some `info` warnings tolerated — only `error`/`warning` block.)
+
+Run: `cd worker_flutter && flutter test`
+Expected: all existing tests still pass + the two new test files pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add worker_flutter/lib/main.dart
+git commit -m "feat(worker): initialize Sentry + breadcrumbs in main"
+```
+
+---
+
+## Task 5: Capture sign-in failures
+
+**Files:**
+- Modify: `worker_flutter/lib/auth/auth_service.dart`
+
+- [ ] **Step 1: Wrap `_signInNative`'s exception path**
+
+Replace the catch block in `_signInNative`:
+
+```dart
+} on FirebaseAuthException catch (e, st) {
+  if (_cancelCodes.contains(e.code)) {
+    throw const AuthCancelledException();
+  }
+  await Telemetry.captureError(
+    e,
+    st,
+    category: TelemetryCategory.signIn,
+    tags: {
+      'platform': Platform.operatingSystem,
+      'provider': 'google',
+      'error_code': e.code,
+    },
+  );
+  rethrow;
+}
+```
+
+- [ ] **Step 2: Wrap `_signInDesktop`'s exception path**
+
+Same pattern in `_signInDesktop`'s `signInWithCredential` catch, plus wrap the generic `try { tokens = await oauth.signIn(); }` in a try/capture that lets `AuthCancelledException` through:
+
+```dart
+final OAuthTokens tokens;
+try {
+  tokens = await oauth.signIn();
+} on AuthCancelledException {
+  rethrow;
+} catch (e, st) {
+  await Telemetry.captureError(
+    e,
+    st,
+    category: TelemetryCategory.signIn,
+    tags: {
+      'platform': Platform.operatingSystem,
+      'provider': 'google',
+      'phase': 'pkce',
+    },
+  );
+  rethrow;
+}
+```
+
+(Adjust `OAuthTokens` to the actual type returned by `DesktopOAuth.signIn()` — read `desktop_oauth.dart` to confirm. If it's `Future<DesktopOAuthTokens>` use that name.)
+
+Then the existing `signInWithCredential` catch:
+
+```dart
+} on FirebaseAuthException catch (e, st) {
+  if (_cancelCodes.contains(e.code)) {
+    throw const AuthCancelledException();
+  }
+  await Telemetry.captureError(
+    e,
+    st,
+    category: TelemetryCategory.signIn,
+    tags: {
+      'platform': Platform.operatingSystem,
+      'provider': 'google',
+      'error_code': e.code,
+      'phase': 'firebase_credential',
+    },
+  );
+  rethrow;
+}
+```
+
+Add the import:
+
+```dart
+import '../telemetry.dart';
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd worker_flutter && flutter test test/auth/`
+Expected: existing `auth_service_test.dart` still passes. If it asserts no Sentry side-effect, it'll need a small mock (see Step 4) — but most likely the existing test injects a fake `FirebaseAuth` and doesn't exercise the rethrow path, in which case it stays green.
+
+- [ ] **Step 4: If existing tests break**
+
+If `auth_service_test.dart` exercises the rethrow path, Sentry will try to send and fail in test (no SDK init). Two options, prefer the first:
+
+a) **Run tests through `Sentry.init` no-op** — call `await Sentry.init((o) => o.dsn = '')` in the test's `setUpAll`. The no-op SDK accepts captures and drops them.
+
+b) Skip if the test doesn't actually test the failure path. Inspect first.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add worker_flutter/lib/auth/auth_service.dart worker_flutter/test/auth/
+git commit -m "feat(worker): capture sign-in failures to Sentry"
+```
+
+---
+
+## Task 6: Capture installer + worker engine failures
+
+**Files:**
+- Modify: `worker_flutter/lib/installer/installer.dart`
+- Modify: `worker_flutter/lib/worker/worker_engine.dart`
+
+- [ ] **Step 1: Installer captures**
+
+Read `worker_flutter/lib/installer/installer.dart` and find every `throw` site for failures (download non-200, SHA mismatch, manifest fetch failure, extract failure). At each throw, prepend a `Telemetry.captureError` call. Example pattern:
+
+```dart
+} catch (e, st) {
+  await Telemetry.captureError(
+    e,
+    st,
+    category: TelemetryCategory.installer,
+    extra: {'stage': 'forge_download', 'url': url},
+  );
+  rethrow;
+}
+```
+
+Or where errors are thrown explicitly:
+
+```dart
+if (resp.statusCode != 200) {
+  final err = InstallerException('forge download failed: ${resp.statusCode}');
+  await Telemetry.captureError(
+    err,
+    StackTrace.current,
+    category: TelemetryCategory.installer,
+    extra: {'stage': 'forge_download', 'status': resp.statusCode},
+  );
+  throw err;
+}
+```
+
+Use whichever shape matches the existing code. Add `import '../telemetry.dart';` at the top.
+
+- [ ] **Step 2: WorkerEngine captures**
+
+In `worker_flutter/lib/worker/worker_engine.dart`, locate the three existing `catch (e)` blocks (lines ~126, ~156, ~290 in the snapshot — verify after edit). Convert each to `catch (e, st)` and add a `Telemetry.captureError(e, st, category: TelemetryCategory.engineRuntime)` call before the existing `_log`/swallow. Do NOT change the catch's swallow behavior — the engine survives single failures and retries; we just want to observe them.
+
+Add `import '../telemetry.dart';` at the top.
+
+- [ ] **Step 3: Run analyzer + tests**
+
+Run: `cd worker_flutter && flutter analyze && flutter test`
+Expected: all green. Existing `worker_engine_error_paths_test.dart` may need the same no-op-Sentry shim from Task 5 Step 4 if it triggers the captured paths.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add worker_flutter/lib/installer/installer.dart worker_flutter/lib/worker/worker_engine.dart worker_flutter/test/
+git commit -m "feat(worker): capture installer + engine runtime failures"
+```
+
+---
+
+## Task 7: Add no-op Sentry to test bootstrap (if needed)
+
+**Files:**
+- Modify: `worker_flutter/test/` setup files for any tests that now flow through `Telemetry.captureError`.
+
+- [ ] **Step 1: Identify affected tests**
+
+After Tasks 5-6, run `cd worker_flutter && flutter test`. Any failing tests are the ones that need the bootstrap.
+
+- [ ] **Step 2: Add bootstrap**
+
+For each affected test file, add at the top of `main()`:
+
+```dart
+setUpAll(() async {
+  await Sentry.init((o) {
+    o.dsn = '';
+    o.tracesSampleRate = 0;
+  });
+});
+```
+
+Import: `import 'package:sentry_flutter/sentry_flutter.dart';`
+
+The empty DSN keeps the SDK in no-op mode; captures become drops. This avoids touching production code with `kIsTest`-style guards.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd worker_flutter && flutter test`
+Expected: all green.
+
+- [ ] **Step 4: Commit (only if files were touched)**
+
+```bash
+git add worker_flutter/test/
+git commit -m "test(worker): bootstrap Sentry no-op for capture-touching tests"
+```
+
+---
+
+## Task 8: Wire `release-worker.yml`
+
+**Files:**
+- Modify: `.github/workflows/release-worker.yml`
+
+- [ ] **Step 1: Add Doppler keys to both build jobs**
+
+In `build-macos` and `build-windows` jobs, extend the `KEYS` JSON array passed to the Doppler step. Find the existing `KEYS='[ ... ]'` block and add:
+
+```
+    "SENTRY_DSN_WORKER",
+    "SENTRY_AUTH_TOKEN_WORKER"
+```
+
+(Comma placement matters — add the comma to whatever's currently the last entry.)
+
+- [ ] **Step 2: Pass `--dart-define`s to `flutter build`**
+
+Locate the `flutter build macos` and `flutter build windows` steps. Modify the build command to:
+
+```bash
+flutter build macos --release \
+  --obfuscate \
+  --split-debug-info=build/debug-info/macos \
+  --dart-define=SENTRY_DSN=$SENTRY_DSN_WORKER \
+  --dart-define=SENTRY_RELEASE=worker_flutter@${{ needs.version.outputs.version }} \
+  --dart-define=GIT_SHA=${{ github.sha }}
+```
+
+And:
+
+```bash
+flutter build windows --release \
+  --obfuscate \
+  --split-debug-info=build/debug-info/windows \
+  --dart-define=SENTRY_DSN=$SENTRY_DSN_WORKER \
+  --dart-define=SENTRY_RELEASE=worker_flutter@${{ needs.version.outputs.version }} \
+  --dart-define=GIT_SHA=${{ github.sha }}
+```
+
+Read the existing yml first — the build command may be inside a larger fastlane / scripts wrapper on macOS. If so, edit the wrapper script instead, but the flags are the same.
+
+- [ ] **Step 3: Add Sentry upload step**
+
+After each `flutter build` step, add:
+
+```yaml
+- name: Upload Dart debug symbols to Sentry
+  if: env.SENTRY_AUTH_TOKEN_WORKER != ''
+  working-directory: worker_flutter
+  env:
+    SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN_WORKER }}
+    SENTRY_RELEASE: worker_flutter@${{ needs.version.outputs.version }}
+  run: dart run sentry_dart_plugin
+  continue-on-error: true   # don't fail a release if Sentry is down
+```
+
+- [ ] **Step 4: Lint the workflow**
+
+Run: `gh workflow view release-worker.yml` — purely a syntax sanity check via the GH API; doesn't execute. If `gh` complains about parsing, fix.
+
+Alternatively run `actionlint` locally if installed; otherwise skip — the actual workflow run will surface errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release-worker.yml
+git commit -m "ci(worker): pass Sentry DSN to build + upload debug symbols"
+```
+
+---
+
+## Task 9: Write manual setup doc
+
+**Files:**
+- Create: `worker_flutter/docs/sentry-setup.md`
+
+- [ ] **Step 1: Write the doc**
+
+`worker_flutter/docs/sentry-setup.md`:
+
+```markdown
+# Sentry setup — worker_flutter desktop
+
+The Flutter worker reports crashes and known failures to Sentry. This
+doc covers the one-time manual setup an operator performs in the
+Sentry UI + Doppler. The code side ships in PR #N.
+
+## 1. Create the Sentry project
+
+In Sentry under the `tytaniumdev` organization:
+
+1. **Projects → Create Project**
+   - Platform: **Flutter**
+   - Team: existing
+   - Name: `magic-bracket-worker`
+2. Copy the DSN shown on the next screen.
+
+## 2. Store DSN + auth token in Doppler
+
+In Doppler, project `blinkbreak`, config `prd`:
+
+1. Add `SENTRY_DSN_WORKER` = the DSN from step 1.
+2. **Settings → Auth Tokens → Create new internal integration token** in
+   Sentry, scoped to `magic-bracket-worker` with permissions
+   `project:releases` + `project:write`.
+3. Add `SENTRY_AUTH_TOKEN_WORKER` = the new token to Doppler.
+
+The release workflow reads both via the Doppler step.
+
+## 3. Wire the GitHub integration
+
+In Sentry → **Settings → Integrations → GitHub**:
+
+1. Install / authorize the integration for
+   `TytaniumDev/MagicBracketSimulator` if not already.
+2. Enable issue creation on the `magic-bracket-worker` project.
+
+## 4. Create alert rules
+
+For each rule below: Sentry → **Alerts → Create Alert → Issues**.
+
+### Rule 1 — Error Spike (catch-all)
+
+- **When:** An issue is seen more than 10 times in 1 hour.
+- **If:** (no filter)
+- **Then:** Create a GitHub issue with labels `bug,sentry,worker`.
+
+### Rule 2 — Sign-in Failures
+
+- **When:** A new issue is created.
+- **If:** The event's `category` tag equals `sign_in`.
+- **Then:** Create a GitHub issue with labels `bug,sentry,worker`.
+
+### Rule 3 — Installer Failures
+
+- **When:** A new issue is created.
+- **If:** The event's `category` tag equals `installer`.
+- **Then:** Create a GitHub issue with labels `bug,sentry,worker`.
+
+### Rule 4 — Engine Start Failures
+
+- **When:** A new issue is created.
+- **If:** The event's `category` tag equals `engine_start`.
+- **Then:** Create a GitHub issue with labels `bug,sentry,worker`.
+
+## 5. Verify
+
+After the next release-worker run succeeds:
+
+1. Sentry → Releases — confirm the new `worker_flutter@<version>+<build>`
+   release shows with `Dart Debug Information Files` uploaded.
+2. Trigger a controlled error in dev (e.g. set an invalid Firebase
+   project) and confirm it shows up in Sentry within ~30 seconds.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add worker_flutter/docs/sentry-setup.md
+git commit -m "docs(worker): add Sentry manual setup checklist"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 1: Full analyzer + test pass**
+
+Run: `cd worker_flutter && flutter analyze`
+Expected: no errors, no warnings.
+
+Run: `cd worker_flutter && flutter test`
+Expected: all tests pass (existing + new).
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin feat/worker-sentry
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base main --head feat/worker-sentry \
+  --title "feat(worker): add Sentry logging to desktop apps" \
+  --body "$(cat docs/superpowers/specs/2026-05-14-flutter-worker-sentry-design.md | head -40)
+
+## Manual setup required after merge
+
+See worker_flutter/docs/sentry-setup.md. Until the operator completes:
+- Create magic-bracket-worker Sentry project
+- Add SENTRY_DSN_WORKER + SENTRY_AUTH_TOKEN_WORKER to Doppler
+- Configure GitHub integration + 4 alert rules
+
+…the SDK runs in no-op mode (graceful skip on empty DSN, same as the API).
+
+## Test plan
+- [x] flutter analyze: clean
+- [x] flutter test: green
+- [ ] Manual: build with --dart-define=SENTRY_DSN=<test-dsn>, force a Firebase init error, confirm event lands in Sentry
+- [ ] Manual: confirm release shows in Sentry → Releases with Dart Debug Files uploaded after first release-worker run
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 4: Merge**
+
+Wait for CI green, then:
+
+```bash
+gh pr merge --squash --auto
+```
+
+(Repo uses auto-approve + automerge-label workflows; `--auto` enables auto-merge once branch protection is satisfied. If the user merges manually, that's fine too.)

--- a/docs/superpowers/specs/2026-05-14-flutter-worker-sentry-design.md
+++ b/docs/superpowers/specs/2026-05-14-flutter-worker-sentry-design.md
@@ -1,0 +1,286 @@
+# Flutter Worker Desktop App — Sentry Integration
+
+**Date:** 2026-05-14
+**Status:** Approved
+**Surface:** `worker_flutter/` (macOS + Windows desktop builds)
+
+## Motivation
+
+The Flutter desktop worker currently writes diagnostics only to
+`~/Library/Logs/com.tytaniumdev.magicBracketSimulator.log` (macOS) or
+`%LocalAppData%\com.tytaniumdev.magicBracketSimulator\Logs\...` (Windows).
+A user hitting the recent `[firebase_auth/null-error] Host platform
+returned null value for non-null return value` on macOS sign-in had to
+send a screenshot — there is no automatic reporting path. Adding Sentry
+gives the same crash-reporting surface the Next.js API already has
+(`@sentry/nextjs`, project `magic-bracket-api`) and lets us learn about
+desktop crashes without waiting for a user to report them.
+
+## Scope
+
+### In scope
+
+- Initialize `sentry_flutter` in the desktop worker.
+- Replace the three manual error hooks in `main.dart`
+  (`FlutterError.onError`, `PlatformDispatcher.onError`,
+  `runZonedGuarded`) with the SDK's automatic equivalents while keeping
+  the existing file logger.
+- Add a `Telemetry` helper for breadcrumb + capture calls with required
+  `category` tagging.
+- Instrument the boot sequence (every current `_log` call becomes a
+  breadcrumb) and explicitly capture errors at known failure sites:
+  Firebase init, sign-in, installer, engine start, worker engine.
+- Release health (auto session tracking).
+- Source map / Dart debug symbol upload from CI via the
+  `sentry_dart_plugin`.
+- A new `magic-bracket-worker` Sentry project, with four alert rules
+  that create GitHub issues mirroring the API project's setup.
+- Tests: unit-test the `Telemetry` helper and the no-DSN graceful path.
+
+### Out of scope
+
+- Performance monitoring (`tracesSampleRate: 0`).
+- Profiling (`profilesSampleRate: 0`).
+- User identification: events stay anonymous. `sendDefaultPii: false`
+  and a `beforeSend` scrubber strip any incidentally captured PII.
+
+## Architecture
+
+### SDK initialization
+
+`main()` becomes:
+
+```dart
+Future<void> main() async {
+  await _initFileLogger();          // unchanged
+  await SentryFlutter.init(
+    (o) {
+      o.dsn = const String.fromEnvironment('SENTRY_DSN', defaultValue: '');
+      o.release = const String.fromEnvironment(
+        'SENTRY_RELEASE',
+        defaultValue: 'worker_flutter@dev',
+      );
+      o.dist = const String.fromEnvironment('GIT_SHA', defaultValue: 'local');
+      o.environment = kDebugMode ? 'development' : 'production';
+      o.tracesSampleRate = 0;
+      o.profilesSampleRate = 0;
+      o.enableAutoSessionTracking = true;
+      o.autoSessionTrackingInterval = const Duration(milliseconds: 30000);
+      o.sendDefaultPii = false;
+      o.beforeSend = _scrubPii;
+    },
+    appRunner: _appMain,
+  );
+}
+```
+
+The three error hooks in the existing `main()` are removed: Sentry
+installs them itself. The file logger is preserved by calling `_log`
+from `_scrubPii` (so every event that reaches Sentry also lands in the
+local log).
+
+When `SENTRY_DSN` is empty (local `flutter run`), `SentryFlutter.init`
+runs in no-op mode — same graceful-skip pattern the API uses.
+
+### Telemetry helper
+
+`lib/telemetry.dart` exposes two functions and a category enum:
+
+```dart
+enum TelemetryCategory {
+  boot,
+  firebaseInit,
+  signIn,
+  installer,
+  engineStart,
+  engineRuntime,
+  autoUpdater,
+  tray,
+}
+
+class Telemetry {
+  static void breadcrumb(
+    TelemetryCategory category,
+    String message, {
+    Map<String, Object?>? data,
+  });
+
+  static Future<void> captureError(
+    Object error,
+    StackTrace? stack, {
+    required TelemetryCategory category,
+    Map<String, String>? tags,
+    Map<String, Object?>? extra,
+  });
+}
+```
+
+`category` is required on `captureError` so every event carries a
+`category` tag. The alert rules in §"Alerts" filter on that tag.
+
+### Replacing `_log`
+
+The existing `_log(String)` function in `main.dart` stays — call sites
+that are pure boot-phase markers (e.g. `_log('main() started')`) gain a
+sibling `Telemetry.breadcrumb(TelemetryCategory.boot, 'main() started')`
+call. The convention: file logger for the local trail, breadcrumb so
+the trail also rides along with any subsequent capture.
+
+For readability we extract a small helper `_trace(category, message)`
+inside `main.dart` that does both, so call sites read:
+
+```dart
+_trace(TelemetryCategory.boot, 'Initializing window_manager');
+```
+
+### Explicit captures
+
+| Site | File | Category | Notes |
+|---|---|---|---|
+| Firebase init failure | `lib/main.dart` `_appMain` | `firebaseInit` | Includes `projectId` and stub-marker detection in extras. |
+| Google sign-in failure | `lib/auth/auth_service.dart` (mac/win/linux paths) | `signIn` | Tags: `platform`, `provider`, `error_code` (the `firebase_auth/...` code). |
+| Installer download/extract/SHA failure | `lib/installer/installer.dart` | `installer` | Includes current `progress.stage` in extras. |
+| `_startEngineSafe` catch | `lib/main.dart` | `engineStart` | Replaces the silent `_log`-only path. |
+| Tray init failure | `lib/main.dart` | `tray` | Breadcrumb only — non-fatal (window is primary UI). |
+| AutoUpdater init failure | `lib/main.dart` | `autoUpdater` | Breadcrumb only — offline ≠ error. |
+| WorkerEngine catches | `lib/worker/worker_engine.dart` | `engineRuntime` | Each existing `_log`-only catch becomes a `captureError`. |
+
+### PII scrubbing
+
+`_scrubPii(SentryEvent event, Hint hint)`:
+
+1. Sets `event.user = null` (defense — we never set it, but guards
+   against future regressions).
+2. Walks `event.extra` and the breadcrumb data maps; redacts any value
+   that matches an email regex or any key named `email`, `mail`,
+   `displayName`, `uid`, `userId`.
+3. Returns the event.
+
+Tested by a unit test that constructs a synthetic event with email-in-
+extras and verifies it comes back redacted.
+
+## CI / source map upload
+
+### Doppler secrets
+
+Two new Doppler entries under `blinkbreak/prd` (the existing project
+the release workflow reads):
+
+| Key | Used by | Scope |
+|---|---|---|
+| `SENTRY_DSN_WORKER` | `--dart-define=SENTRY_DSN=...` at build | Public-ish; embedded in binary. |
+| `SENTRY_AUTH_TOKEN_WORKER` | `sentry_dart_plugin` symbol upload | `project:releases` + `project:write` on `magic-bracket-worker` only. |
+
+Both added to the `KEYS` jq array in `.github/workflows/release-worker.yml`.
+
+### Workflow changes
+
+For both `build-macos` and `build-windows` jobs in `release-worker.yml`:
+
+1. Pull DSN + auth token from Doppler (extend `KEYS`).
+2. Compute `SENTRY_RELEASE = worker_flutter@${VERSION}` and
+   `GIT_SHA = ${{ github.sha }}`.
+3. Build with obfuscation + split debug info:
+   ```
+   flutter build macos --release \
+     --obfuscate \
+     --split-debug-info=build/debug-info/macos \
+     --dart-define=SENTRY_DSN=$SENTRY_DSN_WORKER \
+     --dart-define=SENTRY_RELEASE=$SENTRY_RELEASE \
+     --dart-define=GIT_SHA=${{ github.sha }}
+   ```
+   (Equivalent for `flutter build windows`.)
+4. Run `dart run sentry_dart_plugin` after the build to upload the
+   debug-info directory + source context for `$SENTRY_RELEASE`. The
+   plugin is configured via a `sentry` section in `pubspec.yaml`:
+   ```yaml
+   sentry:
+     project: magic-bracket-worker
+     org: tytaniumdev
+     upload_debug_symbols: true
+     upload_source_maps: false   # Flutter desktop has no JS bundle
+     upload_sources: true
+     log_level: info
+     # release/auth_token read from env vars set by the workflow.
+   ```
+5. The plugin no-ops locally because `SENTRY_AUTH_TOKEN` is unset on
+   developer machines.
+
+## Release health
+
+`enableAutoSessionTracking = true` and a 30s background interval (the
+SDK default) — sessions start at app launch and end on background or
+exit, so the new project's dashboard shows crash-free-users and
+crash-free-sessions automatically. Rolls up per `release` value, which
+matches `worker_flutter@${version}+${buildNumber}`.
+
+## Alerts
+
+Four alert rules on `magic-bracket-worker`, all configured with the
+Sentry-GitHub integration to create issues in
+`TytaniumDev/MagicBracketSimulator` with labels `bug`, `sentry`,
+`worker`:
+
+| Rule | Trigger | Action |
+|---|---|---|
+| Error Spike (catch-all) | Issue seen > 10 times in 1 hour | Create GH issue once per Sentry issue. |
+| Sign-in Failures | New issue where `tags[category] = signIn` | Create GH issue on first occurrence. |
+| Installer Failures | New issue where `tags[category] = installer` | Create GH issue on first occurrence. |
+| Engine Start Failures | New issue where `tags[category] = engineStart` | Create GH issue on first occurrence. |
+
+These are configured manually in the Sentry UI (no Terraform yet). The
+click-by-click is documented in `worker_flutter/docs/sentry-setup.md`.
+
+## Testing
+
+Two new test files under `worker_flutter/test/`:
+
+1. **`telemetry_test.dart`**
+   - `Telemetry.captureError` sets the `category` tag from the enum
+     (snake_case form).
+   - `_scrubPii` strips email-shaped strings from event extras and
+     known PII-keyed entries (`email`, `mail`, `displayName`, `uid`,
+     `userId`).
+   - Breadcrumbs carry the category as the Sentry `breadcrumb.category`
+     value.
+
+2. **`sentry_options_test.dart`**
+   - `buildSentryOptions(dsn: '')` produces an options object that
+     `SentryFlutter.init` accepts without throwing (no-op mode).
+   - With a non-empty DSN: `enableAutoSessionTracking == true`,
+     `tracesSampleRate == 0`, `profilesSampleRate == 0`,
+     `sendDefaultPii == false`, `environment` matches the
+     `kDebugMode`-derived value.
+
+This is the release-health coverage as well — auto session tracking is
+a single options flag.
+
+Local verification: `flutter analyze` (project policy via
+`analysis_options.yaml`) and `flutter test` both pass before the PR.
+
+## Manual setup checklist (operator)
+
+Documented in `worker_flutter/docs/sentry-setup.md`. The agent cannot
+do these:
+
+1. Create Sentry project `magic-bracket-worker` under `tytaniumdev`.
+2. Copy the DSN into Doppler as `SENTRY_DSN_WORKER`.
+3. Create an internal-integration auth token with
+   `project:releases` + `project:write` scopes on the new project; add
+   to Doppler as `SENTRY_AUTH_TOKEN_WORKER`.
+4. Wire the Sentry-GitHub integration for the new project, pointing at
+   `TytaniumDev/MagicBracketSimulator` with labels `bug`, `sentry`,
+   `worker`.
+5. Create the four alert rules in the Sentry UI.
+
+Until step 1+2 are done, all Sentry calls are no-ops. The shipping app
+still functions; nothing else regresses.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `--obfuscate` breaks a reflection-using package. | Smoke-test the obfuscated build locally before merge: build, launch, sign in, run a sim. If any plugin breaks, drop `--obfuscate` and keep `--split-debug-info` (symbols still upload). |
+| Sentry plugin upload fails and breaks releases. | Wrap the plugin step in `continue-on-error: true` for the first release; tighten once we see a green run. |
+| DSN gets embedded in a forked binary and someone abuses quota. | Sentry DSNs are designed to be public; rate-limit/inbound filters on the project mitigate. Accepted risk. |
+| Breadcrumbs include sensitive data. | `_scrubPii` is the safety net; breadcrumb call sites are explicit and reviewed. |

--- a/worker_flutter/docs/sentry-setup.md
+++ b/worker_flutter/docs/sentry-setup.md
@@ -1,0 +1,132 @@
+# Sentry setup — worker_flutter desktop
+
+The Flutter worker reports crashes and known failures (sign-in,
+installer, engine start, worker runtime) to Sentry. The SDK and CI
+wiring are already in code; this doc covers the one-time manual setup
+an operator performs in Sentry + Doppler.
+
+Until step 1+2 are done, every Sentry call in the app is a no-op (the
+SDK treats an empty DSN as disabled). The shipping app still
+functions; this is the same graceful-skip pattern the Next.js API
+uses for `SENTRY_DSN`.
+
+## 1. Create the Sentry project
+
+Sentry org `tytaniumdev`:
+
+1. **Projects → Create Project**
+   - Platform: **Flutter**
+   - Team: existing
+   - Name: `magic-bracket-worker`
+2. Copy the DSN shown on the next screen.
+
+## 2. Store DSN + auth token in Doppler
+
+Doppler project `blinkbreak`, config `prd`:
+
+1. Add `SENTRY_DSN_WORKER` = the DSN from step 1.
+2. In Sentry → **Settings → Auth Tokens → Create new token**:
+   - Scopes: `project:releases`, `project:write`
+   - Restrict to project: `magic-bracket-worker`
+3. Add `SENTRY_AUTH_TOKEN_WORKER` = the new token to Doppler.
+
+`release-worker.yml` already reads both keys from Doppler. The next
+release after these are populated will:
+
+- Build with `--dart-define=SENTRY_DSN=...` (events start flowing).
+- Run `sentry_dart_plugin` to upload the obfuscation debug-info map
+  for the new release (stack traces deobfuscate).
+
+## 3. Wire the GitHub integration
+
+Sentry → **Settings → Integrations → GitHub**:
+
+1. Install / authorize the GitHub integration for
+   `TytaniumDev/MagicBracketSimulator` if it isn't already.
+2. Enable it for the `magic-bracket-worker` project.
+
+## 4. Create alert rules
+
+For each rule: Sentry → **Alerts → Create Alert → Issues**.
+
+All four rules use the same action: **Create a GitHub issue** in
+`TytaniumDev/MagicBracketSimulator` with labels `bug,sentry,worker`.
+
+### Rule 1 — Error Spike (catch-all)
+
+- **When:** An issue is seen more than 10 times in 1 hour.
+- **If:** (no filter)
+
+Mirrors the API project's catch-all rule.
+
+### Rule 2 — Sign-in Failures
+
+- **When:** A new issue is created.
+- **If:** Event has tag `category` equal to `sign_in`.
+
+Specifically aimed at the `firebase_auth/null-error` class and other
+sign-in-path regressions. The capture in `AuthService` tags
+`platform`, `provider`, and `error_code` so the GitHub issue body has
+enough to debug.
+
+### Rule 3 — Installer Failures
+
+- **When:** A new issue is created.
+- **If:** Event has tag `category` equal to `installer`.
+
+First-launch installer breakage means a user can't use the app at
+all, so first occurrence pages.
+
+### Rule 4 — Engine Start Failures
+
+- **When:** A new issue is created.
+- **If:** Event has tag `category` equal to `engine_start`.
+
+The worker can't process jobs if the engine fails to start.
+
+## 5. Verify
+
+After the next `release-worker` run with the secrets in place:
+
+1. Sentry → **Releases** — confirm a new
+   `worker_flutter@<version>+<build>` release appears with `Dart Debug
+   Information Files` uploaded.
+2. Trigger a controlled error in a dev build:
+   ```
+   doppler run --project blinkbreak --config prd -- \
+     flutter run -d macos \
+       --dart-define=SENTRY_DSN=<test-dsn> \
+       --dart-define=GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET=$GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET
+   ```
+   Set `STUB_` apiKey in `firebase_options.dart`, observe the
+   firebase_init capture in Sentry within ~30 seconds.
+
+## Categories in code
+
+The full set of `category` tag values, set by `Telemetry.captureError`
+and breadcrumbs throughout the app:
+
+| Tag | Source | Severity |
+|---|---|---|
+| `boot` | `_appMain` start, key boot phases | breadcrumb |
+| `firebase_init` | `Firebase.initializeApp` failure | capture |
+| `sign_in` | AuthService (native + PKCE + firebase_credential phases) | capture |
+| `installer` | First-run installer (download / SHA / extract) | capture |
+| `engine_start` | `WorkerEngine.start()` outer failure | capture |
+| `engine_runtime` | WorkerEngine lease writer / PENDING listener / sim_run | capture |
+| `auto_updater` | Sparkle init failure (offline ≠ error) | breadcrumb |
+| `tray` | tray_manager init failure | breadcrumb |
+
+Add new values via `TelemetryCategory` in `lib/telemetry.dart`.
+
+## What's NOT collected
+
+- **PII**: `SentryFlutter.init` uses `sendDefaultPii: false`. The
+  `beforeSend` hook (`scrubPii` in `telemetry.dart`) additionally
+  redacts known PII keys (`email`, `uid`, `displayName`, …) and
+  email-shaped strings in event extras and breadcrumb data.
+- **Performance traces**: `tracesSampleRate: 0`.
+- **Profiles**: `profilesSampleRate: 0`.
+
+Release health (crash-free sessions/users) is on via
+`enableAutoSessionTracking: true`.

--- a/worker_flutter/lib/auth/auth_service.dart
+++ b/worker_flutter/lib/auth/auth_service.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
 import '../firebase_options.dart';
+import '../telemetry.dart';
 import 'desktop_oauth.dart';
 
 /// Stable identifier for the currently-signed-in user, plus a small
@@ -89,10 +90,21 @@ class AuthService {
     final UserCredential credential;
     try {
       credential = await _firebaseAuth.signInWithProvider(provider);
-    } on FirebaseAuthException catch (e) {
+    } on FirebaseAuthException catch (e, st) {
       if (_cancelCodes.contains(e.code)) {
         throw const AuthCancelledException();
       }
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.signIn,
+        tags: {
+          'platform': Platform.operatingSystem,
+          'provider': 'google',
+          'error_code': e.code,
+          'phase': 'native_provider',
+        },
+      );
       rethrow;
     }
     return _requireUser(credential);
@@ -126,7 +138,7 @@ class AuthService {
     final oauth =
         _desktopOAuth ??
         DesktopOAuth(clientId: clientId, clientSecret: clientSecret);
-    final tokens = await oauth.signIn();
+    final tokens = await _runPkce(oauth);
     final cred = GoogleAuthProvider.credential(
       idToken: tokens.idToken,
       accessToken: tokens.accessToken,
@@ -134,13 +146,47 @@ class AuthService {
     final UserCredential credential;
     try {
       credential = await _firebaseAuth.signInWithCredential(cred);
-    } on FirebaseAuthException catch (e) {
+    } on FirebaseAuthException catch (e, st) {
       if (_cancelCodes.contains(e.code)) {
         throw const AuthCancelledException();
       }
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.signIn,
+        tags: {
+          'platform': Platform.operatingSystem,
+          'provider': 'google',
+          'error_code': e.code,
+          'phase': 'firebase_credential',
+        },
+      );
       rethrow;
     }
     return _requireUser(credential);
+  }
+
+  /// Run the PKCE flow with capture-on-failure. `AuthCancelledException`
+  /// is passed through so the gate UI keeps treating cancellation as a
+  /// non-error.
+  Future<DesktopOAuthResult> _runPkce(DesktopOAuth oauth) async {
+    try {
+      return await oauth.signIn();
+    } on AuthCancelledException {
+      rethrow;
+    } catch (e, st) {
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.signIn,
+        tags: {
+          'platform': Platform.operatingSystem,
+          'provider': 'google',
+          'phase': 'pkce',
+        },
+      );
+      rethrow;
+    }
   }
 
   AuthedUser _requireUser(UserCredential credential) {

--- a/worker_flutter/lib/installer/install_progress_app.dart
+++ b/worker_flutter/lib/installer/install_progress_app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../telemetry.dart';
 import 'installer.dart';
 
 /// First-run installer screen. Shown while the JRE and Forge are being
@@ -62,8 +63,14 @@ class _InstallScreenState extends State<_InstallScreen> {
   Future<void> _run() async {
     try {
       await widget.installer.install();
-    } catch (e) {
+    } catch (e, st) {
       if (mounted) setState(() => _error = e);
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.installer,
+        extra: {'stage': _last.stage, 'message': _last.message},
+      );
     }
   }
 
@@ -134,7 +141,8 @@ class _StagePanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isThisStage = last.stage == stage;
-    final isDone = !isThisStage &&
+    final isDone =
+        !isThisStage &&
         (stage == 'jre' && (last.stage == 'forge' || last.stage == 'done') ||
             stage == 'forge' && last.stage == 'done');
     final progress = isThisStage ? last.progress : (isDone ? 1.0 : 0.0);
@@ -158,7 +166,10 @@ class _StagePanel extends StatelessWidget {
               const SizedBox(width: 8),
               Text(
                 label,
-                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ],
           ),
@@ -166,7 +177,9 @@ class _StagePanel extends StatelessWidget {
           ClipRRect(
             borderRadius: BorderRadius.circular(2),
             child: LinearProgressIndicator(
-              value: isThisStage && progress > 0 ? progress : (isDone ? 1.0 : null),
+              value: isThisStage && progress > 0
+                  ? progress
+                  : (isDone ? 1.0 : null),
               minHeight: 4,
               backgroundColor: Colors.white12,
             ),

--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'auth/auth_gate_screen.dart';
@@ -17,6 +18,8 @@ import 'installer/installer.dart';
 import 'launch/auto_start_service.dart';
 import 'launch/mode_picker_screen.dart';
 import 'offline/offline_app.dart';
+import 'sentry_setup.dart';
+import 'telemetry.dart';
 import 'ui/dashboard.dart';
 import 'ui/tray_setup.dart';
 import 'worker/worker_engine.dart';
@@ -36,22 +39,42 @@ import 'worker/worker_engine.dart';
 /// and hides instead of exiting — the engine keeps running.
 Future<void> main() async {
   await _initFileLogger();
-  WidgetsFlutterBinding.ensureInitialized();
   _log('main() started');
-  FlutterError.onError = (details) {
-    _log('FlutterError: ${details.exception}\n${details.stack}');
-    FlutterError.dumpErrorToConsole(details);
-  };
-  PlatformDispatcher.instance.onError = (error, stack) {
-    _log('PlatformDispatcher onError: $error\n$stack');
-    return true;
-  };
-  await runZonedGuarded(_appMain, (error, stack) {
-    _log('UNCAUGHT (zone): $error\n$stack');
-  });
+
+  // Crash reporting. The DSN is empty by default — local `flutter run`
+  // builds don't pass --dart-define=SENTRY_DSN=... so the SDK runs in
+  // no-op mode. Release builds wire the DSN through Doppler in
+  // .github/workflows/release-worker.yml. Sentry's `appRunner` installs
+  // its own FlutterError.onError / PlatformDispatcher.onError / zone
+  // guard, replacing the manual hooks we used to set here.
+  const dsn = String.fromEnvironment('SENTRY_DSN', defaultValue: '');
+  const release = String.fromEnvironment(
+    'SENTRY_RELEASE',
+    defaultValue: 'worker_flutter@dev',
+  );
+  const gitSha = String.fromEnvironment('GIT_SHA', defaultValue: 'local');
+
+  await SentryFlutter.init((options) {
+    configureSentryOptions(options, dsn: dsn, release: release, gitSha: gitSha);
+    // Tee Sentry-captured events into the local file log so a user
+    // grabbing ~/Library/Logs/... still sees them. Wrap the existing
+    // PII scrubber so both run.
+    final upstream = options.beforeSend;
+    options.beforeSend = (event, hint) {
+      final summary =
+          event.message?.formatted ??
+          event.throwable?.toString() ??
+          event.exceptions?.firstOrNull?.value ??
+          '(no detail)';
+      _log('Sentry capture: $summary');
+      return upstream != null ? upstream(event, hint) : event;
+    };
+  }, appRunner: _appMain);
 }
 
 Future<void> _appMain() async {
+  Telemetry.breadcrumb(TelemetryCategory.boot, 'appMain started');
+
   // Detect placeholder firebase_options.dart values BEFORE calling
   // initializeApp — the native FirebaseCore plugin throws an uncaught
   // NSException on bad credentials that bypasses Dart try/catch.
@@ -65,9 +88,15 @@ Future<void> _appMain() async {
     try {
       await Firebase.initializeApp(options: fbOpts);
       _log('Firebase ready');
-    } catch (e) {
+    } catch (e, st) {
       firebaseInitError = e.toString();
       _log('Firebase init failed: $e');
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.firebaseInit,
+        extra: {'projectId': fbOpts.projectId},
+      );
     }
   }
 
@@ -239,6 +268,11 @@ Future<void> _bootEngine(WorkerConfig config) async {
     _log('Boot: tray initialized');
   } catch (e, st) {
     _log('Boot: tray init failed (non-fatal): $e\n$st');
+    Telemetry.breadcrumb(
+      TelemetryCategory.tray,
+      'Tray init failed',
+      data: {'error': e.toString()},
+    );
   }
 
   // Run the UI immediately. Start the engine *after* sign-in so
@@ -261,6 +295,11 @@ Future<void> _startEngineSafe(WorkerEngine engine) async {
     _log('Boot: engine running');
   } catch (e, st) {
     _log('Engine start FAILED (caught): $e\n$st');
+    await Telemetry.captureError(
+      e,
+      st,
+      category: TelemetryCategory.engineStart,
+    );
   }
 }
 
@@ -296,6 +335,11 @@ Future<void> _initAutoUpdater() async {
     // not fatal — the worker still runs, just without self-update. Log
     // so we notice in the diagnostic file.
     _log('AutoUpdater init failed (non-fatal): $e\n$st');
+    Telemetry.breadcrumb(
+      TelemetryCategory.autoUpdater,
+      'AutoUpdater init failed',
+      data: {'error': e.toString()},
+    );
   }
 }
 

--- a/worker_flutter/lib/sentry_setup.dart
+++ b/worker_flutter/lib/sentry_setup.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'telemetry.dart';
+
+/// Apply the worker's crash-reporting policy to a [SentryFlutterOptions].
+/// Extracted from `main.dart` so it's unit-testable without booting
+/// Flutter or sentry_flutter's native side.
+///
+/// - No performance / profiling (we don't pay for tracing volume).
+/// - Auto session tracking on (drives release health).
+/// - PII scrubbing via [scrubPii] in `beforeSend`.
+/// - Empty DSN is fine: the SDK treats it as disabled, which matches
+///   our dev-build behavior (no `--dart-define=SENTRY_DSN=...`).
+void configureSentryOptions(
+  SentryFlutterOptions options, {
+  required String dsn,
+  required String release,
+  required String gitSha,
+}) {
+  options.dsn = dsn;
+  options.release = release;
+  options.dist = gitSha;
+  options.environment = kDebugMode ? 'development' : 'production';
+  options.tracesSampleRate = 0;
+  // `profilesSampleRate` is experimental in sentry_flutter 8.x. We pin
+  // it to 0 explicitly so a future default flip doesn't silently start
+  // sending profiles before we've decided we want them.
+  // ignore: experimental_member_use
+  options.profilesSampleRate = 0;
+  options.enableAutoSessionTracking = true;
+  options.autoSessionTrackingInterval = const Duration(seconds: 30);
+  options.sendDefaultPii = false;
+  options.beforeSend = (event, hint) => scrubPii(event, hint: hint);
+}

--- a/worker_flutter/lib/telemetry.dart
+++ b/worker_flutter/lib/telemetry.dart
@@ -1,0 +1,148 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Stable tag values are written as snake_case so they're easy to filter
+/// on in Sentry alert rules (e.g. `category:sign_in`).
+enum TelemetryCategory {
+  boot,
+  firebaseInit,
+  signIn,
+  installer,
+  engineStart,
+  engineRuntime,
+  autoUpdater,
+  tray,
+}
+
+extension TelemetryCategoryTag on TelemetryCategory {
+  String get tagValue {
+    switch (this) {
+      case TelemetryCategory.boot:
+        return 'boot';
+      case TelemetryCategory.firebaseInit:
+        return 'firebase_init';
+      case TelemetryCategory.signIn:
+        return 'sign_in';
+      case TelemetryCategory.installer:
+        return 'installer';
+      case TelemetryCategory.engineStart:
+        return 'engine_start';
+      case TelemetryCategory.engineRuntime:
+        return 'engine_runtime';
+      case TelemetryCategory.autoUpdater:
+        return 'auto_updater';
+      case TelemetryCategory.tray:
+        return 'tray';
+    }
+  }
+}
+
+/// Thin wrapper around `Sentry.addBreadcrumb` and `Sentry.captureException`
+/// so call sites stay readable and the `category` tag is impossible to
+/// forget on a capture.
+class Telemetry {
+  Telemetry._();
+
+  static void breadcrumb(
+    TelemetryCategory category,
+    String message, {
+    Map<String, dynamic>? data,
+  }) {
+    Sentry.addBreadcrumb(
+      Breadcrumb(
+        category: category.tagValue,
+        message: message,
+        data: data,
+        level: SentryLevel.info,
+      ),
+    );
+  }
+
+  static Future<void> captureError(
+    Object error,
+    StackTrace? stack, {
+    required TelemetryCategory category,
+    Map<String, String>? tags,
+    Map<String, dynamic>? extra,
+  }) async {
+    await Sentry.captureException(
+      error,
+      stackTrace: stack,
+      withScope: (scope) {
+        scope.setTag('category', category.tagValue);
+        if (tags != null) {
+          tags.forEach(scope.setTag);
+        }
+        if (extra != null) {
+          // ignore: deprecated_member_use — `setExtra` is the documented
+          // 8.x API. Sentry's 9.x release moves to structured contexts.
+          extra.forEach(scope.setExtra);
+        }
+      },
+    );
+  }
+}
+
+/// Matches typical email addresses. We err on the side of redacting
+/// too eagerly rather than ever leaking PII into Sentry.
+final _emailRegex = RegExp(r'[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,}');
+
+const _piiKeys = <String>{
+  'email',
+  'mail',
+  'displayName',
+  'display_name',
+  'uid',
+  'userId',
+  'user_id',
+};
+
+/// `beforeSend` hook for the Sentry SDK. Replaces any user identifiers
+/// with `[redacted]` and redacts known PII in extras / breadcrumb data.
+/// Synchronous.
+///
+/// We rebuild the user rather than null it because `SentryEvent.user`
+/// is `final` and `copyWith(user: null)` is interpreted as "leave
+/// alone" by sentry-dart. The replacement keeps `[redacted]` in `id`
+/// only — SentryUser's constructor asserts at least one identifier is
+/// present.
+SentryEvent? scrubPii(SentryEvent event, {Hint? hint}) {
+  final originalUser = event.user;
+  final cleaned = originalUser == null
+      ? event
+      : event.copyWith(user: SentryUser(id: '[redacted]'));
+
+  // ignore: deprecated_member_use — see comment in Telemetry.captureError.
+  final extra = cleaned.extra;
+  if (extra != null) {
+    for (final key in extra.keys.toList()) {
+      if (_piiKeys.contains(key)) {
+        extra[key] = '[redacted]';
+        continue;
+      }
+      final value = extra[key];
+      if (value is String && _emailRegex.hasMatch(value)) {
+        extra[key] = value.replaceAll(_emailRegex, '[redacted-email]');
+      }
+    }
+  }
+
+  final breadcrumbs = cleaned.breadcrumbs;
+  if (breadcrumbs != null) {
+    for (final crumb in breadcrumbs) {
+      final data = crumb.data;
+      if (data == null) continue;
+      for (final key in data.keys.toList()) {
+        if (_piiKeys.contains(key)) {
+          data[key] = '[redacted]';
+          continue;
+        }
+        final value = data[key];
+        if (value is String && _emailRegex.hasMatch(value)) {
+          data[key] = value.replaceAll(_emailRegex, '[redacted-email]');
+        }
+      }
+    }
+  }
+
+  return cleaned;
+}

--- a/worker_flutter/lib/worker/worker_engine.dart
+++ b/worker_flutter/lib/worker/worker_engine.dart
@@ -7,6 +7,7 @@ import 'package:rxdart/subjects.dart';
 
 import '../config.dart';
 import '../models/sim.dart';
+import '../telemetry.dart';
 import 'job_aggregator.dart';
 import 'lease_writer.dart';
 import 'log_uploader.dart';
@@ -123,8 +124,14 @@ class WorkerEngine {
 
     try {
       await _leaseWriter.start();
-    } catch (e) {
+    } catch (e, st) {
       _stateSubject.add(currentState.copyWith(lastError: 'lease writer: $e'));
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.engineRuntime,
+        extra: {'phase': 'lease_writer_start'},
+      );
     }
 
     // Listen to PENDING sims across all jobs. Every time the listener
@@ -153,9 +160,15 @@ class WorkerEngine {
               );
             },
           );
-    } catch (e) {
+    } catch (e, st) {
       debugPrint('WorkerEngine: listener setup failed: $e');
       _stateSubject.add(currentState.copyWith(lastError: 'listener setup: $e'));
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.engineRuntime,
+        extra: {'phase': 'pending_listener_setup'},
+      );
     }
   }
 
@@ -287,7 +300,13 @@ class WorkerEngine {
           ),
         );
       }
-    } catch (e) {
+    } catch (e, st) {
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.engineRuntime,
+        extra: {'phase': 'sim_run', 'jobId': sim.jobId, 'simId': sim.simId},
+      );
       await _claimer.reportTerminal(
         sim: sim,
         result: SimResult(

--- a/worker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/worker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import firebase_core
 import firebase_storage
 import package_info_plus
 import screen_retriever_macos
+import sentry_flutter
 import shared_preferences_foundation
 import sqlite3_flutter_libs
 import tray_manager
@@ -26,6 +27,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))

--- a/worker_flutter/macos/fastlane/Fastfile
+++ b/worker_flutter/macos/fastlane/Fastfile
@@ -107,9 +107,23 @@ platform :mac do
       # Doppler (blinkbreak/prd); local dev needs to set the same
       # env var, e.g. via `doppler run -- bundle exec fastlane release`.
       desktop_secret = ENV.fetch("GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET", "")
+      # Sentry DSN + release metadata travel the same path. Empty
+      # values turn Sentry into a no-op, which is what local builds
+      # want until an operator wires the new project up.
+      sentry_dsn     = ENV.fetch("SENTRY_DSN_WORKER", "")
+      sentry_release = ENV.fetch("SENTRY_RELEASE", "worker_flutter@dev")
+      git_sha        = ENV.fetch("GITHUB_SHA", "local")
+      # `--obfuscate --split-debug-info` is what makes sentry_dart_plugin
+      # useful: it strips Dart symbols from the binary and writes the
+      # symbol map to build/debug-info/macos. The plugin then uploads
+      # that map so stack traces in Sentry deobfuscate.
       sh(
         "cd ../.. && flutter build macos --release " \
-        "--dart-define=GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET=#{desktop_secret.shellescape}"
+        "--obfuscate --split-debug-info=build/debug-info/macos " \
+        "--dart-define=GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET=#{desktop_secret.shellescape} " \
+        "--dart-define=SENTRY_DSN=#{sentry_dsn.shellescape} " \
+        "--dart-define=SENTRY_RELEASE=#{sentry_release.shellescape} " \
+        "--dart-define=GIT_SHA=#{git_sha.shellescape}"
       )
     end
 

--- a/worker_flutter/pubspec.lock
+++ b/worker_flutter/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.0.1"
+  ansicolor:
+    dependency: transitive
+    description:
+      name: ansicolor
+      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   antlr4:
     dependency: transitive
     description:
@@ -456,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  globbing:
+    dependency: transitive
+    description:
+      name: globbing
+      sha256: "4f89cfaf6fa74c9c1740a96259da06bd45411ede56744e28017cc534a12b6e2d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   graphs:
     dependency: transitive
     description:
@@ -496,6 +512,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  injector:
+    dependency: transitive
+    description:
+      name: injector
+      sha256: ed389bed5b48a699d5b9561c985023d0d5cc88dd5ff2237aadcce5a5ab433e4e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   io:
     dependency: transitive
     description:
@@ -776,6 +800,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
+  properties:
+    dependency: transitive
+    description:
+      name: properties
+      sha256: "333f427dd4ed07bdbe8c75b9ff864a1e70b5d7a8426a2e8bdd457b65ae5ac598"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   pub_semver:
     dependency: transitive
     description:
@@ -872,6 +912,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      sha256: "599701ca0693a74da361bc780b0752e1abc98226cf5095f6b069648116c896bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.14.2"
+  sentry_dart_plugin:
+    dependency: "direct dev"
+    description:
+      name: sentry_dart_plugin
+      sha256: "84436958fa9231e2e716be117a3b31695e54458b9f27039f76d14515e24248a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
+      sha256: "5ba2cf40646a77d113b37a07bd69f61bb3ec8a73cbabe5537b05a7c89d2656f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.14.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1029,6 +1093,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  system_info2:
+    dependency: transitive
+    description:
+      name: system_info2
+      sha256: b937736ecfa63c45b10dde1ceb6bb30e5c0c340e14c441df024150679d65ac43
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   term_glyph:
     dependency: transitive
     description:

--- a/worker_flutter/pubspec.yaml
+++ b/worker_flutter/pubspec.yaml
@@ -63,6 +63,11 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.24
   path: ^1.9.0
 
+  # Crash + session reporting. DSN is provided at build time via
+  # --dart-define=SENTRY_DSN=... — empty DSN puts the SDK in no-op
+  # mode, which is exactly what dev builds want.
+  sentry_flutter: ^8.10.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -72,6 +77,10 @@ dev_dependencies:
   drift_dev: ^2.20.0
   fake_cloud_firestore: ^3.1.0
   firebase_auth_mocks: ^0.14.1
+  # Uploads Dart obfuscation debug-info + sources to Sentry so
+  # production stack traces deobfuscate. Driven by the
+  # `sentry:` config block below; no-ops without $SENTRY_AUTH_TOKEN.
+  sentry_dart_plugin: ^2.0.0
 
 flutter:
   uses-material-design: true
@@ -84,3 +93,16 @@ flutter:
     - assets/precons/
   # Tray icon asset goes here once you have a 16x16 PNG ready:
   #   - assets/tray_icon.png
+
+# sentry_dart_plugin config — runs during CI release builds to upload
+# the obfuscation debug-info directory + Dart sources to Sentry so
+# stack traces deobfuscate. `release` is read from the
+# $SENTRY_RELEASE env var the release workflow sets; `auth_token`
+# from $SENTRY_AUTH_TOKEN. Both unset locally → plugin no-ops.
+sentry:
+  project: magic-bracket-worker
+  org: tytaniumdev
+  upload_debug_symbols: true
+  upload_source_maps: false
+  upload_sources: true
+  log_level: info

--- a/worker_flutter/test/sentry_options_test.dart
+++ b/worker_flutter/test/sentry_options_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:worker_flutter/sentry_setup.dart';
+
+void main() {
+  group('configureSentryOptions', () {
+    test('disables performance + profiling, enables session tracking', () {
+      final options = SentryFlutterOptions();
+
+      configureSentryOptions(
+        options,
+        dsn: 'https://example@sentry.io/1',
+        release: 'worker_flutter@0.1.0+42',
+        gitSha: 'abc1234',
+      );
+
+      expect(options.tracesSampleRate, 0);
+      // ignore: experimental_member_use
+      expect(options.profilesSampleRate, 0);
+      expect(options.enableAutoSessionTracking, isTrue);
+      expect(options.sendDefaultPii, isFalse);
+      expect(options.release, 'worker_flutter@0.1.0+42');
+      expect(options.dist, 'abc1234');
+      expect(options.environment, kDebugMode ? 'development' : 'production');
+      expect(options.autoSessionTrackingInterval, const Duration(seconds: 30));
+    });
+
+    test('empty DSN still applies safety flags (no-op mode)', () {
+      final options = SentryFlutterOptions();
+
+      configureSentryOptions(
+        options,
+        dsn: '',
+        release: 'worker_flutter@dev',
+        gitSha: 'local',
+      );
+
+      expect(options.dsn, '');
+      expect(options.tracesSampleRate, 0);
+      // ignore: experimental_member_use
+      expect(options.profilesSampleRate, 0);
+      expect(options.sendDefaultPii, isFalse);
+    });
+
+    test('beforeSend is wired up', () {
+      final options = SentryFlutterOptions();
+
+      configureSentryOptions(
+        options,
+        dsn: 'https://example@sentry.io/1',
+        release: 'r',
+        gitSha: 's',
+      );
+
+      expect(options.beforeSend, isNotNull);
+    });
+  });
+}

--- a/worker_flutter/test/telemetry_test.dart
+++ b/worker_flutter/test/telemetry_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:worker_flutter/telemetry.dart';
+
+void main() {
+  group('TelemetryCategory.tagValue', () {
+    test('renders as snake_case', () {
+      expect(TelemetryCategory.boot.tagValue, 'boot');
+      expect(TelemetryCategory.firebaseInit.tagValue, 'firebase_init');
+      expect(TelemetryCategory.signIn.tagValue, 'sign_in');
+      expect(TelemetryCategory.installer.tagValue, 'installer');
+      expect(TelemetryCategory.engineStart.tagValue, 'engine_start');
+      expect(TelemetryCategory.engineRuntime.tagValue, 'engine_runtime');
+      expect(TelemetryCategory.autoUpdater.tagValue, 'auto_updater');
+      expect(TelemetryCategory.tray.tagValue, 'tray');
+    });
+  });
+
+  group('scrubPii', () {
+    test('redacts email-shaped values in event extras', () {
+      final event = SentryEvent(message: const SentryMessage('hi')).copyWith(
+        extra: <String, dynamic>{
+          'note': 'user contacted me at someone@example.com about it',
+          'okField': 'no pii here',
+        },
+      );
+
+      final scrubbed = scrubPii(event);
+
+      expect(scrubbed, isNotNull);
+      expect(scrubbed!.extra!['note'], contains('[redacted-email]'));
+      expect(scrubbed.extra!['note'], isNot(contains('someone@example.com')));
+      expect(scrubbed.extra!['okField'], 'no pii here');
+    });
+
+    test('redacts known PII keys', () {
+      final event = SentryEvent(message: const SentryMessage('hi')).copyWith(
+        extra: <String, dynamic>{
+          'email': 'a@b.com',
+          'uid': 'xyz',
+          'displayName': 'Tyler',
+          'user_id': '42',
+          'safe': 'keep me',
+        },
+      );
+
+      final scrubbed = scrubPii(event);
+
+      expect(scrubbed!.extra!['email'], '[redacted]');
+      expect(scrubbed.extra!['uid'], '[redacted]');
+      expect(scrubbed.extra!['displayName'], '[redacted]');
+      expect(scrubbed.extra!['user_id'], '[redacted]');
+      expect(scrubbed.extra!['safe'], 'keep me');
+    });
+
+    test('replaces user with redacted placeholder', () {
+      final event = SentryEvent(
+        message: const SentryMessage('hi'),
+        user: SentryUser(id: 'abc', email: 'x@y.com'),
+      );
+
+      final scrubbed = scrubPii(event);
+
+      expect(scrubbed, isNotNull);
+      // sentry-dart's SentryEvent.user is final + copyWith treats null
+      // as "no change", so we replace rather than clear. The
+      // identifying fields all become '[redacted]'.
+      expect(scrubbed!.user!.email, isNull);
+      expect(scrubbed.user!.id, '[redacted]');
+    });
+
+    test('redacts email-shaped values inside breadcrumb data', () {
+      final event = SentryEvent(
+        message: const SentryMessage('hi'),
+        breadcrumbs: [
+          Breadcrumb(
+            category: 'sign_in',
+            message: 'attempt',
+            data: <String, dynamic>{
+              'note': 'tried someone@example.com',
+              'email': 'pii@example.com',
+              'safe': 'ok',
+            },
+          ),
+        ],
+      );
+
+      final scrubbed = scrubPii(event)!;
+      final crumbData = scrubbed.breadcrumbs!.single.data!;
+      expect(crumbData['note'], contains('[redacted-email]'));
+      expect(crumbData['email'], '[redacted]');
+      expect(crumbData['safe'], 'ok');
+    });
+  });
+}

--- a/worker_flutter/windows/flutter/generated_plugin_registrant.cc
+++ b/worker_flutter/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_storage/firebase_storage_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -30,6 +31,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   Sqlite3FlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   TrayManagerPluginRegisterWithRegistrar(

--- a/worker_flutter/windows/flutter/generated_plugins.cmake
+++ b/worker_flutter/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   firebase_storage
   screen_retriever_windows
+  sentry_flutter
   sqlite3_flutter_libs
   tray_manager
   url_launcher_windows


### PR DESCRIPTION
## Summary

Wires `sentry_flutter` into the macOS + Windows worker desktop app so unhandled crashes, known failure sites (sign-in, installer, engine start, worker runtime), and release-health sessions report to a new `magic-bracket-worker` Sentry project. Triggered by the recent `[firebase_auth/null-error] Host platform returned null value for non-null return value` sign-in error on macOS — visibility into that class going forward.

- **SDK init**: `SentryFlutter.init(appRunner: _appMain)` replaces the manual `FlutterError.onError` / `PlatformDispatcher.onError` / `runZonedGuarded` hooks; `beforeSend` tees Sentry-captured events into the existing `~/Library/Logs/...` file logger so local debugging still has a single source.
- **`Telemetry` helper** with a required `category` tag (snake_case enum). Alert rules filter on `category` so each site has its own alert.
- **Captures** at: Firebase init (with `projectId`), Google sign-in (native, PKCE, and firebase_credential phases — tagged with `platform`, `provider`, `error_code`), installer (with stage in extras), engine start, and the three `WorkerEngine` runtime catches. Tray + AutoUpdater failures get breadcrumbs only (non-fatal).
- **PII scrubbing**: `sendDefaultPii: false`, plus a `beforeSend` scrubber that redacts emails + known PII keys in event extras and breadcrumb data.
- **Release health**: `enableAutoSessionTracking: true` for crash-free-users metrics. No performance/profiling (`tracesSampleRate: 0`, `profilesSampleRate: 0`).
- **CI**: macOS Fastfile + Windows job both build with `--obfuscate --split-debug-info=build/debug-info/<plat>` and pass `SENTRY_DSN`, `SENTRY_RELEASE`, `GIT_SHA` via `--dart-define`. After each build a `dart run sentry_dart_plugin` step uploads the Dart debug-info map to Sentry so production stack traces deobfuscate.

## Manual setup required after merge

See `worker_flutter/docs/sentry-setup.md`. Operator (Tyler):

1. Create Sentry project `magic-bracket-worker` under `tytaniumdev`.
2. Add `SENTRY_DSN_WORKER` + `SENTRY_AUTH_TOKEN_WORKER` to Doppler (`blinkbreak/prd`).
3. Wire the Sentry-GitHub integration → `TytaniumDev/MagicBracketSimulator` with labels `bug,sentry,worker`.
4. Create the 4 alert rules (Error Spike, Sign-in Failures, Installer Failures, Engine Start Failures).

**Until those are done, every Sentry call is a no-op** (empty DSN → SDK disabled, same graceful-skip pattern as the `@sentry/nextjs` integration on the API).

## Test plan

- [x] `flutter analyze`: clean (`lib/` has no errors; pre-existing info-level warnings only)
- [x] `flutter test`: 91/91 green
- [ ] After Doppler is populated: build with `--dart-define=SENTRY_DSN=<test-dsn>`, force a Firebase init error, confirm event lands in Sentry within 30s
- [ ] After first `release-worker` run with secrets in place: confirm release shows in Sentry → Releases with Dart Debug Files uploaded
- [ ] Confirm the four alert rules fire and create GitHub issues with the expected labels

## Files

- Spec: `docs/superpowers/specs/2026-05-14-flutter-worker-sentry-design.md`
- Plan: `docs/superpowers/plans/2026-05-14-flutter-worker-sentry.md`
- Setup checklist: `worker_flutter/docs/sentry-setup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)