### PR TITLE
chore(appcast): publish worker-v0.2.0

### DIFF
--- a/worker_flutter/appcast.xml
+++ b/worker_flutter/appcast.xml
@@ -22,6 +22,18 @@
     <title>Magic Bracket Simulator</title>
     <description>Desktop worker for the Magic Bracket Simulator project.</description>
     <language>en</language>
+    <item>
+      <title>Version 0.2.0 (macOS)</title>
+      <sparkle:os>macos</sparkle:os>
+      <pubDate>Sun, 17 May 2026 08:47:39 +0000</pubDate>
+      <sparkle:version>8</sparkle:version>
+      <sparkle:shortVersionString>0.2.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.2.0/worker_flutter-macos.zip"
+                 sparkle:edSignature="eflob2HQrKuqSFiTQH9WI4xrNPHmvjszscOuF1B2qrxbVFZX3fQyskR0X0ycO6+fa8RHHCeSdXBScjIDbMlWAw=="
+                 length="40059402"
+                 type="application/octet-stream" />
+    </item>
 
     <!-- Windows (WinSparkle) — separate entries for Windows updates
          will land here once the Windows update flow is verified


### PR DESCRIPTION
Adds the worker-v0.2.0 <item> to appcast.xml so Sparkle can offer it to existing installs.

**Why this is a manual PR rather than an auto-commit from CI:**
The release workflow's `update-appcast` job tried to push this same commit directly to `main` but was blocked by branch protection (\`Changes must be made through a pull request\`). On personal-account repos, `bypass_pull_request_allowances` is an org-only feature — the workflow can't be granted bypass via the legacy branch-protection API. Two valid fixes for next time:

1. Migrate main's protection to a Ruleset (which DOES support bypass actors on personal repos) and add github-actions to bypass_actors. Larger change, keeps the auto-commit design.
2. Change `update-appcast` to push to a new branch and open a PR (with `gh pr merge --auto` if the repo has auto-merge enabled). Adds one PR per release to your queue, but keeps protection strict.

(Tracked as follow-up — see the original feature PR #216 for context.)

## Validation
- `sparkle:version` is `8`, matching `github.run_number=8` from the release workflow run (and thus the binary's `CFBundleVersion`). Sparkle compares this against the running install — Build 2 (CFBundleVersion=2) will be offered v0.2.0.
- `sparkle:edSignature` and `length` pulled verbatim from `worker-v0.2.0/sparkle-manifest.json`. The signature was generated by the CI release job using `SPARKLE_ED_PRIVATE_KEY`.
- The `<language>en</language>` anchor used by the prepend script is intact, so future auto-prepends still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)