### PR TITLE
fix(release): publish appcast via auto-merged PR

### DIFF
--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -378,8 +378,11 @@ jobs:
   update-appcast:
     needs: [version, publish]
     runs-on: ubuntu-latest
+    # `contents: write` to push the side branch; `pull-requests: write`
+    # for `gh pr create` + `gh pr merge --auto`.
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -407,31 +410,38 @@ jobs:
             --build-number "$BUILD_NUMBER" \
             --enclosure-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/worker_flutter-macos.zip"
 
-      - name: Commit and push
+      # We can't push directly to `main` because branch protection
+      # requires PRs and required-status-checks. `bypass_pull_request_
+      # allowances` (the legacy mechanism for "let github-actions
+      # bypass") is org-only and not available on personal-account
+      # repos. The pattern used by release-please / Dependabot / etc.
+      # is to push to a side branch, open a PR, and enable auto-merge
+      # — that respects protection (CI runs, then GitHub merges) while
+      # keeping the release fully automatic. The appcast PR has zero
+      # code changes (just one XML file), so its CI run is ~30 seconds.
+      - name: Push branch, open PR, enable auto-merge
         env:
           TAG: ${{ needs.version.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           if git diff --quiet worker_flutter/appcast.xml; then
             echo "No appcast change to commit (script produced no diff)."
             exit 0
           fi
+          BRANCH="appcast/${TAG}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add worker_flutter/appcast.xml
-          git commit -m "chore(appcast): publish ${TAG} [skip ci]"
-          # Retry push to tolerate concurrent commits to main from other
-          # workflows. Build + notarize can run 30-45 minutes, so plenty
-          # of opportunity for main to move forward. On non-fast-forward,
-          # pull --rebase and try again. Cap at 5 attempts; if we're
-          # still racing after that, something else is wrong.
-          for attempt in 1 2 3 4 5; do
-            if git push origin main; then
-              echo "Pushed on attempt $attempt."
-              exit 0
-            fi
-            echo "Push attempt $attempt failed; rebasing on origin/main and retrying..."
-            git pull --rebase --autostash origin main
-          done
-          echo "::error::Failed to push appcast update after 5 attempts." >&2
-          exit 1
+          git commit -m "chore(appcast): publish ${TAG}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(appcast): publish ${TAG}" \
+            --body "Auto-generated appcast update for ${TAG}. Will auto-merge once required checks pass."
+          # --squash so the appcast history stays linear (one commit per
+          # release on main, not "merge appcast/X.Y.Z + chore commit").
+          # --delete-branch cleans up the side branch on merge.
+          gh pr merge "$BRANCH" --auto --squash --delete-branch


### PR DESCRIPTION
## Summary
Direct push to \`main\` from the \`update-appcast\` job was rejected by branch protection (\`Changes must be made through a pull request\`). \`bypass_pull_request_allowances\` is an org-only mechanism, not available on personal-account repos.

Switching to the same auto-merged-PR pattern release-please / Dependabot / Renovate / semantic-release use:
1. \`update-appcast\` pushes the appcast change to a side branch \`appcast/worker-vX.Y.Z\`.
2. \`gh pr create\` opens a PR.
3. \`gh pr merge --auto --squash --delete-branch\` enables auto-merge.
4. The appcast PR's CI runs (~30s for an XML-only change), passes, and GitHub auto-merges.

The end-user effect is unchanged: Sparkle still picks up the new version within ~1h after merge.

## Validation
- Auto-merge is enabled on the repo (\`allow_auto_merge=true\` confirmed via API).
- Job permissions extended with \`pull-requests: write\` for \`gh pr create\`/\`gh pr merge --auto\`.
- The first real test of this flow happens when this PR itself merges — the next \`release-worker\` run will tag \`worker-v0.2.1\` and try the new flow end-to-end.

## Context
This is a follow-up to PR #216 (the auto-release feature). The release pipeline itself works end-to-end through publish; only the final appcast-commit step was broken. PR #217 was the one-time manual unblock for v0.2.0; future releases will use the flow added in this PR.

## Test plan
- [ ] CI checks pass on this PR
- [ ] After merge, \`release-worker\` run produces \`worker-v0.2.1\` Release + signed artifacts
- [ ] \`update-appcast\` opens an auto-merging PR titled \`chore(appcast): publish worker-v0.2.1\`
- [ ] That PR auto-merges within a few minutes; \`worker_flutter/appcast.xml\` on main now has both 0.2.0 and 0.2.1 entries
- [ ] Sparkle picks up v0.2.1 within ~1h or on app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)