### PR TITLE
fix(release): use APPCAST_PR_TOKEN PAT for the appcast PR

### DIFF
--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -378,17 +378,28 @@ jobs:
   update-appcast:
     needs: [version, publish]
     runs-on: ubuntu-latest
-    # `contents: write` to push the side branch; `pull-requests: write`
-    # for `gh pr create` + `gh pr merge --auto`.
+    # All git/gh operations in this job use APPCAST_PR_TOKEN (a fine-
+    # grained PAT scoped to this repo with `contents: write` +
+    # `pull-requests: write`). Why not GITHUB_TOKEN: PRs created via
+    # GITHUB_TOKEN don't trigger workflows, so required-status-checks
+    # never run on the appcast PR and `--auto` merge stays BLOCKED
+    # forever. A user-owned PAT bypasses the recursive-trigger rule —
+    # the PR fires CI like any other, checks pass quickly (XML-only
+    # diff), auto-merge fires. This matches the workaround documented
+    # by release-please and is the same pattern used by other release
+    # bots that auto-publish to a protected branch.
+    #
+    # The `permissions:` block below scopes GITHUB_TOKEN for any actions
+    # that still implicitly use it (e.g. actions/download-artifact).
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      actions: read
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.APPCAST_PR_TOKEN }}
           fetch-depth: 1
 
       - name: Download macOS artifact
@@ -410,19 +421,15 @@ jobs:
             --build-number "$BUILD_NUMBER" \
             --enclosure-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/worker_flutter-macos.zip"
 
-      # We can't push directly to `main` because branch protection
-      # requires PRs and required-status-checks. `bypass_pull_request_
-      # allowances` (the legacy mechanism for "let github-actions
-      # bypass") is org-only and not available on personal-account
-      # repos. The pattern used by release-please / Dependabot / etc.
-      # is to push to a side branch, open a PR, and enable auto-merge
-      # — that respects protection (CI runs, then GitHub merges) while
-      # keeping the release fully automatic. The appcast PR has zero
-      # code changes (just one XML file), so its CI run is ~30 seconds.
+      # Push the appcast change to a side branch, open a PR via the
+      # PAT, and enable auto-merge. The PAT is what makes CI trigger on
+      # the new PR (GITHUB_TOKEN-created PRs don't fire workflows). CI
+      # passes in ~30s on this XML-only diff and the PR squash-merges
+      # itself. See the job-level comment for the full rationale.
       - name: Push branch, open PR, enable auto-merge
         env:
           TAG: ${{ needs.version.outputs.tag }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.APPCAST_PR_TOKEN }}
         run: |
           set -euo pipefail
           if git diff --quiet worker_flutter/appcast.xml; then


### PR DESCRIPTION
## Summary
Switches the \`update-appcast\` job from \`GITHUB_TOKEN\` to a fine-grained PAT (\`APPCAST_PR_TOKEN\`) for both the side-branch push and the \`gh pr create\`/\`gh pr merge --auto\` calls.

## Why
The previous PR (#218) enabled the auto-merged-PR pattern, but missed a subtle GitHub Actions rule: **PRs created with \`GITHUB_TOKEN\` do not trigger workflows.** That meant the appcast PR opened with auto-merge set, but its required status checks (\`CI / Lint\`, \`CI / Build\`, \`CI / Test\`) never appeared — so auto-merge stayed \`BLOCKED\` forever.

This is exactly the limitation [release-please documents](https://github.com/googleapis/release-please/issues/922) and the canonical fix is the same: use a user-owned PAT for PR creation. PRs from a real user trigger CI normally.

PR #219 (the v0.2.2 appcast publish) was admin-merged manually as a one-time unblock; PR #220+ (future releases) will sail through automatically.

## Prerequisite: secret must be present before merge
\`APPCAST_PR_TOKEN\` needs to be set in \`Settings → Secrets and variables → Actions\` as a fine-grained PAT scoped to:
- Repository: \`TytaniumDev/MagicBracketSimulator\` (only this repo)
- Permissions: \`contents: write\`, \`pull-requests: write\`

If you merge this PR without the secret set, the next release's \`update-appcast\` job will fail with an authentication error — but the release itself will still publish to GitHub Releases successfully.

## Test plan
- [ ] \`APPCAST_PR_TOKEN\` secret created
- [ ] PR CI passes (Lint/Build/Test/Release scripts)
- [ ] After merge, observe the \`release-worker\` run for \`worker-v0.2.3\`
- [ ] The auto-generated appcast PR (\`appcast/worker-v0.2.3\`) has CI checks run on it (proving the PAT triggered them)
- [ ] That PR auto-merges within a few minutes — no admin override needed
- [ ] Live appcast.xml on \`main\` gets a v0.2.3 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)