### PR TITLE
feat(worker/macos): hybrid Dock + menu-bar mode

### DIFF
--- a/worker_flutter/lib/macos/activation_policy.dart
+++ b/worker_flutter/lib/macos/activation_policy.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+/// Hybrid Dock / menu-bar bridge for macOS.
+///
+/// The worker launches as a normal Mac app (Dock icon + menu bar via
+/// the standard MainMenu.xib) and folds into a menu-bar-only
+/// "Accessory" app once the user closes the dashboard window. The
+/// engine keeps running through the transition — `NSApp.activationPolicy`
+/// only governs UI affordances (Dock icon, menu bar, Cmd-Tab), not
+/// lifecycle. See `MainFlutterWindow.swift` for the native handler.
+///
+/// On non-macOS platforms every method is a no-op so callers don't
+/// need to gate on `Platform.isMacOS` at every callsite.
+enum MacActivationPolicy {
+  /// Standard Mac app: Dock icon, menu bar, Cmd-Tab entry.
+  regular('regular'),
+
+  /// Menu-bar-only: no Dock icon, no Cmd-Tab, no menu bar — only the
+  /// tray icon installed by `tray_manager` remains visible.
+  accessory('accessory');
+
+  const MacActivationPolicy(this.wireName);
+
+  /// String form sent across the method channel. Keep in sync with the
+  /// switch in `MainFlutterWindow.swift`.
+  final String wireName;
+}
+
+class MacActivationPolicyBridge {
+  MacActivationPolicyBridge._();
+
+  /// Channel name matches the native handler in MainFlutterWindow.swift.
+  static const MethodChannel _channel = MethodChannel(
+    'magic_bracket/activation_policy',
+  );
+
+  /// Promote the app to a regular Mac app (Dock + menu bar) and bring
+  /// it to the foreground. Idempotent; calling while already `.regular`
+  /// just re-activates the app.
+  ///
+  /// No-op on Windows/Linux.
+  static Future<void> setRegular() => _set(MacActivationPolicy.regular);
+
+  /// Demote to a menu-bar-only accessory app — drops the Dock icon
+  /// and menu bar. Idempotent.
+  ///
+  /// No-op on Windows/Linux.
+  static Future<void> setAccessory() => _set(MacActivationPolicy.accessory);
+
+  static Future<void> _set(MacActivationPolicy policy) async {
+    if (!Platform.isMacOS) return;
+    await _channel.invokeMethod<void>('set', {'policy': policy.wireName});
+  }
+}

--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -506,16 +506,27 @@ class _WorkerAppState extends State<_WorkerApp> with WindowListener {
     // setPreventClose). On Windows we keep historical behavior: the X
     // really quits since there's no tray icon there and no NSApp
     // activation-policy equivalent to fold the app away gracefully.
-    _log('onWindowClose: hiding window, demoting to accessory');
-    if (Platform.isMacOS) {
-      // Hide the window first, then demote to `.accessory` so the
-      // Dock icon and menu bar disappear in a single visual beat. Tray
-      // icon stays around as the way back. Engine keeps running — the
-      // activation policy only affects UI affordances.
-      await windowManager.hide();
-      await MacActivationPolicyBridge.setAccessory();
-    } else {
-      await windowManager.destroy();
+    //
+    // The listener has a `void` return type, so any throw here would
+    // be silently dropped by the framework. Wrap the whole body in
+    // try/catch so a bridge failure (PlatformException) is at least
+    // visible in the log file — the user might otherwise see "window
+    // hides but Dock icon still showing" with no clue why.
+    try {
+      if (Platform.isMacOS) {
+        _log('onWindowClose: hiding window, demoting to accessory');
+        // Hide the window first, then demote to `.accessory` so the
+        // Dock icon and menu bar disappear in a single visual beat.
+        // Tray icon stays around as the way back. Engine keeps running
+        // — the activation policy only affects UI affordances.
+        await windowManager.hide();
+        await MacActivationPolicyBridge.setAccessory();
+      } else {
+        _log('onWindowClose: destroying window (non-macOS quit-on-close)');
+        await windowManager.destroy();
+      }
+    } catch (e, st) {
+      _log('onWindowClose: transition failed: $e\n$st');
     }
   }
 

--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -17,6 +17,7 @@ import 'installer/install_progress_app.dart';
 import 'installer/installer.dart';
 import 'launch/auto_start_service.dart';
 import 'launch/mode_picker_screen.dart';
+import 'macos/activation_policy.dart';
 import 'offline/offline_app.dart';
 import 'sentry_setup.dart';
 import 'telemetry.dart';
@@ -29,14 +30,18 @@ import 'worker/worker_engine.dart';
 /// On launch:
 ///   1. Initialize Firebase (cloud_firestore listener target)
 ///   2. Load persistent worker config (workerId, capacity, paths)
-///   3. Set up an invisible window (LSUIElement=true hides the Dock icon
-///      already; we additionally `hide()` the window so it doesn't flash)
-///   4. Set up the tray icon; left-click shows the dashboard
+///   3. Show the dashboard window as a normal Mac app (Dock + menu bar)
+///   4. Set up the tray icon as a secondary affordance
 ///   5. Start the worker engine (Firestore listener + lease + sim runner)
 ///
-/// The window starts hidden. The user opens it from the tray. Closing the
-/// window via the red dot is intercepted by window_manager.setPreventClose
-/// and hides instead of exiting — the engine keeps running.
+/// Hybrid Dock/tray model on macOS: the app launches as `.regular`
+/// (full Mac app). Closing the window via the red dot is intercepted —
+/// `windowManager.setPreventClose(true)` keeps the engine alive, then
+/// `MacActivationPolicyBridge.setAccessory()` drops the Dock icon and
+/// menu bar so the only remaining affordance is the tray icon. A tray
+/// click promotes back to `.regular` and re-shows the window. Windows
+/// and Linux keep the historical "X actually quits" behavior since
+/// there's no equivalent of NSApp.activationPolicy.
 Future<void> main() async {
   await _initFileLogger();
   _log('main() started');
@@ -100,10 +105,12 @@ Future<void> _appMain() async {
     }
   }
 
-  // Native window setup. With LSUIElement=false (MVP fallback) the app
-  // appears in the Dock with a regular window. The user can minimize-to-
-  // tray-style behavior via the tray icon; closing the window hides it
-  // (setPreventClose=true) so the engine keeps running.
+  // Native window setup. The app launches as `.regular` (default in
+  // Info.plist) so the user sees a Dock icon + menu bar + window
+  // immediately. The close button is intercepted on macOS — see
+  // _WorkerAppState.onWindowClose, which hides the window AND demotes
+  // the app to `.accessory` so the Dock icon disappears while the
+  // worker keeps running behind the tray icon.
   _log('Initializing window_manager');
   await windowManager.ensureInitialized();
   _log('window_manager initialized');
@@ -495,13 +502,18 @@ class _WorkerAppState extends State<_WorkerApp> with WindowListener {
 
   @override
   void onWindowClose() async {
-    // Only macOS gets the hide-to-tray treatment (see _initWindow
-    // where setPreventClose is mac-only). On Windows the listener
-    // still fires before the OS-default close because window_manager
-    // installs its own hook, so quit explicitly to match the user's
-    // expectation that X actually closes the app.
+    // Only macOS gets the hide-to-tray treatment (see _appMain's
+    // setPreventClose). On Windows we keep historical behavior: the X
+    // really quits since there's no tray icon there and no NSApp
+    // activation-policy equivalent to fold the app away gracefully.
+    _log('onWindowClose: hiding window, demoting to accessory');
     if (Platform.isMacOS) {
+      // Hide the window first, then demote to `.accessory` so the
+      // Dock icon and menu bar disappear in a single visual beat. Tray
+      // icon stays around as the way back. Engine keeps running — the
+      // activation policy only affects UI affordances.
       await windowManager.hide();
+      await MacActivationPolicyBridge.setAccessory();
     } else {
       await windowManager.destroy();
     }

--- a/worker_flutter/lib/ui/tray_setup.dart
+++ b/worker_flutter/lib/ui/tray_setup.dart
@@ -1,14 +1,19 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
 
+import '../macos/activation_policy.dart';
 import '../worker/worker_engine.dart';
 
 /// Sets up the menu-bar tray icon and click-to-open-window behavior.
 ///
-/// With `LSUIElement=true` in Info.plist the app has no Dock icon and no
-/// visible window unless explicitly shown. The tray icon is the only
-/// affordance; left-clicking it shows the dashboard window.
+/// The tray icon is the user's way back to the dashboard after they
+/// close the window: closing demotes the app to `.accessory` (no Dock
+/// icon, no menu bar) while keeping the engine alive. A tray click —
+/// or the "Show dashboard" menu item — promotes back to `.regular` and
+/// re-shows the window. See `lib/macos/activation_policy.dart`.
 ///
 /// Right-click menu has: Show, Start/Stop worker, Quit.
 class TraySetup with TrayListener {
@@ -37,25 +42,29 @@ class TraySetup with TrayListener {
     final active = engine.currentState.activeSims.length;
     final completed = engine.currentState.completedCount;
 
-    await trayManager.setContextMenu(Menu(items: [
-      MenuItem(
-        key: 'status',
-        label: running
-            ? (active == 0
-                ? 'Idle • $completed done'
-                : 'Running $active sim(s)')
-            : 'Stopped',
-        disabled: true,
+    await trayManager.setContextMenu(
+      Menu(
+        items: [
+          MenuItem(
+            key: 'status',
+            label: running
+                ? (active == 0
+                      ? 'Idle • $completed done'
+                      : 'Running $active sim(s)')
+                : 'Stopped',
+            disabled: true,
+          ),
+          MenuItem.separator(),
+          MenuItem(key: 'show', label: 'Show dashboard'),
+          MenuItem(
+            key: 'toggle',
+            label: running ? 'Stop worker' : 'Start worker',
+          ),
+          MenuItem.separator(),
+          MenuItem(key: 'quit', label: 'Quit Magic Bracket Worker'),
+        ],
       ),
-      MenuItem.separator(),
-      MenuItem(key: 'show', label: 'Show dashboard'),
-      MenuItem(
-        key: 'toggle',
-        label: running ? 'Stop worker' : 'Start worker',
-      ),
-      MenuItem.separator(),
-      MenuItem(key: 'quit', label: 'Quit Magic Bracket Worker'),
-    ]));
+    );
   }
 
   Future<void> dispose() async {
@@ -97,6 +106,16 @@ class TraySetup with TrayListener {
   }
 
   Future<void> _showDashboard() async {
+    // Order matters: promote to `.regular` first so the Dock icon and
+    // menu bar are already in place when the window animates in,
+    // otherwise the user sees a brief flicker where the window is up
+    // but the Dock icon is still missing. The native bridge also
+    // calls `NSApp.activate` for us, so we don't need to focus
+    // separately — but call focus() anyway as a no-op safety net for
+    // edge cases where activate raced.
+    if (Platform.isMacOS) {
+      await MacActivationPolicyBridge.setRegular();
+    }
     await windowManager.show();
     await windowManager.focus();
   }

--- a/worker_flutter/lib/ui/tray_setup.dart
+++ b/worker_flutter/lib/ui/tray_setup.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
@@ -20,6 +18,12 @@ class TraySetup with TrayListener {
   TraySetup({required this.engine});
 
   final WorkerEngine engine;
+
+  /// Guard against double-firing the show-window flow on rapid tray
+  /// clicks. `setRegular` + `show` + `focus` are individually
+  /// idempotent, but interleaving two calls can produce a visible
+  /// Dock-icon flicker as the second call races the first.
+  bool _showingDashboard = false;
 
   Future<void> init() async {
     trayManager.addListener(this);
@@ -86,37 +90,51 @@ class TraySetup with TrayListener {
 
   @override
   void onTrayMenuItemClick(MenuItem menuItem) async {
-    switch (menuItem.key) {
-      case 'show':
-        await _showDashboard();
-        break;
-      case 'toggle':
-        if (engine.currentState.running) {
+    // tray_manager's listener has a `void` return type, so a throw
+    // from any of the awaited calls would be silently dropped. Wrap
+    // the body so engine.stop/start or a bridge transition failure at
+    // least surfaces in the log file.
+    try {
+      switch (menuItem.key) {
+        case 'show':
+          await _showDashboard();
+          break;
+        case 'toggle':
+          if (engine.currentState.running) {
+            await engine.stop();
+          } else {
+            await engine.start();
+          }
+          break;
+        case 'quit':
           await engine.stop();
-        } else {
-          await engine.start();
-        }
-        break;
-      case 'quit':
-        await engine.stop();
-        await dispose();
-        await windowManager.destroy();
-        break;
+          await dispose();
+          await windowManager.destroy();
+          break;
+      }
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('tray menu "${menuItem.key}" failed: $e\n$st');
+      }
     }
   }
 
   Future<void> _showDashboard() async {
-    // Order matters: promote to `.regular` first so the Dock icon and
-    // menu bar are already in place when the window animates in,
-    // otherwise the user sees a brief flicker where the window is up
-    // but the Dock icon is still missing. The native bridge also
-    // calls `NSApp.activate` for us, so we don't need to focus
-    // separately — but call focus() anyway as a no-op safety net for
-    // edge cases where activate raced.
-    if (Platform.isMacOS) {
+    if (_showingDashboard) return;
+    _showingDashboard = true;
+    try {
+      // Order matters: promote to `.regular` first so the Dock icon
+      // and menu bar are already in place when the window animates
+      // in, otherwise the user sees a brief flicker where the window
+      // is up but the Dock icon is still missing. The native bridge
+      // is a no-op on non-macOS and also calls `NSApp.activate` for
+      // us on macOS — we still call focus() afterwards as a safety
+      // net for any edge case where activate raced the show.
       await MacActivationPolicyBridge.setRegular();
+      await windowManager.show();
+      await windowManager.focus();
+    } finally {
+      _showingDashboard = false;
     }
-    await windowManager.show();
-    await windowManager.focus();
   }
 }

--- a/worker_flutter/macos/Runner/AppDelegate.swift
+++ b/worker_flutter/macos/Runner/AppDelegate.swift
@@ -3,8 +3,17 @@ import FlutterMacOS
 
 @main
 class AppDelegate: FlutterAppDelegate {
+  // Hybrid Dock / menu-bar model: closing the dashboard window flips
+  // the activation policy to `.accessory` so the Dock icon goes away,
+  // but the engine + tray icon must keep running. Returning `false`
+  // here keeps the app alive when the last window closes regardless of
+  // whether window_manager's `setPreventClose` intercept fires (e.g.
+  // AXPress on the close button bypasses `windowShouldClose:` and
+  // closes the window directly — without this override the OS would
+  // terminate the process on that path). The user explicitly quits via
+  // Cmd-Q, the tray menu's Quit item, or Force Quit.
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-    return true
+    return false
   }
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/worker_flutter/macos/Runner/Info.plist
+++ b/worker_flutter/macos/Runner/Info.plist
@@ -45,7 +45,10 @@
 	          Flutter event loop (see lib/auth/auth_service.dart).
 	       2. The app is Developer-ID signed + notarized so the OS
 	          doesn't kill it for unsigned-plugin-load violations. -->
-	<!-- LSUIElement intentionally omitted (defaults to false). -->
+	<!-- Explicitly false rather than omitted: keeping the key present
+	     and visible documents the cold-launch state alongside the
+	     comment above, instead of relying on the OS default behavior
+	     of an absent key. -->
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSHumanReadableCopyright</key>

--- a/worker_flutter/macos/Runner/Info.plist
+++ b/worker_flutter/macos/Runner/Info.plist
@@ -22,24 +22,32 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<!-- LSUIElement=true makes this a menu-bar-only app: no Dock icon,
-	     no Cmd-Tab entry. The tray icon is the user's primary affordance
-	     for re-opening the dashboard window after closing it.
+	<!-- Activation policy is NOT pinned via LSUIElement. The app
+	     launches as a normal Mac app (Dock icon + menu bar) and Dart
+	     code toggles `NSApp.setActivationPolicy(.accessory)` on
+	     window-close so the worker folds into a menu-bar-only state
+	     while still running, then back to `.regular` when the user
+	     re-opens the dashboard from the tray icon. See
+	     `MainFlutterWindow.swift` for the native handler and
+	     `lib/macos/activation_policy.dart` for the Dart bridge.
 
-	     Historical note: under earlier code the combination of
-	     LSUIElement=true + tray_manager + cloud_firestore crashed on
-	     cold boot (uncaught NSExceptions bypassed Dart try/catch). The
-	     things that made that path safe now:
+	     Why not LSUIElement=true: that flag locks the launch state to
+	     Accessory, which suppresses the menu bar even when a window is
+	     focused and was confusing for active monitoring of the worker.
+
+	     Historical note: a previous combination of LSUIElement=true +
+	     tray_manager + cloud_firestore crashed on cold boot (uncaught
+	     NSExceptions bypassed Dart try/catch). That crash path is now
+	     irrelevant since boot starts as `.regular`, but two fixes from
+	     that era remain load-bearing for the runtime `.accessory`
+	     toggle:
 	       1. firebase_auth.instance access is deferred until inside the
-	          Flutter event loop (see lib/auth/auth_service.dart). Even
-	          though tray init happens before `runApp` (lib/main.dart:238),
-	          tray init itself doesn't touch FirebaseAuth, so the
-	          documented native crash condition no longer materializes.
-	       2. The app is now Developer-ID signed + notarized, so the
-	          OS doesn't kill it for unsigned-plugin-load violations.
-	     Revert to <false/> here if menu-bar mode regresses. -->
+	          Flutter event loop (see lib/auth/auth_service.dart).
+	       2. The app is Developer-ID signed + notarized so the OS
+	          doesn't kill it for unsigned-plugin-load violations. -->
+	<!-- LSUIElement intentionally omitted (defaults to false). -->
 	<key>LSUIElement</key>
-	<true/>
+	<false/>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>

--- a/worker_flutter/macos/Runner/MainFlutterWindow.swift
+++ b/worker_flutter/macos/Runner/MainFlutterWindow.swift
@@ -92,8 +92,17 @@ class MainFlutterWindow: NSWindow {
           // menu bar reflects the new policy immediately. We always
           // activate here; the Dart caller decides when to invoke this,
           // so the activation is intentional.
+          //
+          // `activate(ignoringOtherApps:)` was deprecated in macOS 14
+          // (Sonoma) in favor of the no-arg `activate()` which respects
+          // the OS's cooperative activation rules. Fall back to the old
+          // signature for 10.13–13.x deployment targets.
           if target == .regular {
-            NSApp.activate(ignoringOtherApps: true)
+            if #available(macOS 14.0, *) {
+              NSApp.activate()
+            } else {
+              NSApp.activate(ignoringOtherApps: true)
+            }
           }
           result(nil)
         }

--- a/worker_flutter/macos/Runner/MainFlutterWindow.swift
+++ b/worker_flutter/macos/Runner/MainFlutterWindow.swift
@@ -39,6 +39,69 @@ class MainFlutterWindow: NSWindow {
       }
     }
 
+    // Hybrid Dock/menu-bar mode: Dart toggles NSApp.activationPolicy at
+    // runtime so the worker behaves like a normal Mac app while the
+    // dashboard window is open (Dock icon + menu bar), then folds back
+    // into a menu-bar-only "Accessory" app once the user closes the
+    // window — the engine keeps running through the transition since
+    // the policy only affects UI affordances. `LSUIElement` is left
+    // unset (i.e. false) in Info.plist so cold launch starts as
+    // `.regular`; the Dart side calls `setActivationPolicy("accessory")`
+    // on window-close and `setActivationPolicy("regular")` before
+    // re-showing from the tray icon.
+    //
+    // The transition from `.regular` to `.accessory` removes the Dock
+    // icon and menu bar without affecting any of our long-lived
+    // singletons (window_manager, tray_manager, Firestore listeners).
+    FlutterMethodChannel(
+      name: "magic_bracket/activation_policy",
+      binaryMessenger: flutterViewController.engine.binaryMessenger
+    ).setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "set":
+        guard let arguments = call.arguments as? [String: Any],
+              let policy = arguments["policy"] as? String else {
+          result(FlutterError(
+            code: "BAD_ARGS",
+            message: "set requires policy: String (regular|accessory)",
+            details: nil
+          ))
+          return
+        }
+        let target: NSApplication.ActivationPolicy
+        switch policy {
+        case "regular":
+          target = .regular
+        case "accessory":
+          target = .accessory
+        default:
+          result(FlutterError(
+            code: "BAD_POLICY",
+            message: "Unknown activation policy '\(policy)' — expected 'regular' or 'accessory'",
+            details: nil
+          ))
+          return
+        }
+        // `setActivationPolicy` must run on the main thread; method channel
+        // callbacks already arrive there, but be explicit for safety.
+        DispatchQueue.main.async {
+          NSApp.setActivationPolicy(target)
+          // Going .accessory drops the Dock icon. Going .regular adds it
+          // back but doesn't automatically promote the window to the
+          // foreground — call activate so the app gets focus and the
+          // menu bar reflects the new policy immediately. We always
+          // activate here; the Dart caller decides when to invoke this,
+          // so the activation is intentional.
+          if target == .regular {
+            NSApp.activate(ignoringOtherApps: true)
+          }
+          result(nil)
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()


### PR DESCRIPTION
## Summary

- Worker launches as a normal Mac app (Dock icon + standard menu bar + dashboard window visible on cold boot). Closes the dashboard window → app folds into a menu-bar-only `.accessory` state so the engine keeps running silently via the tray icon. Clicking the tray icon (or the "Show dashboard" item) promotes back to `.regular` and re-shows the window.
- Implementation: new `magic_bracket/activation_policy` MethodChannel in `MainFlutterWindow.swift` (sets `NSApp.activationPolicy` + calls `NSApp.activate` on promotion), `lib/macos/activation_policy.dart` as the Dart bridge, and two call sites — `_WorkerAppState.onWindowClose` (`hide()` → `setAccessory()`) and `TraySetup._showDashboard` (`setRegular()` → `show()`).
- `Info.plist`: `LSUIElement` flipped to `<false/>`. Was `true` from the original tray-only design, but that locked launch to Accessory which suppresses the menu bar even with a window focused — the source of "no menu bar in macOS" complaint.
- `AppDelegate.applicationShouldTerminateAfterLastWindowClosed` now returns `false`. **Load-bearing** for the hybrid: `window_manager`'s `setPreventClose(true)` covers real red-dot clicks via `windowShouldClose:`, but paths that bypass that delegate method (AXPress, programmatic close) would otherwise terminate a `.regular` app after the window closed.

## Test plan

- [ ] Cold launch — confirm Dock icon appears, full menu bar populated (Apple / MagicBracketWorker / Edit / View / Window / Help), dashboard window opens immediately.
- [ ] Click the red close button — confirm window hides, Dock icon disappears, menu bar disappears, tray icon stays visible, engine continues running (check `~/Library/Logs/com.tytaniumdev.magicBracketSimulator.log` for the new `onWindowClose: hiding window, demoting to accessory` line).
- [ ] Click tray icon — confirm window reappears, Dock icon comes back, menu bar comes back, app is focused.
- [ ] Repeat close/open cycle a couple times — no flicker, engine stays alive across transitions.
- [ ] Tray right-click menu (Show dashboard / Start/Stop / Quit) still works in both `.regular` and `.accessory` states.
- [ ] Cmd-Q quits the app cleanly.
- [ ] Windows / Linux builds keep historical behavior (red X actually quits — no `NSApp.activationPolicy` equivalent there; `setRegular`/`setAccessory` are no-ops).

## Verification done locally

- `flutter build macos --debug` clean; `flutter analyze` no new issues.
- `lsappinfo info -only ApplicationType` reports `Foreground` (regular) after cold launch.
- AppleScript enumeration of menu bar items confirms the full set is now populated.
- Programmatic AppleScript close paths (AXPress, `keystroke "w"`, `tell window to close`) all leave the process alive — the `applicationShouldTerminateAfterLastWindowClosed=false` fix is verified working. The actual `.regular` → `.accessory` toggle on `onWindowClose:` couldn't be auto-verified because none of those paths go through `windowShouldClose:` without Accessibility permissions on the controlling process; needs a manual red-dot click to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)