### PR TITLE
feat(worker/macos): add Check for Updates… menu item

### DIFF
--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -325,12 +326,35 @@ const _kAppcastUrl =
 /// surface a "new version available" dialog itself; we don't render UI.
 const _kAutoUpdateCheckIntervalSeconds = 3600;
 
+/// Channel paired with the "Check for Updates…" NSMenuItem installed
+/// by `MainFlutterWindow.swift`. The Swift side fires "checkForUpdates"
+/// when the user clicks the menu item; we forward to
+/// `autoUpdater.checkForUpdates(inBackground: false)` so Sparkle shows
+/// its UI even when there's no update available — the interactive
+/// "You're up to date" alert is the expected affordance when the user
+/// explicitly asks. The background poll set up below keeps using
+/// `inBackground: true` to stay silent on the no-update path.
+const _kAutoUpdaterChannel = MethodChannel('magic_bracket/auto_updater');
+
 Future<void> _initAutoUpdater() async {
   try {
     await autoUpdater.setFeedURL(_kAppcastUrl);
     await autoUpdater.setScheduledCheckInterval(
       _kAutoUpdateCheckIntervalSeconds,
     );
+    // Listen for the menu-item-triggered check from Swift. Set the
+    // handler BEFORE kicking off the initial background poll so a
+    // user mashing the menu item during cold boot is still handled.
+    _kAutoUpdaterChannel.setMethodCallHandler((call) async {
+      if (call.method == 'checkForUpdates') {
+        _log('AutoUpdater: user-initiated check from menu');
+        try {
+          await autoUpdater.checkForUpdates(inBackground: false);
+        } catch (e, st) {
+          _log('AutoUpdater: user-initiated check failed: $e\n$st');
+        }
+      }
+    });
     // Background check so the user doesn't see a "no update available" toast
     // when nothing is new.
     await autoUpdater.checkForUpdates(inBackground: true);

--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -337,24 +337,32 @@ const _kAutoUpdateCheckIntervalSeconds = 3600;
 const _kAutoUpdaterChannel = MethodChannel('magic_bracket/auto_updater');
 
 Future<void> _initAutoUpdater() async {
+  // Register the menu-item channel handler FIRST — before any await
+  // that could throw and skip the rest of the setup. If `setFeedURL`
+  // or `setScheduledCheckInterval` fails, Sparkle's appcast polling
+  // is disabled, but the menu item should still respond (with the
+  // failure surfaced in the log) instead of clicking into the void.
+  _kAutoUpdaterChannel.setMethodCallHandler((call) async {
+    if (call.method != 'checkForUpdates') {
+      // Unknown method on a channel we control both ends of — bubble
+      // a real error so a wiring mistake surfaces during development
+      // rather than getting silently swallowed.
+      throw MissingPluginException(
+        'magic_bracket/auto_updater: unknown method "${call.method}"',
+      );
+    }
+    _log('AutoUpdater: user-initiated check from menu');
+    try {
+      await autoUpdater.checkForUpdates(inBackground: false);
+    } catch (e, st) {
+      _log('AutoUpdater: user-initiated check failed: $e\n$st');
+    }
+  });
   try {
     await autoUpdater.setFeedURL(_kAppcastUrl);
     await autoUpdater.setScheduledCheckInterval(
       _kAutoUpdateCheckIntervalSeconds,
     );
-    // Listen for the menu-item-triggered check from Swift. Set the
-    // handler BEFORE kicking off the initial background poll so a
-    // user mashing the menu item during cold boot is still handled.
-    _kAutoUpdaterChannel.setMethodCallHandler((call) async {
-      if (call.method == 'checkForUpdates') {
-        _log('AutoUpdater: user-initiated check from menu');
-        try {
-          await autoUpdater.checkForUpdates(inBackground: false);
-        } catch (e, st) {
-          _log('AutoUpdater: user-initiated check failed: $e\n$st');
-        }
-      }
-    });
     // Background check so the user doesn't see a "no update available" toast
     // when nothing is new.
     await autoUpdater.checkForUpdates(inBackground: true);

--- a/worker_flutter/macos/Runner/MainFlutterWindow.swift
+++ b/worker_flutter/macos/Runner/MainFlutterWindow.swift
@@ -160,9 +160,13 @@ class MainFlutterWindow: NSWindow {
     // Index 0 is "About <AppName>" in the Flutter-generated XIB. Slot
     // the new item + a separator immediately after it so the layout
     // matches the macOS HIG convention (About / Check for Updates /
-    // separator / Settings / Services / …).
-    appMenu.insertItem(item, at: 1)
-    appMenu.insertItem(NSMenuItem.separator(), at: 2)
+    // separator / Settings / Services / …). `min(numberOfItems, …)`
+    // is defensive against a future MainMenu.xib rewrite that ships
+    // with an empty app menu — `insertItem(at:)` would crash on an
+    // out-of-range index, but clamping keeps it valid even then.
+    let itemIndex = min(appMenu.numberOfItems, 1)
+    appMenu.insertItem(item, at: itemIndex)
+    appMenu.insertItem(NSMenuItem.separator(), at: min(appMenu.numberOfItems, itemIndex + 1))
   }
 
   @objc private func handleCheckForUpdates(_ sender: Any?) {

--- a/worker_flutter/macos/Runner/MainFlutterWindow.swift
+++ b/worker_flutter/macos/Runner/MainFlutterWindow.swift
@@ -3,6 +3,12 @@ import FlutterMacOS
 import LaunchAtLogin
 
 class MainFlutterWindow: NSWindow {
+  /// Retained reference so the "Check for Updates…" menu item action
+  /// can route through it. The auto_updater plugin owns Sparkle's
+  /// SPUStandardUpdaterController internally and only exposes a Dart
+  /// API, so the menu item round-trips Swift → Dart → autoUpdater.
+  private var autoUpdaterChannel: FlutterMethodChannel?
+
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
@@ -111,8 +117,59 @@ class MainFlutterWindow: NSWindow {
       }
     }
 
+    // "Check for Updates…" menu item.
+    //
+    // Sparkle 2 doesn't install a menu item for you — host apps wire
+    // one up themselves and bind it to SPUStandardUpdaterController's
+    // `checkForUpdates:` IBAction. The auto_updater Flutter plugin
+    // owns its updater controller privately, so we can't bind a menu
+    // item directly to it. Instead we route the click back through a
+    // FlutterMethodChannel and let the Dart side call
+    // `autoUpdater.checkForUpdates(inBackground: false)`, which
+    // eventually reaches the same controller. One extra hop, no extra
+    // cost the user can feel.
+    autoUpdaterChannel = FlutterMethodChannel(
+      name: "magic_bracket/auto_updater",
+      binaryMessenger: flutterViewController.engine.binaryMessenger
+    )
+    installCheckForUpdatesMenuItem()
+
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+  }
+
+  /// Insert "Check for Updates…" into the app menu, right after
+  /// "About <AppName>". The app menu (`MagicBracketWorker`) is always
+  /// the first entry in `NSApp.mainMenu` — the system-rendered Apple
+  /// menu isn't part of the app's NSMenu structure.
+  private func installCheckForUpdatesMenuItem() {
+    guard let mainMenu = NSApp.mainMenu,
+          let appMenu = mainMenu.items.first?.submenu else {
+      // Defensive: if the standard MainMenu.xib didn't load (e.g.
+      // somebody rewrites it later), don't crash — just skip and let
+      // the dashboard's in-app update button be the only affordance.
+      return
+    }
+    let item = NSMenuItem(
+      title: "Check for Updates…",
+      action: #selector(handleCheckForUpdates(_:)),
+      keyEquivalent: ""
+    )
+    item.target = self
+    // Index 0 is "About <AppName>" in the Flutter-generated XIB. Slot
+    // the new item + a separator immediately after it so the layout
+    // matches the macOS HIG convention (About / Check for Updates /
+    // separator / Settings / Services / …).
+    appMenu.insertItem(item, at: 1)
+    appMenu.insertItem(NSMenuItem.separator(), at: 2)
+  }
+
+  @objc private func handleCheckForUpdates(_ sender: Any?) {
+    // inBackground: false on the Dart side — this is an interactive
+    // user-initiated check, so Sparkle should surface a "You're up to
+    // date" dialog when there's no new version, instead of staying
+    // silent the way the scheduled hourly poll does.
+    autoUpdaterChannel?.invokeMethod("checkForUpdates", arguments: nil)
   }
 }


### PR DESCRIPTION
## Summary

- Sparkle 2 doesn't install a "Check for Updates…" menu item itself — host apps wire one up and bind it to `SPUStandardUpdaterController.checkForUpdates(_:)`. The `auto_updater` Flutter plugin keeps its updater controller private, so a direct binding isn't possible; the menu item instead routes Swift → Dart via a new `magic_bracket/auto_updater` method channel that calls `autoUpdater.checkForUpdates(inBackground: false)`.
- `inBackground: false` is the key bit for this entry point — it tells Sparkle to surface the "You're up to date" alert when there's no update, which is the HIG expectation for an explicit user-initiated check. The hourly background poll keeps using `inBackground: true` so it stays silent on the no-update path.
- Menu item slots at index 1 of the app menu (right after "About <AppName>") with a trailing separator, matching the Apple-standard layout.

## Verification done locally

```
$ osascript -e '... name of every menu item of menu 1 of menu bar item 2 ...'
About MagicBracketWorker, Check for Updates…, (separator), Settings…, …

$ osascript -e '... click menu item "Check for Updates…" ...'
$ tail -1 ~/Library/Logs/com.tytaniumdev.magicBracketSimulator.log
2026-05-18T16:52:45.933312 AutoUpdater: user-initiated check from menu
```

Confirms (a) the item is present, (b) it sits in the correct slot, (c) the Swift → Dart round-trip fires when clicked.

## Test plan

- [ ] Cold-launch the new build, open the `MagicBracketWorker` app menu, confirm "Check for Updates…" appears right under "About MagicBracketWorker".
- [ ] Click "Check for Updates…" while on the latest version — Sparkle should show its "You're up to date" alert.
- [ ] When a newer release lands, the same menu item should show "A new version of Magic Bracket Worker is available".
- [ ] On Windows / Linux: no regression. The native menu code is macOS-only; on other platforms the channel handler just never fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)