### PR TITLE
fix(worker/macos): disable SPM to unbreak release build

### DIFF
--- a/worker_flutter/pubspec.yaml
+++ b/worker_flutter/pubspec.yaml
@@ -90,6 +90,9 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  config:
+    # Force CocoaPods — sentry_flutter 8.14.2's Package.swift uses `from: "8.46.0"` and resolves a newer Sentry-Cocoa missing SentryBinaryImageCache.image(byAddress:); its Podspec pins exactly 8.46.0.
+    enable-swift-package-manager: false
   assets:
     # Bundled Forge precons — copied verbatim from
     # `worker/forge-engine/decks/` so offline mode works out of the


### PR DESCRIPTION
## Summary

- The release-worker workflow's `build-macos` job has failed on every push since PR #221 (3 consecutive failed releases: #224, #225, #226).
- Root cause: Flutter auto-enabled Swift Package Manager between the `worker-v0.2.4` cut and the next merge. `sentry_flutter` 8.14.2's `Package.swift` declares `sentry-cocoa from: "8.46.0"`, so SPM resolves the latest 8.x. Its Podspec, by contrast, pins `Sentry/HybridSDK` to exactly `8.46.0`. Newer 8.x sentry-cocoa dropped `SentryBinaryImageCache.image(byAddress:)`, which `SentryFlutterPlugin.swift:266` still calls — so the Swift build fails.
- Fix: opt this project out of SPM via `flutter.config.enable-swift-package-manager: false` in `worker_flutter/pubspec.yaml`. This forces CocoaPods, which honors the exact `= 8.46.0` Podspec pin.

## Test plan

- [x] Confirm pubspec syntax matches current Flutter docs (`flutter.config.enable-swift-package-manager`, not the deprecated `disable-swift-package-manager`).
- [ ] Merge to main and watch the `release-worker.yml` run — `build-macos` should pass and a new `worker-v0.2.5` release should be cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)