### PR TITLE
fix(worker/macos): preserve entitlements on outer .app re-sign

### DIFF
--- a/worker_flutter/macos/fastlane/Fastfile
+++ b/worker_flutter/macos/fastlane/Fastfile
@@ -205,7 +205,19 @@ platform :mac do
     # verification didn't catch it (Debug builds skip this re-signing
     # pass). Fail the lane loudly here so a future Fastfile edit can't
     # break Firebase Auth sign-in on macOS without CI noticing.
-    entitlements_dump = `codesign -d --entitlements - #{app_path_abs.shellescape} 2>&1`
+    #
+    # `sh` (not backticks) so a non-zero codesign exit fails the lane
+    # by itself, and so the command + output land in the fastlane CI
+    # log. `log: false` suppresses fastlane's "$ codesign ..." prefix
+    # to keep the log focused. We search for the bare
+    # `keychain-access-groups` substring rather than the XML key tag —
+    # `codesign -d --entitlements -` switched output format somewhere
+    # between Sequoia and Tahoe (XML plist vs `[Key] foo` bracketed),
+    # and the substring is the one token present in both.
+    entitlements_dump = sh(
+      "codesign -d --entitlements - #{app_path_abs.shellescape} 2>&1",
+      log: false
+    )
     unless entitlements_dump.include?("keychain-access-groups")
       UI.user_error!(
         "Outer .app is missing keychain-access-groups after re-sign. " \

--- a/worker_flutter/macos/fastlane/Fastfile
+++ b/worker_flutter/macos/fastlane/Fastfile
@@ -172,13 +172,46 @@ platform :mac do
       "#{sparkle_root}/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader",
       "#{sparkle_root}/Versions/B/XPCServices/Downloader.xpc",
       sparkle_root,
-      app_path_abs,
     ].each do |target|
       unless File.exist?(target)
         UI.message("Skipping #{target} — not present")
         next
       end
       sh("codesign --force --options runtime --timestamp --sign #{sign_id.shellescape} #{target.shellescape}")
+    end
+
+    # Re-seal the outer .app last, AFTER nested Sparkle components have
+    # been re-signed (changing nested signatures invalidates the parent
+    # seal). The `--preserve-metadata=entitlements,requirements` is what
+    # makes Firebase Auth's keychain access work on macOS Tahoe: without
+    # it, `codesign --force --sign` regenerates the signature from
+    # scratch and discards the entitlements Xcode applied from
+    # Release.entitlements during `flutter build` (notably
+    # `keychain-access-groups`, plus the JIT / library-validation /
+    # network entitlements). The shipped v0.2.43 binary had an empty
+    # entitlements dictionary, surfaced as
+    # `[firebase_auth/keychain-error]` from
+    # `FirebaseAuthHostApi.signInWithCredential` because Firebase Auth's
+    # SecItemAdd call returns errSecMissingEntitlement (-34018) on
+    # hardened-runtime + sandbox-disabled bundles with no keychain
+    # access group declared.
+    sh("codesign --force --options runtime --timestamp " \
+       "--preserve-metadata=entitlements,requirements " \
+       "--sign #{sign_id.shellescape} #{app_path_abs.shellescape}")
+
+    # Guardrail: assert the outer .app still carries the keychain
+    # entitlement after the re-sign. v0.2.43 shipped without it because
+    # the loop above stripped entitlements silently — local Debug
+    # verification didn't catch it (Debug builds skip this re-signing
+    # pass). Fail the lane loudly here so a future Fastfile edit can't
+    # break Firebase Auth sign-in on macOS without CI noticing.
+    entitlements_dump = `codesign -d --entitlements - #{app_path_abs.shellescape} 2>&1`
+    unless entitlements_dump.include?("keychain-access-groups")
+      UI.user_error!(
+        "Outer .app is missing keychain-access-groups after re-sign. " \
+        "Firebase Auth would fail with [firebase_auth/keychain-error] " \
+        "on macOS Tahoe. codesign output:\n#{entitlements_dump}"
+      )
     end
 
     # Notarize the signed .app, then staple the ticket so users without


### PR DESCRIPTION
## Summary

The Sparkle deep-signing loop in `worker_flutter/macos/fastlane/Fastfile` ran `codesign --force --options runtime --timestamp --sign IDENTITY` on the outer `.app` without `--preserve-metadata=entitlements`, which regenerates the signature from scratch and discards every entitlement Xcode applied from `Release.entitlements` during `flutter build`.

Verified on the actual v0.2.43 release artifact: `codesign -d --entitlements -` returns an empty dictionary. Firebase Auth's `SecItemAdd` then returns `errSecMissingEntitlement` (-34018) on hardened-runtime + sandbox-disabled bundles, surfaced to Dart as `[firebase_auth/keychain-error]` from `FirebaseAuthHostApi.signInWithCredential` — the bug Sentry caught in `MAGIC-BRACKET-WORKER-2`. PR #224's entitlement addition was correct; the local verification only exercised a Debug build, which is signed by Xcode and skips this re-signing pipeline.

The fix splits the outer `.app` out of the in-loop re-sign and gives it a dedicated `codesign … --preserve-metadata=entitlements,requirements …` invocation. A post-resign guardrail fails the lane (via fastlane's `sh` helper) if `keychain-access-groups` is missing — so a future Fastfile edit can't silently regress sign-in again.

Sparkle nested binaries (Autoupdate, Updater.app, XPC services) keep the existing re-signing behavior — they don't carry the keychain entitlement and auto-update has been working unchanged.

> Originally bundled the SPM-disable fix too, but #227 already shipped that to main; rebase dropped the duplicate commit.

## Test plan

- [x] Confirmed v0.2.43 artifact has empty entitlements via `codesign -d --entitlements -`
- [x] Reproduced the strip with `codesign --force --options runtime --sign -` on a copy of the local Debug `.app` → empty entitlements
- [x] Verified `--preserve-metadata=entitlements,requirements` preserves all entitlements (`keychain-access-groups`, `allow-jit`, `disable-library-validation`, `network.client`) on the same Debug `.app`
- [x] Simulated the full Fastfile flow (nested Sparkle resigns + new outer-app resign) on a copy → final outer `.app` carries `keychain-access-groups = [F2HXQGU2CC.com.tytaniumdev.magicBracketSimulator]`
- [x] `ruby -c Fastfile` syntax-clean
- [ ] CI release-worker.yml produces a new `.app` whose `codesign -d --entitlements -` includes `keychain-access-groups` (guardrail in Fastfile will fail the lane otherwise)
- [ ] Manual smoke on the resulting build: Google Sign-In succeeds without `[firebase_auth/keychain-error]`

Fixes MAGIC-BRACKET-WORKER-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)