### PR TITLE
perf: coalesce concurrent fetchJob calls with in-memory cache

### DIFF
--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -74,6 +74,40 @@ const activeAbortControllers = new Map<string, Set<AbortController>>();
 // Ordered list of all active abort controllers for capacity preemption (most recent at end)
 const allActiveAbortControllers: AbortController[] = [];
 
+// ============================================================================
+// Job Cache
+// ============================================================================
+
+/**
+ * In-flight job fetch cache.
+ *
+ * When many simulations under the same job start concurrently, each one
+ * previously called fetchJob independently, generating N identical HTTP/DB
+ * round-trips. This map coalesces them: the first caller inserts a Promise
+ * and all subsequent callers for the same jobId await the same Promise.
+ *
+ * The entry is deleted once the Promise settles so that a subsequent poll
+ * cycle (e.g. a retry or a new batch of sims) always fetches fresh data.
+ */
+const jobFetchCache = new Map<string, Promise<JobData | null>>();
+
+/**
+ * Fetch job details, coalescing concurrent requests for the same jobId.
+ * Uses the module-level jobFetchCache so that N simultaneous sims for
+ * the same job share one network round-trip.
+ */
+function fetchJobCached(jobId: string): Promise<JobData | null> {
+  const cached = jobFetchCache.get(jobId);
+  if (cached) return cached;
+
+  const promise = fetchJob(jobId).finally(() => {
+    // Evict once settled so the next batch always sees fresh data.
+    jobFetchCache.delete(jobId);
+  });
+  jobFetchCache.set(jobId, promise);
+  return promise;
+}
+
 // Notify mechanism for push-based job notification (local polling mode)
 let jobNotifyResolve: (() => void) | null = null;
 
@@ -324,8 +358,8 @@ async function processSimulationInternal(
 ): Promise<void> {
   const simLabel = `[${simId}]`;
 
-  // Fetch job for deck data
-  const job = await fetchJob(jobId);
+  // Fetch job for deck data (coalesced — concurrent sims for the same job share one request)
+  const job = await fetchJobCached(jobId);
   if (!job) {
     console.error(`${simLabel} Job ${jobId} not found, reporting FAILED`);
     await reportSimulationStatus(jobId, simId, {


### PR DESCRIPTION
## Summary

When many simulations for the same job start concurrently, each previously called `fetchJob(jobId)` independently, generating N identical HTTP/DB round-trips against the API. This PR eliminates that N-1 overhead.

## What changed

Added a module-level `jobFetchCache: Map<string, Promise<JobData | null>>` in `worker/src/worker.ts`. A new `fetchJobCached()` wrapper checks the map before issuing a network call:
- If an in-flight Promise for the jobId already exists, it returns that Promise directly (all concurrent callers share the same result).
- If not, it calls `fetchJob()`, stores the Promise, and evicts it in a `.finally()` handler so the next poll cycle always fetches fresh data.

`processSimulationInternal` now calls `fetchJobCached` instead of `fetchJob`.

## Proposals absorbed
- `performance-worker-job-cache`

## Test plan
- `cd worker && npm run test:unit` — 4/4 passed ✅
- `cd worker && npm run build` — TypeScript compiles cleanly ✅
- `cd api && npm run test:unit` — all API unit tests still pass ✅

Generated by Antigravity /overnight run 20260520-063420