### PR TITLE
docs(worker): reflect that App Attest is already configured

### DIFF
--- a/worker_flutter/docs/APP_CHECK_SETUP.md
+++ b/worker_flutter/docs/APP_CHECK_SETUP.md
@@ -33,14 +33,22 @@ To verify with `gcloud`:
 
 ```bash
 TOKEN=$(gcloud auth print-access-token)
+APP=1:14286370379:ios:eb91598352257eef6d7fce
+BASE=https://firebaseappcheck.googleapis.com/v1/projects/magic-bracket-simulator/apps/$APP
+
+# App Attest (macOS 11+ / signed release builds):
 curl -s -H "Authorization: Bearer $TOKEN" \
      -H "X-Goog-User-Project: magic-bracket-simulator" \
-     "https://firebaseappcheck.googleapis.com/v1/projects/magic-bracket-simulator/apps/1:14286370379:ios:eb91598352257eef6d7fce/appAttestConfig"
+     "$BASE/appAttestConfig"
+
+# DeviceCheck (macOS <11 fallback):
+curl -s -H "Authorization: Bearer $TOKEN" \
+     -H "X-Goog-User-Project: magic-bracket-simulator" \
+     "$BASE/deviceCheckConfig"
 ```
 
-A non-empty response with `tokenTtl` set means App Attest is active.
-The matching `deviceCheckConfig` endpoint confirms the macOS <11
-fallback is wired up too.
+Each non-empty response with `tokenTtl` set means that provider is
+active.
 
 If you ever need to re-register from scratch (e.g. for a new Firebase
 project), the Console flow is:
@@ -95,10 +103,12 @@ Two different layers control what happens when a request lacks
   here — the request returns 401 immediately. This is what surfaces as
   the desktop worker's "Auth token rejected" error.
 - **Firebase service-level (Firestore + Identity Toolkit):** controlled
-  by `enforcementMode` on each service in
-  `projects/14286370379/services/*`. Currently both are `UNENFORCED`,
-  which means direct Firestore client calls (e.g. the run-locally
-  Firestore mirror in `lib/offline/cloud_mirror.dart`) work without an
-  App Check token. Flip these to `ENFORCED` only after every supported
-  platform — including Windows — sends a real token; Windows currently
-  can't, so leaving them `UNENFORCED` is correct.
+  by `enforcementMode` on each service under
+  `projects/magic-bracket-simulator/services/*` (Firebase Console →
+  App Check → APIs → Cloud Firestore / Identity Toolkit → **Enforce**).
+  Currently both are `UNENFORCED`, which means direct Firestore client
+  calls (e.g. the run-locally Firestore mirror in
+  `lib/offline/cloud_mirror.dart`) work without an App Check token.
+  Flip these to `ENFORCED` only after every supported platform —
+  including Windows — sends a real token; Windows currently can't, so
+  leaving them `UNENFORCED` is correct.

--- a/worker_flutter/docs/APP_CHECK_SETUP.md
+++ b/worker_flutter/docs/APP_CHECK_SETUP.md
@@ -22,15 +22,33 @@ entirely.
   request and attaches it as `X-Firebase-AppCheck`. Soft-fails on
   platforms or environments where activation didn't succeed.
 
-## One-time Firebase Console setup
+## Firebase Console state — already configured
+
+App Attest and DeviceCheck are already enabled on the Apple Firebase
+app entry (`1:14286370379:ios:eb91598352257eef6d7fce`, shared by the
+iOS-type and macOS targets — Firebase treats them as one app). No
+further Firebase Console action is required for release builds.
+
+To verify with `gcloud`:
+
+```bash
+TOKEN=$(gcloud auth print-access-token)
+curl -s -H "Authorization: Bearer $TOKEN" \
+     -H "X-Goog-User-Project: magic-bracket-simulator" \
+     "https://firebaseappcheck.googleapis.com/v1/projects/magic-bracket-simulator/apps/1:14286370379:ios:eb91598352257eef6d7fce/appAttestConfig"
+```
+
+A non-empty response with `tokenTtl` set means App Attest is active.
+The matching `deviceCheckConfig` endpoint confirms the macOS <11
+fallback is wired up too.
+
+If you ever need to re-register from scratch (e.g. for a new Firebase
+project), the Console flow is:
 
 1. Open
    https://console.firebase.google.com/project/magic-bracket-simulator/appcheck/apps
-2. Find the macOS app entry (bundle ID
-   `com.tytaniumdev.magicBracketSimulator`). If it isn't listed yet, the
-   parent Firebase app (the iOS-type one registered for `firebase_auth`)
-   doesn't have App Check enabled — click **Register** to enable.
-3. Under **Apple App Attest**, click **Register** and save. No keys or
+2. Find the Apple app entry.
+3. Under **Apple App Attest**, click **Activate** and save. No keys or
    secrets to paste; Firebase coordinates with Apple's attestation
    service directly.
 4. Optionally enable **DeviceCheck** as a fallback for macOS <11 / when
@@ -65,12 +83,22 @@ token requirement. Two acceptable options:
 
 Production app bundles (signed + notarized via the
 `.github/workflows/release-worker.yml` pipeline) work with App Attest
-out of the box once the Firebase Console registration above is done.
+out of the box — the Firebase Console registration is already in place.
 
-## Once registered, monitor before enforcing
+## API enforcement vs. Firebase enforcement
 
-App Check ships in "monitor only" mode on the API side by default. Once
-the macOS app has been live for a release cycle without surfacing
-unexpected 401s in Sentry, you can flip enforcement on in Firebase
-Console → App Check → APIs → Cloud Run (or Cloud Functions, depending
-on where the API runs) → **Enforce**.
+Two different layers control what happens when a request lacks
+`X-Firebase-AppCheck`:
+
+- **API-level (the actual gate today):** `api/lib/auth.ts#verifyAppCheck`
+  throws as soon as the header is missing. There is no "monitor mode"
+  here — the request returns 401 immediately. This is what surfaces as
+  the desktop worker's "Auth token rejected" error.
+- **Firebase service-level (Firestore + Identity Toolkit):** controlled
+  by `enforcementMode` on each service in
+  `projects/14286370379/services/*`. Currently both are `UNENFORCED`,
+  which means direct Firestore client calls (e.g. the run-locally
+  Firestore mirror in `lib/offline/cloud_mirror.dart`) work without an
+  App Check token. Flip these to `ENFORCED` only after every supported
+  platform — including Windows — sends a real token; Windows currently
+  can't, so leaving them `UNENFORCED` is correct.


### PR DESCRIPTION
## Summary

While shipping #301 I verified the Firebase App Check config via `firebaseappcheck.googleapis.com` and confirmed that **App Attest and DeviceCheck are already configured** on the Apple Firebase app entry (`1:14286370379:ios:eb91598352257eef6d7fce`). The setup doc told the user to register them — which would no-op at best, confuse at worst.

Changes:
- Rewrite the "One-time Firebase Console setup" section to "verify-not-register," with a `gcloud` one-liner to confirm.
- Keep the original Console flow as a re-register-from-scratch fallback for new projects.
- Add a new section distinguishing **API-level App Check enforcement** (always on, hard-fails in `verifyAppCheck`) from **Firebase service-level `enforcementMode`** (currently `UNENFORCED` for Firestore + Identity Toolkit — which is intentional, since the Windows worker can't send App Check tokens yet and the run-locally Firestore mirror depends on unenforced direct Firestore writes).

Pure docs change. No code touched.

## Test plan
- [x] Verify the gcloud command in the doc returns a non-empty appAttestConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)