### PR TITLE
feat(a11y): improve web accessibility on Browse, Home, and JobStatus pages

### DIFF
--- a/frontend/src/pages/Browse.tsx
+++ b/frontend/src/pages/Browse.tsx
@@ -118,9 +118,11 @@ export default function Browse() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  const toggleSelectJob = (id: string, e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const toggleSelectJob = (id: string, e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     setSelectedJobs((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -370,77 +372,86 @@ export default function Browse() {
       )}
 
       {!isLoading && !error && visibleJobs.length > 0 && (
-        <div className="space-y-3">
+        <ul className="space-y-3">
           {visibleJobs.map((run) => (
-            <Link
+            <li
               key={run.id}
-              to={`/jobs/${run.id}`}
-              className={`block bg-gray-800 rounded-lg p-4 border transition-colors relative ${
+              className={`relative bg-gray-800 rounded-lg border transition-colors ${
                 selectedJobs.has(run.id)
                   ? 'border-blue-500'
                   : 'border-gray-700 hover:border-gray-600'
-              } ${isAdmin ? 'pl-10' : ''}`}
+              }`}
             >
               {isAdmin && (
-                <input
-                  type="checkbox"
-                  checked={selectedJobs.has(run.id)}
-                  onClick={(e) => toggleSelectJob(run.id, e)}
-                  onChange={() => {}}
-                  className="absolute left-3 top-5 w-4 h-4 accent-blue-500 cursor-pointer"
-                  aria-label={`Select job ${run.name}`}
-                />
-              )}
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <h3 className="font-semibold text-white truncate">
-                      {run.name}
-                    </h3>
-                    <StatusBadge status={run.status} />
-                  </div>
-                  <p className="text-sm text-gray-400 truncate">
-                    {run.deckNames.join(', ')}
-                  </p>
+                <div className="absolute left-3 top-5 z-10">
+                  <input
+                    type="checkbox"
+                    checked={selectedJobs.has(run.id)}
+                    onChange={() => toggleSelectJob(run.id)}
+                    className="w-4 h-4 accent-blue-500 cursor-pointer"
+                    aria-label={`Select job ${run.name}`}
+                  />
                 </div>
-                <div className="text-right flex-shrink-0">
-                  <div className="text-sm font-medium text-gray-300">
-                    {run.status === 'COMPLETED'
-                      ? `${run.simulations} / ${run.simulations} games`
-                      : `${run.gamesCompleted ?? 0} / ${run.simulations} games`}
-                  </div>
-                  {run.durationMs != null && run.durationMs >= 0 && (
-                    <div className="text-xs text-gray-400">
-                      Run time: {formatDurationMs(run.durationMs)}
+              )}
+              <Link
+                to={`/jobs/${run.id}`}
+                className={`block p-4 ${isAdmin ? 'pl-10' : ''}`}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <h3 className="font-semibold text-white truncate">
+                        {run.name}
+                      </h3>
+                      <StatusBadge status={run.status} />
                     </div>
-                  )}
-                  <div className="text-xs text-gray-500">
-                    {formatDate(run.createdAt)}
+                    <p className="text-sm text-gray-400 truncate">
+                      {run.deckNames.join(', ')}
+                    </p>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    <div className="text-sm font-medium text-gray-300">
+                      {run.status === 'COMPLETED'
+                        ? `${run.simulations} / ${run.simulations} games`
+                        : `${run.gamesCompleted ?? 0} / ${run.simulations} games`}
+                    </div>
+                    {run.durationMs != null && run.durationMs >= 0 && (
+                      <div className="text-xs text-gray-400">
+                        Run time: {formatDurationMs(run.durationMs)}
+                      </div>
+                    )}
+                    <div className="text-xs text-gray-500">
+                      {formatDate(run.createdAt)}
+                    </div>
                   </div>
                 </div>
-              </div>
-              {run.status === 'RUNNING' && (
-                <div className="mt-2">
-                  <div
-                    className="w-full bg-gray-700 rounded-full h-1.5 overflow-hidden"
-                    role="progressbar"
-                    aria-valuenow={run.gamesCompleted}
-                    aria-valuemin={0}
-                    aria-valuemax={run.simulations}
-                  >
+                {run.status === 'RUNNING' && (
+                  <div className="mt-2">
                     <div
-                      className="bg-blue-500 h-1.5 rounded-full transition-all duration-300"
-                      style={{
-                        width: `${Math.min(100, (run.gamesCompleted / run.simulations) * 100)}%`,
-                      }}
-                    />
+                      className="w-full bg-gray-700 rounded-full h-1.5 overflow-hidden"
+                      role="progressbar"
+                      aria-valuenow={run.gamesCompleted}
+                      aria-valuemin={0}
+                      aria-valuemax={run.simulations}
+                    >
+                      <div
+                        className="bg-blue-500 h-1.5 rounded-full transition-all duration-300"
+                        style={{
+                          width: `${Math.min(100, (run.gamesCompleted / run.simulations) * 100)}%`,
+                        }}
+                      />
+                    </div>
                   </div>
-                </div>
-              )}
-            </Link>
+                )}
+              </Link>
+            </li>
           ))}
+        </ul>
+      )}
 
-          {/* Load More / end-of-history */}
+      {/* Load More / end-of-history */}
+      {!isLoading && !error && visibleJobs.length > 0 && (
+        <>
           {hasMoreHistory && (
             <div className="pt-2 flex flex-col items-center gap-2">
               <button
@@ -460,7 +471,7 @@ export default function Browse() {
           {!hasMoreHistory && visibleJobs.length >= 100 && (
             <p className="pt-2 text-center text-xs text-gray-500">End of history.</p>
           )}
-        </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -392,6 +392,7 @@ function SimulationForm() {
             value={deckUrl}
             onChange={(e) => setDeckUrl(e.target.value)}
             placeholder="https://moxfield.com/decks/... or https://archidekt.com/decks/..."
+            aria-label="Deck URL"
             className="flex-1 px-4 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           <button
@@ -429,6 +430,7 @@ function SimulationForm() {
                 value={deckName}
                 onChange={(e) => setDeckName(e.target.value)}
                 placeholder="Deck name (optional)"
+                aria-label="Deck name (optional)"
                 className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
             </div>
@@ -437,6 +439,7 @@ function SimulationForm() {
               value={deckText}
               onChange={(e) => setDeckText(e.target.value)}
               placeholder={`Paste your deck list here...\n\nExample:\n1 Sol Ring\n1 Command Tower\n1 Arcane Signet`}
+              aria-label="Deck list text"
               rows={8}
               className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm resize-y"
             />
@@ -502,6 +505,7 @@ function SimulationForm() {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search by name, set, or commander..."
+            aria-label="Search decks"
             className="w-full mb-2 px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
           />
 
@@ -534,70 +538,69 @@ function SimulationForm() {
                 <div className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">
                   Community Decks
                 </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   {communityDecks.map((deck) => (
-                    <div
+                    <li
                       key={deck.id}
-                      role="checkbox"
-                      aria-checked={selectedDeckIds.includes(deck.id)}
-                      tabIndex={0}
-                      className={`flex items-center justify-between p-2 rounded cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
-                        selectedDeckIds.includes(deck.id)
-                          ? 'bg-blue-600/30 border border-blue-500'
-                          : 'bg-gray-600 hover:bg-gray-500 border border-transparent'
+                      className={`flex items-center gap-2 bg-gray-600 rounded border border-transparent hover:bg-gray-500 transition-colors ${
+                        selectedDeckIds.includes(deck.id) ? 'bg-blue-600/30 border-blue-500' : ''
                       }`}
-                      onClick={() => handleDeckToggle(deck.id)}
-                      onKeyDown={(e) => {
-                        if (e.key === ' ' || e.key === 'Enter') {
-                          e.preventDefault();
-                          handleDeckToggle(deck.id);
-                        }
-                      }}
                     >
-                      <div className="flex-1 min-w-0">
-                        <span className="text-sm flex items-center">
-                          <span className="truncate">{deck.name}</span>
-                          <ColorIdentity colorIdentity={deck.colorIdentity} className="ml-1.5" />
-                        </span>
-                        <div className="text-xs text-gray-400 mt-0.5">
-                          {deck.ownerEmail ?? 'unknown'}
-                          {deck.link && (
-                            <>
-                              {' · '}
-                              <a
-                                href={deck.link}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                onClick={(e) => e.stopPropagation()}
-                                className="text-blue-400 hover:underline"
-                              >
-                                View source
-                              </a>
-                            </>
-                          )}
+                      <div
+                        role="checkbox"
+                        aria-checked={selectedDeckIds.includes(deck.id)}
+                        aria-label={`Select deck ${deck.name}`}
+                        tabIndex={0}
+                        onClick={() => handleDeckToggle(deck.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === ' ' || e.key === 'Enter') {
+                            e.preventDefault();
+                            handleDeckToggle(deck.id);
+                          }
+                        }}
+                        className="flex-1 flex items-center p-2 rounded cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 text-white"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <span className="text-sm flex items-center">
+                            <span className="truncate">{deck.name}</span>
+                            <ColorIdentity colorIdentity={deck.colorIdentity} className="ml-1.5" />
+                          </span>
+                          <div className="text-xs text-gray-400 mt-0.5">
+                            {deck.ownerEmail ?? 'unknown'}
+                          </div>
                         </div>
                       </div>
-                      {deck.ownerId === user?.uid && (
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleDeleteDeck(deck);
-                          }}
-                          disabled={isDeleting === deck.id}
-                          aria-label={`Delete deck ${deck.name}`}
-                          className={`ml-2 px-2 py-0.5 rounded text-xs ${
-                            isDeleting === deck.id
-                              ? 'bg-gray-500 text-gray-300 cursor-not-allowed'
-                              : 'bg-red-600/50 text-red-200 hover:bg-red-600'
-                          }`}
-                        >
-                          {isDeleting === deck.id ? '...' : 'X'}
-                        </button>
-                      )}
-                    </div>
+                      <div className="flex items-center gap-1.5 pr-2">
+                        {deck.link && (
+                          <a
+                            href={deck.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-blue-400 hover:underline"
+                            aria-label={`View source for ${deck.name}`}
+                          >
+                            Source
+                          </a>
+                        )}
+                        {deck.ownerId === user?.uid && (
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteDeck(deck)}
+                            disabled={isDeleting === deck.id}
+                            aria-label={`Delete deck ${deck.name}`}
+                            className={`px-2 py-0.5 rounded text-xs ${
+                              isDeleting === deck.id
+                                ? 'bg-gray-500 text-gray-300 cursor-not-allowed'
+                                : 'bg-red-600/50 text-red-200 hover:bg-red-600'
+                            }`}
+                          >
+                            {isDeleting === deck.id ? '...' : 'X'}
+                          </button>
+                        )}
+                      </div>
+                    </li>
                   ))}
-                </div>
+                </ul>
               </div>
             )}
 
@@ -606,52 +609,54 @@ function SimulationForm() {
               <div className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">
                 Preconstructed Decks
               </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 {precons.map((deck) => (
-                  <div
+                  <li
                     key={deck.id}
-                    role="checkbox"
-                    aria-checked={selectedDeckIds.includes(deck.id)}
-                    tabIndex={0}
-                    className={`flex items-center p-2 rounded cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
-                      selectedDeckIds.includes(deck.id)
-                        ? 'bg-blue-600/30 border border-blue-500'
-                        : 'bg-gray-600 hover:bg-gray-500 border border-transparent'
+                    className={`flex items-center gap-2 bg-gray-600 rounded border border-transparent hover:bg-gray-500 transition-colors ${
+                      selectedDeckIds.includes(deck.id) ? 'bg-blue-600/30 border-blue-500' : ''
                     }`}
-                    onClick={() => handleDeckToggle(deck.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === ' ' || e.key === 'Enter') {
-                        e.preventDefault();
-                        handleDeckToggle(deck.id);
-                      }
-                    }}
                   >
-                    <div className="flex-1 min-w-0">
-                      <span className="text-sm flex items-center">
-                        <span className="truncate">{deck.name}</span>
-                        <ColorIdentity colorIdentity={deck.colorIdentity} className="ml-1.5" />
-                      </span>
-                      <div className="text-xs text-gray-400 mt-0.5">
-                        {deck.setName ?? 'precon'}
-                        {deck.link && (
-                          <>
-                            {' · '}
-                            <a
-                              href={deck.link}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              onClick={(e) => e.stopPropagation()}
-                              className="text-blue-400 hover:underline"
-                            >
-                              Archidekt
-                            </a>
-                          </>
-                        )}
+                    <div
+                      role="checkbox"
+                      aria-checked={selectedDeckIds.includes(deck.id)}
+                      aria-label={`Select deck ${deck.name}`}
+                      tabIndex={0}
+                      onClick={() => handleDeckToggle(deck.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === ' ' || e.key === 'Enter') {
+                          e.preventDefault();
+                          handleDeckToggle(deck.id);
+                        }
+                      }}
+                      className="flex-1 flex items-center p-2 rounded cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 text-white"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <span className="text-sm flex items-center">
+                          <span className="truncate">{deck.name}</span>
+                          <ColorIdentity colorIdentity={deck.colorIdentity} className="ml-1.5" />
+                        </span>
+                        <div className="text-xs text-gray-400 mt-0.5">
+                          {deck.setName ?? 'precon'}
+                        </div>
                       </div>
                     </div>
-                  </div>
+                    {deck.link && (
+                      <div className="flex items-center pr-2">
+                        <a
+                          href={deck.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-blue-400 hover:underline"
+                          aria-label={`View Archidekt for ${deck.name}`}
+                        >
+                          Archidekt
+                        </a>
+                      </div>
+                    )}
+                  </li>
                 ))}
-              </div>
+              </ul>
             </div>
             </>
             )}

--- a/frontend/src/pages/JobStatus.tsx
+++ b/frontend/src/pages/JobStatus.tsx
@@ -664,9 +664,11 @@ export default function JobStatusPage() {
 
             {showLogPanel && (
               <div id="log-panel-section" className="mt-4">
-                <div className="flex gap-2 mb-4">
+                <div className="flex gap-2 mb-4" role="tablist" aria-label="Log View Options">
                   <button
                     type="button"
+                    role="tab"
+                    aria-selected={logViewTab === 'condensed'}
                     onClick={() => setLogViewTab('condensed')}
                     className={`px-3 py-1 rounded text-sm ${
                       logViewTab === 'condensed'
@@ -678,6 +680,8 @@ export default function JobStatusPage() {
                   </button>
                   <button
                     type="button"
+                    role="tab"
+                    aria-selected={logViewTab === 'raw'}
                     onClick={() => setLogViewTab('raw')}
                     className={`px-3 py-1 rounded text-sm ${
                       logViewTab === 'raw'


### PR DESCRIPTION
## Summary

Addresses web accessibility (a11y) violations across the three main frontend pages.

### Browse.tsx
- Replaced flat div jobs list with semantic ul/li structure so screen readers can announce item counts
- Extracted admin bulk-delete checkbox out of the Link element into a sibling div — eliminates nested interactive element ARIA violation
- Made toggleSelectJob event arg optional so standalone onChange handler works correctly

### Home.tsx
- Added aria-label to deckUrl, deckName, deckText, and searchQuery inputs
- Replaced div-based community and precon deck grids with semantic ul/li elements
- Separated role=checkbox interactive region from View Source and Delete controls into siblings inside each li — eliminates nested interactive controls violation

### JobStatus.tsx
- Added role=tablist / role=tab / aria-selected on the Condensed / Raw log switcher tabs for proper ARIA tab semantics

### Verification
- ./scripts/build.sh ✅ all packages compile clean
- cd frontend && npm test -- --run ✅ 94/94 tests pass