### PR TITLE
docs: refresh API.md and PRD.md to reflect shipped system

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,10 +3,15 @@
 This document describes the REST API for the Magic Bracket Simulator.
 
 **Base URL:** `/api`
+
 **Authentication:**
 
-- Most endpoints are public or use Firebase Auth (Bearer Token).
-- Worker endpoints use `X-Worker-Secret` header or `Authorization: Bearer <token>` if configured.
+- Public endpoints require no auth.
+- User endpoints require Firebase Auth: `Authorization: Bearer <firebase-id-token>`
+- Worker endpoints require `X-Worker-Secret: <secret>` header.
+- Admin endpoints require Firebase Auth **and** admin role on the account.
+
+---
 
 ## Jobs
 
@@ -14,7 +19,11 @@ This document describes the REST API for the Magic Bracket Simulator.
 
 `GET /jobs`
 
-Returns a list of recent jobs with summary information.
+Returns paginated recent jobs. Supports `limit` and `cursor` query parameters.
+
+**Query Parameters:**
+- `limit` (optional, default 100, max 100): number of jobs to return
+- `cursor` (optional): base64-encoded pagination cursor from a previous response
 
 **Response:**
 
@@ -22,19 +31,21 @@ Returns a list of recent jobs with summary information.
 {
   "jobs": [
     {
-      "id": "job-id",
+      "id": "job-uuid",
       "name": "Deck A vs Deck B vs Deck C vs Deck D",
       "deckNames": ["Deck A", "Deck B", "Deck C", "Deck D"],
       "status": "COMPLETED",
       "simulations": 100,
       "gamesCompleted": 100,
-      "createdAt": "2023-10-27T10:00:00.000Z",
-      "hasResult": true,
+      "createdAt": "2024-01-15T10:00:00.000Z",
       "durationMs": 120000,
       "parallelism": 4,
-      "resultJson": { ... }
+      "startedAt": "2024-01-15T10:00:01.000Z",
+      "completedAt": "2024-01-15T10:02:01.000Z",
+      "dockerRunDurationsMs": [60000, 60000]
     }
-  ]
+  ],
+  "nextCursor": "base64-cursor-or-null"
 }
 ```
 
@@ -42,7 +53,7 @@ Returns a list of recent jobs with summary information.
 
 `POST /jobs`
 
-Creates a new simulation job. Requires authentication (Firebase Auth).
+Creates a new simulation job. Requires user auth.
 
 **Body:**
 
@@ -50,7 +61,6 @@ Creates a new simulation job. Requires authentication (Firebase Auth).
 {
   "deckIds": ["id1", "id2", "id3", "id4"],
   "simulations": 100,
-  "parallelism": 4,
   "idempotencyKey": "optional-uuid"
 }
 ```
@@ -59,7 +69,7 @@ Creates a new simulation job. Requires authentication (Firebase Auth).
 
 ```json
 {
-  "id": "new-job-id",
+  "id": "new-job-uuid",
   "deckNames": ["Deck A", "Deck B", "Deck C", "Deck D"]
 }
 ```
@@ -74,88 +84,74 @@ Returns detailed information about a specific job.
 
 ```json
 {
-  "id": "job-id",
+  "id": "job-uuid",
   "status": "RUNNING",
   "simulations": 100,
   "gamesCompleted": 50,
-  "decks": [ ... ],
-  "workerId": "worker-123",
-  "workerName": "MyWorker",
+  "deckNames": ["Deck A", "Deck B", "Deck C", "Deck D"],
+  "deckIds": ["id1", "id2", "id3", "id4"],
+  "deckLinks": ["https://...", null, "https://...", null],
   "errorMessage": null,
-  "resultJson": null
+  "retryCount": 0,
+  "queuePosition": 0,
+  "workers": { "online": 2, "idle": 1, "updating": 0 },
+  "createdAt": "2024-01-15T10:00:00.000Z",
+  "startedAt": "2024-01-15T10:00:01.000Z",
+  "completedAt": null,
+  "durationMs": null,
+  "dockerRunDurationsMs": null
 }
 ```
-
-### Stream Job Updates (SSE)
-
-`GET /jobs/:id/stream`
-
-Server-Sent Events stream for real-time job updates.
-
-**Events:**
-
-- `data`: Job status update (JSON)
-- `event: simulations`: List of simulation statuses (JSON)
-
-### Claim Next Simulation (Worker)
-
-`GET /jobs/claim-sim`
-
-Used by the worker to atomically claim the next PENDING simulation.
-Accepts `workerId` and `workerName` as query parameters.
-**Auth:** `X-Worker-Secret` header required.
-
-**Response:**
-
-- `200 OK`: JSON object with `jobId`, `simId`, and `simIndex`.
-- `204 No Content`: No simulations available.
 
 ### Cancel Job
 
 `POST /jobs/:id/cancel`
 
-Cancels a QUEUED or RUNNING job.
-**Auth:** Firebase Auth required.
+Cancels a QUEUED or RUNNING job. Requires user auth (must be owner or admin).
 
 **Response:**
 
 ```json
-{
-  "id": "job-id",
-  "status": "CANCELLED"
-}
+{ "id": "job-uuid", "status": "CANCELLED" }
 ```
 
 ### Recover Job
 
 `POST /jobs/:id/recover`
 
-One-shot recovery check for a stuck job. Called by Cloud Tasks after a scheduled delay.
-**Auth:** `X-Worker-Secret` header required.
+One-shot recovery check for a stuck job (called by Cloud Tasks after a delay).
+**Auth:** Worker auth required.
 
 **Response:**
 
 ```json
-{
-  "status": "ok",
-  "recovered": true,
-  "stillActive": false
-}
+{ "status": "ok", "recovered": true, "stillActive": false }
+```
+
+### Aggregate If Done
+
+`POST /jobs/:id/aggregate-if-done`
+
+Triggers aggregation of simulation results if the job is complete. Called by workers.
+**Auth:** Worker auth required.
+
+**Response:**
+
+```json
+{ "ok": true, "aggregated": true }
 ```
 
 ### Bulk Delete Jobs
 
 `POST /jobs/bulk-delete`
 
-Bulk deletes jobs and their associated artifacts (max 50 per request).
+Deletes multiple jobs (max 50) and their artifacts.
 **Auth:** Admin access required.
 
 **Body:**
 
 ```json
-{
-  "jobIds": ["job-1", "job-2"]
-}
+{ "jobIds": ["job-1", "job-2"] }
 ```
 
 **Response:**
@@ -164,17 +160,34 @@ Bulk deletes jobs and their associated artifacts (max 50 per request).
 {
   "deletedCount": 2,
   "results": [
-    {
-      "id": "job-1",
-      "deleted": true
-    },
-    {
-      "id": "job-2",
-      "deleted": true
-    }
+    { "id": "job-1", "deleted": true },
+    { "id": "job-2", "deleted": true }
   ]
 }
 ```
+
+### Claim Next Simulation (Worker)
+
+`POST /jobs/claim-sim`
+
+Atomically claims the next PENDING simulation for a worker.
+**Auth:** Worker auth required.
+
+**Body:**
+
+```json
+{
+  "workerId": "worker-1",
+  "workerName": "MyWorker"
+}
+```
+
+**Response:**
+
+- `200 OK`: `{ "jobId": "...", "simId": "sim_000", "simIndex": 0 }`
+- `204 No Content`: No simulations available.
+
+---
 
 ## Simulations
 
@@ -182,7 +195,7 @@ Bulk deletes jobs and their associated artifacts (max 50 per request).
 
 `GET /jobs/:id/simulations`
 
-Returns the status of all individual simulations for a job.
+Returns status of all individual simulations for a job.
 
 **Response:**
 
@@ -194,6 +207,7 @@ Returns the status of all individual simulations for a job.
       "index": 0,
       "state": "COMPLETED",
       "workerId": "worker-1",
+      "workerName": "MyWorker",
       "durationMs": 45000,
       "winner": "Deck A",
       "winningTurn": 8
@@ -212,9 +226,7 @@ Initializes simulation tracking for a job.
 **Body:**
 
 ```json
-{
-  "count": 25
-}
+{ "count": 25 }
 ```
 
 ### Update Simulation Status (Worker)
@@ -228,7 +240,7 @@ Updates the status of a single simulation.
 
 ```json
 {
-  "state": "COMPLETED", // PENDING, RUNNING, COMPLETED, FAILED, CANCELLED
+  "state": "COMPLETED",
   "workerId": "worker-1",
   "workerName": "MyWorker",
   "durationMs": 45000,
@@ -237,6 +249,18 @@ Updates the status of a single simulation.
   "winningTurn": 8
 }
 ```
+
+Valid `state` values: `PENDING`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`
+
+---
+
+## Logs
+
+### Get Combined Logs
+
+`GET /jobs/:id/logs`
+
+Returns all logs for a job (raw and/or structured).
 
 ### Upload Simulation Log (Worker)
 
@@ -254,13 +278,155 @@ Uploads the raw log for a completed simulation.
 }
 ```
 
+### Get Raw Logs
+
+`GET /jobs/:id/logs/raw`
+
+Returns raw (unprocessed) game logs for a job.
+
+### Get Condensed Logs
+
+`GET /jobs/:id/logs/condensed`
+
+Returns condensed AI-input logs (processed summary of each game).
+
+### Get Structured Logs
+
+`GET /jobs/:id/logs/structured`
+
+Returns fully parsed, structured game-action logs (deck × turn granularity).
+
+---
+
+## Decks
+
+### List Decks
+
+`GET /decks`
+
+Lists all decks (precons and user-submitted). No auth required.
+
+**Response:**
+
+```json
+{
+  "decks": [
+    {
+      "id": "deck-uuid",
+      "name": "Deck Name",
+      "primaryCommander": "Commander Name",
+      "colorIdentity": ["W", "U"],
+      "isPrecon": false,
+      "link": "https://moxfield.com/...",
+      "setName": null,
+      "ownerId": "user-uid",
+      "ownerEmail": "user@example.com"
+    }
+  ]
+}
+```
+
+### Create Deck
+
+`POST /decks/create`
+
+Creates a new deck from a URL (Moxfield, Archidekt, ManaBox) or raw deck-list text.
+**Auth:** User auth required.
+
+**Validation:** `deckUrl` and `deckLink` must be valid `http:` or `https:` URLs to prevent SSRF.
+
+**Body (URL import):**
+
+```json
+{ "deckUrl": "https://moxfield.com/decks/..." }
+```
+
+**Body (manual paste):**
+
+```json
+{
+  "deckText": "1 Sol Ring\n1 Command Tower...",
+  "deckName": "My Custom Deck",
+  "deckLink": "https://moxfield.com/decks/..."
+}
+```
+
+**Response:**
+
+```json
+{ "id": "deck-uuid", "name": "My Custom Deck" }
+```
+
+### Get Deck
+
+`GET /decks/:id`
+
+Returns metadata for a specific deck. No auth required.
+
+### Get Deck Content
+
+`GET /decks/:id/content`
+
+Returns the raw `.dck` text for a deck. Used by workers to download deck content.
+**Auth:** Worker auth required.
+
+**Response:**
+
+```json
+{ "name": "My Deck", "dck": "1 Sol Ring\n..." }
+```
+
+### Delete Deck
+
+`DELETE /decks/:id`
+
+Deletes a deck. Must be the owner or admin.
+**Auth:** User auth required.
+
+**Response:** `204 No Content`
+
+### Get Deck Color Identity
+
+`GET /deck-color-identity`
+
+Returns color identity for one or more decks by name.
+
+---
+
+## Leaderboard
+
+### Get Leaderboard
+
+`GET /leaderboard`
+
+Returns deck win-rate leaderboard across all completed simulations.
+
+**Response:**
+
+```json
+{
+  "leaderboard": [
+    {
+      "deckId": "deck-uuid",
+      "deckName": "Deck Name",
+      "wins": 42,
+      "losses": 58,
+      "winRate": 0.42,
+      "avgWinTurn": 9.5
+    }
+  ]
+}
+```
+
+---
+
 ## Workers
 
 ### List Workers
 
 `GET /workers`
 
-Lists all active workers and the current queue depth.
+Lists all active workers and current queue depth.
 **Auth:** Firebase Auth required.
 
 **Response:**
@@ -275,43 +441,48 @@ Lists all active workers and the current queue depth.
       "capacity": 8,
       "activeSimulations": 4,
       "uptimeMs": 3600000,
-      "lastHeartbeat": "2023-10-27T10:00:00.000Z"
+      "lastHeartbeat": "2024-01-15T10:00:00.000Z",
+      "ownerEmail": "admin@example.com"
     }
   ],
   "queueDepth": 5
 }
 ```
 
+### Get Worker Health
+
+`GET /health/workers`
+
+Returns a lightweight check on worker pool health (no auth required).
+
 ### Update Worker Config
 
 `PATCH /workers/:id`
 
-Updates per-worker configuration. Only the worker's owner can modify its configuration.
-**Auth:** Firebase Auth required.
+Updates per-worker configuration (e.g. concurrency override).
+**Auth:** Firebase Auth required (must be owner or admin).
 
 **Body:**
 
 ```json
-{
-  "maxConcurrentOverride": 4 // null to clear override
-}
+{ "maxConcurrentOverride": 4 }
 ```
+
+Pass `null` to clear the override.
 
 **Response:**
 
 ```json
-{
-  "ok": true,
-  "maxConcurrentOverride": 4,
-  "pushResult": "success" // 'success', 'failed', or 'no_url'
-}
+{ "ok": true, "maxConcurrentOverride": 4, "pushResult": "success" }
 ```
+
+`pushResult` is one of `"success"`, `"failed"`, or `"no_url"`.
 
 ### Worker Heartbeat
 
 `POST /workers/heartbeat`
 
-Reports worker status and retrieves dynamic configuration overrides.
+Reports worker liveness and retrieves configuration overrides.
 **Auth:** Worker auth required.
 
 **Body:**
@@ -320,7 +491,7 @@ Reports worker status and retrieves dynamic configuration overrides.
 {
   "workerId": "worker-1",
   "workerName": "MyWorker",
-  "status": "busy", // idle, busy, updating
+  "status": "busy",
   "capacity": 8,
   "activeSimulations": 4,
   "uptimeMs": 3600000,
@@ -331,11 +502,10 @@ Reports worker status and retrieves dynamic configuration overrides.
 **Response:**
 
 ```json
-{
-  "ok": true,
-  "maxConcurrentOverride": 4 // Optional override from admin
-}
+{ "ok": true, "maxConcurrentOverride": null }
 ```
+
+---
 
 ## Worker Setup
 
@@ -343,16 +513,16 @@ Reports worker status and retrieves dynamic configuration overrides.
 
 `POST /worker-setup/token`
 
-Generates a time-limited setup token for bootstrapping a remote worker.
+Generates a time-limited token for bootstrapping a new worker.
 **Auth:** Firebase Auth required.
 
 **Response:**
 
 ```json
 {
-  "token": "base64-encoded-token",
+  "token": "base64-setup-token",
   "expiresIn": "24 hours",
-  "apiUrl": "https://api...",
+  "apiUrl": "https://api.example.com",
   "scriptUrl": "https://raw.githubusercontent.com/..."
 }
 ```
@@ -361,9 +531,9 @@ Generates a time-limited setup token for bootstrapping a remote worker.
 
 `POST /worker-setup/config`
 
-Returns AES-256-GCM encrypted worker configuration.
-**Auth:** Validates `X-Setup-Token` header.
-**Headers:** Requires `X-Encryption-Key` header with 64-char hex string.
+Returns AES-256-GCM encrypted worker config (secrets, API URL, worker secret).
+**Auth:** `X-Setup-Token` header required.
+**Headers:** `X-Encryption-Key` (64-char hex string).
 
 **Response:**
 
@@ -375,49 +545,101 @@ Returns AES-256-GCM encrypted worker configuration.
 }
 ```
 
-## System
+---
 
-### Health Check
+## Coverage (Internal / Admin)
 
-`GET /health`
+These endpoints support the automated coverage-testing system that ensures all precon matchups are simulated.
 
-Unauthenticated system health check. Evaluates stuck jobs, leaderboard ratings, and worker connectivity.
-**Auth:** None required.
+### Get Coverage Config
+
+`GET /coverage/config`
+
+Returns coverage configuration (enabled, target matchups, etc.).
+**Auth:** Admin access required.
+
+### Get Next Coverage Job
+
+`GET /coverage/next-job`
+
+Returns the next uncovered matchup to simulate.
+**Auth:** Admin access required.
+
+### Get Coverage Status
+
+`GET /coverage/status`
+
+Returns overall coverage progress (% of matchups completed).
+**Auth:** Admin access required.
+
+---
+
+## Access Requests
+
+### Submit Access Request
+
+`POST /access-requests`
+
+Submits a user's request to be granted submission access.
+**Auth:** Firebase Auth required.
+
+### Approve Access Request
+
+`POST /access-requests/approve`
+
+Approves a pending access request.
+**Auth:** Admin access required.
+
+---
+
+## User
+
+### Get Current User
+
+`GET /me`
+
+Returns the current authenticated user's profile and permissions.
+**Auth:** Firebase Auth required.
 
 **Response:**
 
 ```json
 {
-  "status": "ok",
-  "checks": {
-    "stuckJobs": { "ok": true, "detail": "0 active job(s), none stuck" },
-    "ratings": { "ok": true, "detail": "Leaderboard has entries" },
-    "worker": { "ok": true, "detail": "1 active worker(s)" }
-  }
+  "uid": "user-uid",
+  "email": "user@example.com",
+  "isAdmin": false,
+  "isAllowed": true
 }
 ```
 
-### Broadcast Pull Image
+### Moxfield Import Status
 
-`POST /admin/pull-image`
+`GET /moxfield-status`
 
-Broadcasts a `pull-image` command to all active workers.
-**Auth:** `X-Worker-Secret` header required.
+Returns whether the server-side Moxfield API import is currently enabled.
 
 **Response:**
 
 ```json
-{
-  "ok": true,
-  "message": "Pull-image broadcast sent"
-}
+{ "enabled": true }
 ```
+
+---
+
+## Admin
+
+### Backfill Ratings
+
+`POST /admin/backfill-ratings`
+
+Rebuilds deck Elo/rating data from scratch across all match results.
+**Auth:** Admin access required.
 
 ### Backfill Win Turns
 
 `POST /admin/backfill-win-turns`
 
-Rebuilds `winTurnSum`, `winTurnWins`, and `winTurnHistogram` for every deck from the match results store.
+Rebuilds `winTurnSum`, `winTurnWins`, and `winTurnHistogram` for all decks.
 **Auth:** Admin access required.
 
 **Response:**
@@ -431,86 +653,59 @@ Rebuilds `winTurnSum`, `winTurnWins`, and `winTurnHistogram` for every deck from
 }
 ```
 
-## Decks
+### Broadcast Pull Image
 
-### List Decks
+`POST /admin/pull-image`
 
-`GET /decks`
+Broadcasts a `pull-image` command to all active workers so they update their Docker image.
+**Auth:** Worker auth required.
 
-Lists all decks (precons and user submissions).
+**Response:**
+
+```json
+{ "ok": true, "message": "Pull-image broadcast sent" }
+```
+
+### Sweep Leases
+
+`POST /admin/sweep-leases`
+
+Releases stale worker simulation leases that have exceeded their timeout.
+**Auth:** Admin access required.
+
+### Sweep Stale Jobs
+
+`POST /admin/sweep-stale-jobs`
+
+Marks jobs FAILED if they have been stuck in RUNNING/QUEUED beyond a timeout threshold.
+**Auth:** Admin access required.
+
+### Sync Precons
+
+`POST /sync/precons`
+
+Triggers a re-sync of the preconstructed deck library from the source data.
+**Auth:** Admin access required.
+
+---
+
+## System
+
+### Health Check
+
+`GET /health`
+
+Unauthenticated system health check. Evaluates stuck jobs, leaderboard ratings, and worker connectivity.
 
 **Response:**
 
 ```json
 {
-  "decks": [
-    {
-      "id": "deck-id",
-      "name": "Deck Name",
-      "primaryCommander": "Commander Name",
-      "colorIdentity": ["W", "U"],
-      "isPrecon": false,
-      "link": "https://moxfield.com/..."
-    }
-  ]
+  "status": "ok",
+  "checks": {
+    "stuckJobs": { "ok": true, "detail": "0 active job(s), none stuck" },
+    "ratings": { "ok": true, "detail": "Leaderboard has entries" },
+    "worker": { "ok": true, "detail": "1 active worker(s)" }
+  }
 }
 ```
-
-### Create Deck
-
-`POST /decks`
-
-Creates a new deck from a URL (Moxfield, Archidekt, ManaBox) or raw text.
-**Validation:** Deck links (`deckUrl` or `deckLink`) must be valid, well-formed URLs with `http:` or `https:` protocols. Malformed or non-HTTP URLs will be rejected with a `400 Bad Request` to prevent Server-Side Request Forgery (SSRF) and protocol injection.
-**Auth:** User auth required.
-
-**Body:**
-
-```json
-{
-  "deckUrl": "https://moxfield.com/..."
-}
-```
-
-OR
-
-```json
-{
-  "deckText": "1 Sol Ring\n1 Command Tower...",
-  "deckName": "My Custom Deck",
-  "deckLink": "Optional Link"
-}
-```
-
-### Get Deck Content
-
-`GET /decks/:id/content`
-
-Gets the raw deck content (`name` and `dck` text) for a specific deck.
-**Auth:** `X-Worker-Secret` header required.
-
-**Response:**
-
-```json
-{
-  "name": "My Deck",
-  "dck": "1 Sol Ring\n..."
-}
-```
-
-### Delete Deck
-
-`DELETE /decks/:id`
-
-Deletes a deck.
-**Auth:** User auth required. User must be the owner of the deck.
-
-**Response:**
-
-- `204 No Content`: Deck deleted successfully
-
-### List Precons
-
-`GET /precons`
-
-Legacy endpoint to list precon decks. Use `GET /decks` with client-side filtering instead.

--- a/api/PRD.md
+++ b/api/PRD.md
@@ -1,71 +1,149 @@
-# Product Requirement Document: API Service
+# Product Requirements Document: API Service
+
+_Last updated: May 2025 — reflects the shipped system, not a future plan._
 
 ## 1. Overview
-The **API Service** is the user-facing "brain" of the application. It handles deck ingestion from external sites (Moxfield/Archidekt/ManaBox), manages the queue of simulation jobs, and displays the final results.
 
-## 2. Goals
--   **Easy Onboarding**: Users need a deck URL (Moxfield, Archidekt, or ManaBox) to add decks.
--   **Async Processing**: UI should not hang while 5-10 minute simulations run.
--   **Scalability**: Manage multiple simulation requests without crashing the single Forge instance (Queue system).
+The **API Service** is the backend of the Magic Bracket Simulator. It handles:
 
-## 3. Specifications
+- **Deck ingestion** from Moxfield, Archidekt, and ManaBox (URL import and manual text paste).
+- **Job lifecycle management** — creating, queuing, tracking, and cancelling simulation jobs.
+- **Worker coordination** — handing out simulation work, receiving results, and managing heartbeats.
+- **Results storage and aggregation** — structured logs, win tallies, Elo-style ratings, and a leaderboard.
+- **Auth and access control** — Firebase Authentication for user-facing endpoints; HMAC-signed Worker Secret for internal worker communication.
 
-### 3.1 Tech Stack (Unified)
--   **Framework**: **Next.js 14+ (App Router)**. This handles both the Frontend UI and the API/Backend logic.
--   **Database**: PostgreSQL (via Prisma or Drizzle) or SQLite (for local dev).
--   **Queue**: `bullmq` (Redis) or a simple DB-based poller if Redis is overkill. *Recommendation: Start with DB-polling for simplicity, upgrade to Redis if scale is needed.*
+---
 
-### 3.2 Feature Specifications
+## 2. Architecture
 
-#### A. Frontend UI
--   **Input Form**:
-    -   `Deck URL` (validated for moxfield.com / archidekt.com / manabox.app only).
-    -   `Opponent Selector`: Dropdown of "Random Precons" or "Specific Precons" (served from a static list).
-    -   `Simulations`: Slider (1-10).
--   **Status Dashboard**:
-    -   Real-time polling of Job Status.
-    -   Visual progress bar ("Game 2 of 5").
-    -   **Results View**: Display the Analysis JSON (Bracket, Confidence, Reasoning) and simple stats (Win Rate).
+| Layer          | Technology                                                         |
+| -------------- | ------------------------------------------------------------------ |
+| Framework      | **Next.js 15 (App Router)** — serves both frontend and API routes |
+| Database       | **SQLite** (local dev) · **Firestore** (GCP production)           |
+| Storage        | **Local filesystem** (dev) · **Google Cloud Storage** (GCP prod)  |
+| Auth           | **Firebase Authentication** (Google sign-in)                      |
+| Worker auth    | `X-Worker-Secret` HMAC-signed header                              |
+| Job dispatch   | **Polling** (workers claim simulations via `POST /api/jobs/claim-sim`) |
+| Concurrency    | Per-job parallelism — each job is split into `N` independent simulations claimed by workers |
 
-#### B. Backend Services (Next.js API Routes / Server Actions)
--   **Deck Ingestion**:
-    -   Service to fetch metadata from Moxfield/Archidekt APIs and ManaBox deck pages.
-    -   `Converter`: Logic to transform imports into `.dck` format.
--   **Job Lifecycle & Data Model**:
-    -   **Job Table**:
-        -   `id`: UUID
-        -   `deck_name`: String
-        -   `deck_dck`: Text (blob)
-        -   `status`: ENUM (QUEUED, RUNNING, ANALYZING, COMPLETED, FAILED)
-        -   `result_json`: JSON (nullable)
-        -   `created_at`: Date
--   **Worker Logic (Background Process)**:
-    -   Can be a separate Node.js script `worker.js` that connects to the DB.
-    -   **Loop**:
-        1.  Find `PENDING` Job.
-        2.  Mark `RUNNING`.
-        3.  Spawn Docker: `docker run -v ... forge-sim ...`
-        4.  Wait for exit.
-        5.  Read Logs from volume.
-        6.  Send Logs to **Analysis Service** API.
-        7.  Save Response to `result_json`.
-        8.  Mark `COMPLETED`.
+---
 
-### 3.3 Opponent Selection Logic
--   The API maintains a list of the 50 predefined precons (matching the Forge Engine's internal list).
--   **Randomizer**: Randomly selects 3 unique names from this list to pass to the Docker container.
+## 3. Core Concepts
 
-## 4. Key Workflows
-1.  **User submits URL**.
-2.  **Next.js Backend** fetches deck, creates `Job` record (Status: QUEUED).
-3.  **Worker** picks up Job.
-4.  **Worker** executes `docker run` with volume mounts for the deck file.
-5.  **Worker** gathers logs, calls Analysis Service `POST /analyze`.
-6.  **Worker** updates DB.
-7.  **Frontend** polls DB and shows "Bracket 4: Optimized" to user.
+### 3.1 Jobs
 
-## 5. Work Plan
-1.  **Scaffold**: Create Next.js App with matching DB schema.
-2.  **Ingestion**: Implement Moxfield/Archidekt/ManaBox scrapers.
-3.  **Worker**: Build the `worker.js` process to handle Docker spawning.
-4.  **Integration**: connect Worker -> Forge (Docker) -> Analysis (API).
+A **Job** represents one bracket simulation request: 4 decks, N games, optionally split across multiple worker processes.
+
+| Field          | Description                                                     |
+| -------------- | --------------------------------------------------------------- |
+| `id`           | UUID                                                            |
+| `deckIds`      | Array of 4 deck IDs                                             |
+| `simulations`  | Total number of games to simulate                               |
+| `status`       | `QUEUED` → `RUNNING` → `COMPLETED` \| `FAILED` \| `CANCELLED`  |
+| `parallelism`  | How many worker containers run in parallel for this job         |
+| `gamesCompleted` | Running count of finished games                               |
+| `retryCount`   | Number of times the job has been re-queued after a failure      |
+| `errorMessage` | Set on `FAILED`                                                 |
+
+### 3.2 Simulations
+
+Each Job is divided into **Simulations** (sub-units of work). Each simulation is a fixed batch of games (currently `GAMES_PER_CONTAINER` = 25). Workers atomically claim one simulation at a time via `POST /api/jobs/claim-sim`.
+
+| State     | Meaning                                 |
+| --------- | --------------------------------------- |
+| `PENDING` | Not yet started                         |
+| `RUNNING` | Claimed by a worker                     |
+| `COMPLETED` | Finished successfully                 |
+| `FAILED`  | Worker reported an error                |
+| `CANCELLED` | Parent job was cancelled              |
+
+### 3.3 Workers
+
+Workers are long-running Node.js processes that communicate with the API via HTTP. They:
+
+1. Send a heartbeat (`POST /api/workers/heartbeat`) every 30s.
+2. Poll for available simulations (`POST /api/jobs/claim-sim`).
+3. Spawn a Docker container with the Forge simulation engine.
+4. Upload results via `PATCH /api/jobs/:id/simulations/:simId` and `POST /api/jobs/:id/logs/simulation`.
+5. Trigger aggregation when done (`POST /api/jobs/:id/aggregate-if-done`).
+
+### 3.4 Decks
+
+Decks are stored centrally and reused across jobs. They come in two forms:
+
+- **Precons** — official Commander preconstructed decks, loaded from a static JSON file served via GCS.
+- **Community decks** — user-submitted decks stored in the database.
+
+Decks are stored in `.dck` format (MTGO deck list syntax), which the Forge engine reads directly.
+
+---
+
+## 4. Feature Specifications
+
+### 4.1 Deck Ingestion
+
+- **Moxfield** — direct API fetch when available, fallback to manual paste export (MTGO format).
+- **Archidekt** — direct URL import via Archidekt API.
+- **ManaBox** — direct URL import via ManaBox share link.
+- **Text paste** — user can paste a raw MTGO deck list directly.
+
+All `deckUrl` and `deckLink` values are validated as well-formed `http:` or `https:` URLs to prevent SSRF.
+
+### 4.2 Job Lifecycle
+
+```
+POST /api/jobs
+  → Job created with status QUEUED
+  → Simulations initialized (N = ceil(simulations / GAMES_PER_CONTAINER))
+  → Workers poll claim-sim and start claiming
+  → Each worker runs Docker container, uploads logs
+  → aggregate-if-done checks if all sims finished
+  → Job marked COMPLETED / FAILED
+```
+
+### 4.3 Authentication Model
+
+| Endpoint type      | Auth required                                  |
+| ------------------ | ---------------------------------------------- |
+| Read-only public   | None                                           |
+| User writes        | Firebase Auth Bearer token                     |
+| Worker internal    | `X-Worker-Secret` header                       |
+| Admin              | Firebase Auth + admin flag in user record      |
+
+### 4.4 Coverage Testing
+
+An automated system tracks which precon × precon matchups have been simulated. Admins can query coverage status and the system can auto-schedule uncovered matchups.
+
+---
+
+## 5. API Surface
+
+See [API.md](../API.md) for full endpoint documentation.
+
+**Endpoint count:** 41 route handlers across Jobs, Simulations, Logs, Decks, Workers, Leaderboard, Coverage, Access Requests, and System endpoints.
+
+---
+
+## 6. Data Storage
+
+### Local (SQLite)
+
+All data stored in a local SQLite database at `api/data/database.db`.
+
+### GCP (Firestore + GCS)
+
+- **Firestore**: job documents with real-time updates (`onSnapshot`).
+- **GCS**: raw game logs, condensed logs, structured logs, and precon deck JSON.
+
+Environment is determined by the `GCP_MODE` env var (`true` = GCP, `false`/absent = local SQLite).
+
+---
+
+## 7. Deployment
+
+| Environment | Method                                                |
+| ----------- | ----------------------------------------------------- |
+| Local dev   | `npm run dev` in `api/`                              |
+| Production  | Google Cloud Run (auto-scaled), deployed via GitHub Actions |
+
+See `AGENTS.md` for the full build and test workflow.


### PR DESCRIPTION
## Summary

Both docs were significantly out of date with the actual codebase.

### API.md
- Now documents all **41 actual route handlers** (was missing ~18 endpoints)
- New sections: Coverage, Leaderboard, Access Requests, `/me`, Moxfield Status, Deck Color Identity, `aggregate-if-done`, `sweep-leases`, `sweep-stale-jobs`, `sync/precons`, `health/workers`
- Fixed: deck create path was `/decks` (wrong) → `/decks/create` (correct)
- Fixed: `GET /jobs` now documents cursor-based pagination and correct response shape
- Fixed: `POST /jobs/claim-sim` was documented as GET, is actually POST
- Removed: phantom `GET /precons` endpoint (does not exist in code)
- Improved auth documentation per-endpoint
- Added PATCH /workers/:id response shape

### api/PRD.md
- Rewrote from scratch to reflect the **shipped system**, not the 2023 planning document
- Correctly documents: Next.js 15, SQLite (local) / Firestore+GCS (GCP), Firebase Auth
- Explains the job → simulation → worker concurrency model
- Removes stale references to bullmq, Redis, Prisma, `ANALYZING` status
- Adds coverage testing system, auth model comparison table, and deployment section