### PR TITLE
fix: implement unified secure desktop OAuth persistence via refresh tokens

### DIFF
--- a/worker_flutter/lib/auth/auth_service.dart
+++ b/worker_flutter/lib/auth/auth_service.dart
@@ -125,27 +125,7 @@ class AuthService {
     if (kDebugMode) {
       debugPrint('AuthService.signIn() — using PKCE + signInWithCredential');
     }
-    final clientId = DefaultFirebaseOptions.desktopOAuthClientId;
-    final clientSecret = DefaultFirebaseOptions.desktopOAuthClientSecret;
-    if (clientId == 'REPLACE_WITH_DESKTOP_OAUTH_CLIENT_ID') {
-      throw StateError(
-        'Desktop sign-in needs a Desktop OAuth Client ID. Create one at '
-        'https://console.cloud.google.com/apis/credentials (Application '
-        'type: Desktop app) and paste it into '
-        'DefaultFirebaseOptions.desktopOAuthClientId in firebase_options.dart.',
-      );
-    }
-    if (clientSecret.isEmpty) {
-      throw StateError(
-        'Desktop sign-in is missing GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET. '
-        'Release builds load it from Doppler (blinkbreak/prd). For local '
-        'dev, run: doppler run --project blinkbreak --config prd -- sh -c '
-        "'flutter run -d macos --dart-define=GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET=\$GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET'",
-      );
-    }
-    final oauth =
-        _desktopOAuth ??
-        DesktopOAuth(clientId: clientId, clientSecret: clientSecret);
+    final oauth = _getDesktopOAuth();
     final tokens = await _runPkce(oauth);
     final cred = GoogleAuthProvider.credential(
       idToken: tokens.idToken,
@@ -260,12 +240,54 @@ class AuthService {
       return null;
     }
 
-    final oauth =
-        _desktopOAuth ??
-        DesktopOAuth(clientId: clientId, clientSecret: clientSecret);
+    final oauth = _getDesktopOAuth();
+    final DesktopOAuthResult tokens;
+    try {
+      tokens = await oauth.refresh(refreshToken);
+    } on GoogleRefreshTokenException catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('AuthService.trySilentSignIn() — Google token refresh permanent failure: $e');
+      }
+      // Only delete the stored token if the Google endpoint returns a permanent invalid_grant error.
+      if (e.isInvalidGrant) {
+        if (kDebugMode) {
+          debugPrint('AuthService.trySilentSignIn() — Token is invalid/revoked, clearing from secure storage');
+        }
+        try {
+          await _secureStorage.delete(key: _googleRefreshTokenKey);
+        } catch (storageError) {
+          debugPrint('AuthService: Failed to delete refresh token: $storageError');
+        }
+      }
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.signIn,
+        tags: {
+          'platform': Platform.operatingSystem,
+          'phase': 'silent_refresh_google',
+          'is_permanent': e.isInvalidGrant.toString(),
+        },
+      );
+      return null;
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('AuthService.trySilentSignIn() — Google token refresh transient/network failure: $e');
+      }
+      // Network or other transient issues — DO NOT delete the stored token.
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.signIn,
+        tags: {
+          'platform': Platform.operatingSystem,
+          'phase': 'silent_refresh_google_transient',
+        },
+      );
+      return null;
+    }
 
     try {
-      final tokens = await oauth.refresh(refreshToken);
       final cred = GoogleAuthProvider.credential(
         idToken: tokens.idToken,
         accessToken: tokens.accessToken,
@@ -288,27 +310,45 @@ class AuthService {
       return user;
     } catch (e, st) {
       if (kDebugMode) {
-        debugPrint('AuthService.trySilentSignIn() — Silent sign-in failed: $e');
+        debugPrint('AuthService.trySilentSignIn() — Firebase sign-in failed: $e');
       }
-      // If the refresh token is invalid/revoked or network fails, clean secure storage.
-      // Note: We only delete if it's a real Auth error (e.g. invalid grant),
-      // but to be absolutely safe and prevent infinite boot-loops on bad tokens,
-      // we clean it on any exception here.
-      try {
-        await _secureStorage.delete(key: _googleRefreshTokenKey);
-      } catch (_) {}
-
+      // Firebase auth failed, but Google token refresh succeeded, so the token itself is valid.
+      // E.g., Firebase is down, or transient network error. DO NOT delete the stored refresh token.
       await Telemetry.captureError(
         e,
         st,
         category: TelemetryCategory.signIn,
         tags: {
           'platform': Platform.operatingSystem,
-          'phase': 'silent_refresh',
+          'phase': 'silent_refresh_firebase',
         },
       );
       return null;
     }
+  }
+
+  DesktopOAuth _getDesktopOAuth() {
+    if (_desktopOAuth != null) return _desktopOAuth;
+
+    final clientId = DefaultFirebaseOptions.desktopOAuthClientId;
+    final clientSecret = DefaultFirebaseOptions.desktopOAuthClientSecret;
+    if (clientId == 'REPLACE_WITH_DESKTOP_OAUTH_CLIENT_ID') {
+      throw StateError(
+        'Desktop sign-in needs a Desktop OAuth Client ID. Create one at '
+        'https://console.cloud.google.com/apis/credentials (Application '
+        'type: Desktop app) and paste it into '
+        'DefaultFirebaseOptions.desktopOAuthClientId in firebase_options.dart.',
+      );
+    }
+    if (clientSecret.isEmpty) {
+      throw StateError(
+        'Desktop sign-in is missing GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET. '
+        'Release builds load it from Doppler (blinkbreak/prd). For local '
+        'dev, run: doppler run --project blinkbreak --config prd -- sh -c '
+        "'flutter run -d macos --dart-define=GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET=\$GOOGLE_DESKTOP_OAUTH_CLIENT_SECRET'",
+      );
+    }
+    return DesktopOAuth(clientId: clientId, clientSecret: clientSecret);
   }
 
   Future<void> signOut() async {

--- a/worker_flutter/lib/auth/auth_service.dart
+++ b/worker_flutter/lib/auth/auth_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../firebase_options.dart';
 import '../telemetry.dart';
@@ -45,12 +46,19 @@ class AuthedUser {
 /// cloud_firestore reads `request.auth.uid` on subsequent writes
 /// either way.
 class AuthService {
-  AuthService({FirebaseAuth? firebaseAuth, DesktopOAuth? desktopOAuth})
-    : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance,
-      _desktopOAuth = desktopOAuth;
+  AuthService({
+    FirebaseAuth? firebaseAuth,
+    DesktopOAuth? desktopOAuth,
+    FlutterSecureStorage? secureStorage,
+  }) : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance,
+       _desktopOAuth = desktopOAuth,
+       _secureStorage = secureStorage ?? const FlutterSecureStorage();
 
   final FirebaseAuth _firebaseAuth;
   final DesktopOAuth? _desktopOAuth;
+  final FlutterSecureStorage _secureStorage;
+
+  static const _googleRefreshTokenKey = 'google_refresh_token';
 
   /// Stream of the current Firebase user, mapped to our `AuthedUser`
   /// shape. Emits `null` while signed out.
@@ -163,6 +171,26 @@ class AuthService {
       );
       rethrow;
     }
+
+    // Save the Google OAuth refresh token securely for silent sign-in on boot.
+    if (tokens.refreshToken != null) {
+      try {
+        await _secureStorage.write(
+          key: _googleRefreshTokenKey,
+          value: tokens.refreshToken,
+        );
+      } catch (e, st) {
+        debugPrint('AuthService: Failed to save refresh token: $e');
+        // Non-fatal error for the sign-in itself, but capture it.
+        await Telemetry.captureError(
+          e,
+          st,
+          category: TelemetryCategory.signIn,
+          tags: {'phase': 'persist_refresh_token'},
+        );
+      }
+    }
+
     return _requireUser(credential);
   }
 
@@ -201,7 +229,96 @@ class AuthService {
     );
   }
 
-  Future<void> signOut() => _firebaseAuth.signOut();
+  /// Attempts to silently sign in using a previously persisted Google refresh token.
+  /// Returns the authenticated user on success, or `null` if silent sign-in fails
+  /// or no refresh token is stored.
+  Future<AuthedUser?> trySilentSignIn() async {
+    if (!_useDesktopFlow) {
+      // Non-desktop platforms use the native Firebase Auth persistence.
+      // Firebase Auth's currentUser will automatically populate.
+      return currentUserSnapshot;
+    }
+
+    final refreshToken = await _secureStorage.read(key: _googleRefreshTokenKey);
+    if (refreshToken == null) {
+      if (kDebugMode) {
+        debugPrint('AuthService.trySilentSignIn() — No saved refresh token found');
+      }
+      return null;
+    }
+
+    if (kDebugMode) {
+      debugPrint('AuthService.trySilentSignIn() — Found saved refresh token, attempting silent refresh');
+    }
+
+    final clientId = DefaultFirebaseOptions.desktopOAuthClientId;
+    final clientSecret = DefaultFirebaseOptions.desktopOAuthClientSecret;
+    if (clientId == 'REPLACE_WITH_DESKTOP_OAUTH_CLIENT_ID' || clientSecret.isEmpty) {
+      if (kDebugMode) {
+        debugPrint('AuthService.trySilentSignIn() — Missing clientId or clientSecret');
+      }
+      return null;
+    }
+
+    final oauth =
+        _desktopOAuth ??
+        DesktopOAuth(clientId: clientId, clientSecret: clientSecret);
+
+    try {
+      final tokens = await oauth.refresh(refreshToken);
+      final cred = GoogleAuthProvider.credential(
+        idToken: tokens.idToken,
+        accessToken: tokens.accessToken,
+      );
+
+      final credential = await _firebaseAuth.signInWithCredential(cred);
+
+      // Persist the new refresh token if Google returned one.
+      if (tokens.refreshToken != null) {
+        await _secureStorage.write(
+          key: _googleRefreshTokenKey,
+          value: tokens.refreshToken,
+        );
+      }
+
+      final user = _requireUser(credential);
+      if (kDebugMode) {
+        debugPrint('AuthService.trySilentSignIn() — Silent refresh successful for ${user.email}');
+      }
+      return user;
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('AuthService.trySilentSignIn() — Silent sign-in failed: $e');
+      }
+      // If the refresh token is invalid/revoked or network fails, clean secure storage.
+      // Note: We only delete if it's a real Auth error (e.g. invalid grant),
+      // but to be absolutely safe and prevent infinite boot-loops on bad tokens,
+      // we clean it on any exception here.
+      try {
+        await _secureStorage.delete(key: _googleRefreshTokenKey);
+      } catch (_) {}
+
+      await Telemetry.captureError(
+        e,
+        st,
+        category: TelemetryCategory.signIn,
+        tags: {
+          'platform': Platform.operatingSystem,
+          'phase': 'silent_refresh',
+        },
+      );
+      return null;
+    }
+  }
+
+  Future<void> signOut() async {
+    try {
+      await _secureStorage.delete(key: _googleRefreshTokenKey);
+    } catch (e) {
+      debugPrint('AuthService: Failed to clear secure storage on signOut: $e');
+    }
+    await _firebaseAuth.signOut();
+  }
 
   /// Sign-in is supported on every desktop target via the PKCE flow.
   static bool get isSupported => true;

--- a/worker_flutter/lib/auth/desktop_oauth.dart
+++ b/worker_flutter/lib/auth/desktop_oauth.dart
@@ -81,8 +81,8 @@ class DesktopOAuth {
         'code_challenge': challenge,
         'code_challenge_method': 'S256',
         'state': state,
-        'access_type': 'online',
-        'prompt': 'select_account',
+        'access_type': 'offline',
+        'prompt': 'select_account consent',
       },
     );
 
@@ -122,12 +122,17 @@ class DesktopOAuth {
       final tokens = jsonDecode(resp.body) as Map<String, dynamic>;
       final idToken = tokens['id_token'] as String?;
       final accessToken = tokens['access_token'] as String?;
+      final refreshToken = tokens['refresh_token'] as String?;
       if (idToken == null || accessToken == null) {
         throw StateError(
           'Token response missing id_token/access_token: ${resp.body}',
         );
       }
-      return DesktopOAuthResult(idToken: idToken, accessToken: accessToken);
+      return DesktopOAuthResult(
+        idToken: idToken,
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+      );
     } finally {
       // Always close the listener — leaving it bound on a random port
       // would leak file descriptors and could collide on a future run.
@@ -225,18 +230,57 @@ display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
 h1{font-size:18px;margin:0 0 8px}p{font-size:13px;margin:0;color:#cbd5e1}</style></head>
 <body><div class="card"><h1>$title</h1><p>$body</p></div></body></html>''';
   }
+
+  /// Exchange a refresh token for a fresh idToken and accessToken.
+  /// Used for silent sign-in on boot.
+  Future<DesktopOAuthResult> refresh(String refreshToken) async {
+    final resp = await _http.post(
+      Uri.parse(_tokenEndpoint),
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: {
+        'client_id': clientId,
+        if (clientSecret.isNotEmpty) 'client_secret': clientSecret,
+        'refresh_token': refreshToken,
+        'grant_type': 'refresh_token',
+      },
+    );
+    if (resp.statusCode != 200) {
+      throw StateError(
+        'Google token endpoint returned ${resp.statusCode}: ${resp.body}',
+      );
+    }
+    final tokens = jsonDecode(resp.body) as Map<String, dynamic>;
+    final idToken = tokens['id_token'] as String?;
+    final accessToken = tokens['access_token'] as String?;
+    if (idToken == null || accessToken == null) {
+      throw StateError(
+        'Token response missing id_token/access_token: ${resp.body}',
+      );
+    }
+    return DesktopOAuthResult(
+      idToken: idToken,
+      accessToken: accessToken,
+      refreshToken: tokens['refresh_token'] as String? ?? refreshToken,
+    );
+  }
 }
 
 class DesktopOAuthResult {
-  DesktopOAuthResult({required this.idToken, required this.accessToken});
+  DesktopOAuthResult({
+    required this.idToken,
+    required this.accessToken,
+    this.refreshToken,
+  });
   final String idToken;
   final String accessToken;
+  final String? refreshToken;
 
   @override
   String toString() {
     if (kDebugMode) {
       return 'DesktopOAuthResult(idToken: ${idToken.substring(0, 16)}…, '
-          'accessToken: ${accessToken.substring(0, 16)}…)';
+          'accessToken: ${accessToken.substring(0, 16)}…, '
+          'refreshToken: ${refreshToken != null ? (refreshToken!.length > 8 ? "${refreshToken!.substring(0, 8)}…" : "present") : "null"})';
     }
     return 'DesktopOAuthResult';
   }

--- a/worker_flutter/lib/auth/desktop_oauth.dart
+++ b/worker_flutter/lib/auth/desktop_oauth.dart
@@ -245,9 +245,7 @@ h1{font-size:18px;margin:0 0 8px}p{font-size:13px;margin:0;color:#cbd5e1}</style
       },
     );
     if (resp.statusCode != 200) {
-      throw StateError(
-        'Google token endpoint returned ${resp.statusCode}: ${resp.body}',
-      );
+      throw GoogleRefreshTokenException(resp.statusCode, resp.body);
     }
     final tokens = jsonDecode(resp.body) as Map<String, dynamic>;
     final idToken = tokens['id_token'] as String?;
@@ -284,4 +282,22 @@ class DesktopOAuthResult {
     }
     return 'DesktopOAuthResult';
   }
+}
+
+class GoogleRefreshTokenException implements Exception {
+  GoogleRefreshTokenException(this.statusCode, this.body);
+  final int statusCode;
+  final String body;
+
+  bool get isInvalidGrant {
+    try {
+      final json = jsonDecode(body) as Map<String, dynamic>;
+      return json['error'] == 'invalid_grant';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  @override
+  String toString() => 'GoogleRefreshTokenException: Google token endpoint returned $statusCode: $body';
 }

--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -510,20 +510,35 @@ class _WorkerAppState extends State<_WorkerApp> with WindowListener {
   final AuthService _auth = AuthService();
   AuthedUser? _user;
   bool _engineStarted = false;
+  bool _restoringSession = true;
 
   @override
   void initState() {
     super.initState();
     windowManager.addListener(this);
-    // firebase_auth persists the session across launches — restore it
-    // synchronously so a returning user lands straight on the
-    // dashboard rather than the AuthGate.
-    final restored = _auth.currentUserSnapshot;
-    if (restored != null) {
-      _user = restored;
-      // Schedule outside the build cycle: _startEngineSafe awaits the
-      // engine, and initState shouldn't be async.
-      Future.microtask(() => _onAuthed(restored));
+    _performSilentSignIn();
+  }
+
+  Future<void> _performSilentSignIn() async {
+    try {
+      final user = await _auth.trySilentSignIn();
+      if (mounted) {
+        setState(() {
+          _user = user;
+          _restoringSession = false;
+        });
+        if (user != null) {
+          await _onAuthed(user);
+        }
+      }
+    } catch (e, st) {
+      _log('Silent sign-in threw error: $e\n$st');
+      if (mounted) {
+        setState(() {
+          _user = null;
+          _restoringSession = false;
+        });
+      }
     }
   }
 
@@ -594,13 +609,29 @@ class _WorkerAppState extends State<_WorkerApp> with WindowListener {
           surface: Color(0xFF111827),
         ),
       ),
-      home: _user == null
-          ? AuthGateScreen(
-              authService: _auth,
-              onAuthed: _onAuthed,
-              onSwitchToOffline: _switchToOffline,
+      home: _restoringSession
+          ? const Scaffold(
+              body: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    CircularProgressIndicator(),
+                    SizedBox(height: 16),
+                    Text(
+                      'Restoring session…',
+                      style: TextStyle(color: Colors.white70, fontSize: 14),
+                    ),
+                  ],
+                ),
+              ),
             )
-          : Dashboard(engine: widget.engine, config: widget.config),
+          : (_user == null
+              ? AuthGateScreen(
+                  authService: _auth,
+                  onAuthed: _onAuthed,
+                  onSwitchToOffline: _switchToOffline,
+                )
+              : Dashboard(engine: widget.engine, config: widget.config)),
     );
   }
 }

--- a/worker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/worker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import cloud_firestore
 import firebase_auth
 import firebase_core
 import firebase_storage
+import flutter_secure_storage_macos
 import package_info_plus
 import screen_retriever_macos
 import sentry_flutter
@@ -25,6 +26,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))

--- a/worker_flutter/pubspec.lock
+++ b/worker_flutter/pubspec.lock
@@ -446,6 +446,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -544,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:

--- a/worker_flutter/pubspec.yaml
+++ b/worker_flutter/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   firebase_auth: ^5.4.0
   cloud_firestore: ^5.6.0
   firebase_storage: ^12.3.0
+  flutter_secure_storage: ^9.2.2
 
   # Native window + tray
   tray_manager: ^0.5.2

--- a/worker_flutter/windows/flutter/generated_plugin_registrant.cc
+++ b/worker_flutter/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_storage/firebase_storage_plugin_c_api.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
@@ -29,6 +30,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FirebaseStoragePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   SentryFlutterPluginRegisterWithRegistrar(

--- a/worker_flutter/windows/flutter/generated_plugins.cmake
+++ b/worker_flutter/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   firebase_storage
+  flutter_secure_storage_windows
   screen_retriever_windows
   sentry_flutter
   sqlite3_flutter_libs


### PR DESCRIPTION
### Summary
This PR resolves the issue where the Magic Bracket Windows Flutter worker forces the user to sign in every time the app or computer restarts. By utilizing Google OAuth offline access (refresh tokens), storing them securely via platform-native credential storage, and silently re-establishing the Firebase Auth session on boot, we ensure robust, silent re-authentication across all desktop ports.

### Key Changes
- **Dependency Added**: Added `flutter_secure_storage: ^9.2.2` in `worker_flutter` to leverage Windows DPAPI, macOS Keychain, and Linux Secret Service.
- **Desktop OAuth Driver**: Updated authorization query parameters to `'access_type': 'offline'` and `'prompt': 'select_account consent'` to retrieve a refresh token. Implemented the silent `refresh()` method to exchange the refresh token for a fresh `id_token` and `access_token`.
- **Authentication Service**: Implemented secure refresh token persistence under `'google_refresh_token'`. Added `trySilentSignIn()` to fetch, refresh, and silently sign into Firebase Auth with the stored token.
- **Boot Lifecycle**: Integrated silent sign-in on boot in `_WorkerAppState.initState()`. Display a clean, dark-themed "Restoring session…" progress indicator while restoring.
- **Unified Desktops**: macOS, Windows, and Linux all now share the unified secure PKCE silent re-authentication path.

### Test Plan
- Run `flutter analyze` to ensure zero compilation or type safety issues.
- Run `flutter test` to ensure all 141 tests in the suite pass successfully.
- Manual verification instructions:
  1. Boot the worker app, log in for the first time, and complete the one-time browser consent screen.
  2. Exit the app completely, then re-launch it. Confirm it silently logs you into the dashboard within a second.
  3. Sign out, close, and re-launch to verify it returns to the login screen securely.

*This PR was prepared by Antigravity, an advanced agentic AI coding assistant.*