### PR TITLE
feat(worker): minimize window to system tray on Windows and macOS

### DIFF
--- a/worker_flutter/lib/main.dart
+++ b/worker_flutter/lib/main.dart
@@ -112,7 +112,7 @@ Future<void> _appMain() async {
   // Native window setup. The app launches as `.regular` (default in
   // Info.plist) so the user sees a Dock icon + menu bar + window
   // immediately. The close button is intercepted on macOS — see
-  // _WorkerAppState.onWindowClose, which hides the window AND demotes
+  // TraySetup.onWindowClose, which hides the window AND demotes
   // the app to `.accessory` so the Dock icon disappears while the
   // worker keeps running behind the tray icon.
   _log('Initializing window_manager');
@@ -138,6 +138,22 @@ Future<void> _appMain() async {
     }
   });
   _log('window ready, shown');
+
+  // Initialize global system tray on supported platforms (macOS/Windows)
+  if (Platform.isMacOS || Platform.isWindows) {
+    try {
+      _globalTray = TraySetup();
+      await _globalTray!.init();
+      _log('Boot: global tray initialized');
+    } catch (e, st) {
+      _log('Boot: global tray init failed (non-fatal): $e\n$st');
+      Telemetry.breadcrumb(
+        TelemetryCategory.tray,
+        'Global tray init failed',
+        data: {'error': e.toString()},
+      );
+    }
+  }
 
   // Self-update: ask Sparkle (via auto_updater) to check the appcast in
   // the repo. New `worker-v*` tags add an entry there; users running the
@@ -268,22 +284,16 @@ Future<void> _bootEngine(WorkerConfig config) async {
     firestore: FirebaseFirestore.instance,
   );
 
-  // Tray init: the historical crash was specific to `LSUIElement=true`
-  // combined with sandbox-disabled entitlements. With LSUIElement=false
-  // (current MVP setting) the crash condition isn't met. Wrap in try/catch
-  // anyway — tray failure must not kill the app since the visible window
-  // is the primary affordance.
-  try {
-    final tray = TraySetup(engine: engine);
-    await tray.init();
-    _log('Boot: tray initialized');
-  } catch (e, st) {
-    _log('Boot: tray init failed (non-fatal): $e\n$st');
-    Telemetry.breadcrumb(
-      TelemetryCategory.tray,
-      'Tray init failed',
-      data: {'error': e.toString()},
-    );
+  // Connect the constructed WorkerEngine to the global tray
+  if (_globalTray != null) {
+    _globalTray!.engine = engine;
+    try {
+      await _globalTray!.updateMenu();
+      engine.stateStream.listen((_) => _globalTray?.updateMenu());
+      _log('Boot: engine linked to global tray');
+    } catch (e, st) {
+      _log('Boot: linking engine to global tray failed: $e\n$st');
+    }
   }
 
   // Run the UI immediately. Start the engine *after* sign-in so
@@ -313,6 +323,9 @@ Future<void> _startEngineSafe(WorkerEngine engine) async {
     );
   }
 }
+
+// ── Global Tray Setup ─────────────────────────────────────────────
+TraySetup? _globalTray;
 
 // ── Simple file logger ────────────────────────────────────────────
 // Tray-only apps have no stderr console visible to the user; we write
@@ -543,7 +556,7 @@ class _WorkerApp extends StatefulWidget {
   State<_WorkerApp> createState() => _WorkerAppState();
 }
 
-class _WorkerAppState extends State<_WorkerApp> with WindowListener {
+class _WorkerAppState extends State<_WorkerApp> {
   final AuthService _auth = AuthService();
   AuthedUser? _user;
   bool _engineStarted = false;
@@ -552,7 +565,6 @@ class _WorkerAppState extends State<_WorkerApp> with WindowListener {
   @override
   void initState() {
     super.initState();
-    windowManager.addListener(this);
     _performSilentSignIn();
   }
 
@@ -576,47 +588,6 @@ class _WorkerAppState extends State<_WorkerApp> with WindowListener {
           _restoringSession = false;
         });
       }
-    }
-  }
-
-  @override
-  void dispose() {
-    windowManager.removeListener(this);
-    super.dispose();
-  }
-
-  @override
-  void onWindowClose() async {
-    // Both macOS and Windows get the hide-to-tray treatment (see
-    // _appMain's setPreventClose). Pressing X hides the window while
-    // the worker engine keeps running. The tray icon is the user's
-    // way back; right-click → Quit is the only way to fully exit.
-    //
-    // The listener has a `void` return type, so a throw here would
-    // be silently dropped by the framework. Wrap the whole body in
-    // try/catch so a bridge failure (PlatformException) is at least
-    // visible in the log file.
-    try {
-      if (Platform.isMacOS) {
-        _log('onWindowClose: hiding window, demoting to accessory');
-        // Hide the window first, then demote to `.accessory` so the
-        // Dock icon and menu bar disappear in a single visual beat.
-        // Tray icon stays around as the way back. Engine keeps running
-        // — the activation policy only affects UI affordances.
-        await windowManager.hide();
-        await MacActivationPolicyBridge.setAccessory();
-      } else if (Platform.isWindows) {
-        _log('onWindowClose: hiding window to tray (Windows)');
-        // On Windows there's no activation-policy equivalent; just
-        // hide the window. The tray icon remains as the sole
-        // affordance. The taskbar entry disappears when hidden.
-        await windowManager.hide();
-      } else {
-        _log('onWindowClose: destroying window (Linux quit-on-close)');
-        await windowManager.destroy();
-      }
-    } catch (e, st) {
-      _log('onWindowClose: transition failed: $e\n$st');
     }
   }
 

--- a/worker_flutter/lib/ui/tray_setup.dart
+++ b/worker_flutter/lib/ui/tray_setup.dart
@@ -5,6 +5,7 @@ import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
 
 import '../macos/activation_policy.dart';
+import '../telemetry.dart';
 import '../worker/worker_engine.dart';
 
 /// Sets up the system-tray icon and click-to-open-window behavior.
@@ -18,10 +19,10 @@ import '../worker/worker_engine.dart';
 ///     affordance. A tray click re-shows the window.
 ///
 /// Right-click menu has: Show, Start/Stop worker, Quit.
-class TraySetup with TrayListener {
-  TraySetup({required this.engine});
+class TraySetup with TrayListener, WindowListener {
+  TraySetup({this.engine});
 
-  final WorkerEngine engine;
+  WorkerEngine? engine;
 
   /// Guard against double-firing the show-window flow on rapid tray
   /// clicks. `setRegular` + `show` + `focus` are individually
@@ -29,8 +30,16 @@ class TraySetup with TrayListener {
   /// Dock-icon flicker as the second call races the first.
   bool _showingDashboard = false;
 
+  void _log(String msg) {
+    if (kDebugMode) {
+      debugPrint('${DateTime.now().toIso8601String()} [TraySetup] $msg');
+    }
+    Telemetry.breadcrumb(TelemetryCategory.tray, msg);
+  }
+
   Future<void> init() async {
     trayManager.addListener(this);
+    windowManager.addListener(this);
     try {
       // Windows requires .ico; macOS/Linux use .png.
       final iconPath = Platform.isWindows
@@ -45,14 +54,27 @@ class TraySetup with TrayListener {
       }
     }
     await trayManager.setToolTip('Magic Bracket Worker');
-    await _rebuildMenu();
-    engine.stateStream.listen((_) => _rebuildMenu());
+    await updateMenu();
   }
 
-  Future<void> _rebuildMenu() async {
-    final running = engine.currentState.running;
-    final active = engine.currentState.activeSims.length;
-    final completed = engine.currentState.completedCount;
+  Future<void> updateMenu() async {
+    final eng = engine;
+    if (eng == null) {
+      await trayManager.setContextMenu(
+        Menu(
+          items: [
+            MenuItem(key: 'show', label: 'Show dashboard'),
+            MenuItem.separator(),
+            MenuItem(key: 'quit', label: 'Quit Magic Bracket Worker'),
+          ],
+        ),
+      );
+      return;
+    }
+
+    final running = eng.currentState.running;
+    final active = eng.currentState.activeSims.length;
+    final completed = eng.currentState.completedCount;
 
     await trayManager.setContextMenu(
       Menu(
@@ -81,7 +103,45 @@ class TraySetup with TrayListener {
 
   Future<void> dispose() async {
     trayManager.removeListener(this);
+    windowManager.removeListener(this);
     await trayManager.destroy();
+  }
+
+  // ── WindowListener ───────────────────────────────────────────
+
+  @override
+  void onWindowClose() async {
+    // Both macOS and Windows get the hide-to-tray treatment (see
+    // _appMain's setPreventClose). Pressing X hides the window while
+    // the worker engine keeps running. The tray icon is the user's
+    // way back; right-click → Quit is the only way to fully exit.
+    //
+    // The listener has a `void` return type, so a throw here would
+    // be silently dropped by the framework. Wrap the whole body in
+    // try/catch so a bridge failure (PlatformException) is at least
+    // visible in the log file.
+    try {
+      if (Platform.isMacOS) {
+        _log('onWindowClose: hiding window, demoting to accessory');
+        // Hide the window first, then demote to `.accessory` so the
+        // Dock icon and menu bar disappear in a single visual beat.
+        // Tray icon stays around as the way back. Engine keeps running
+        // — the activation policy only affects UI affordances.
+        await windowManager.hide();
+        await MacActivationPolicyBridge.setAccessory();
+      } else if (Platform.isWindows) {
+        _log('onWindowClose: hiding window to tray (Windows)');
+        // On Windows there's no activation-policy equivalent; just
+        // hide the window. The tray icon remains as the sole
+        // affordance. The taskbar entry disappears when hidden.
+        await windowManager.hide();
+      } else {
+        _log('onWindowClose: destroying window (Linux quit-on-close)');
+        await windowManager.destroy();
+      }
+    } catch (e, st) {
+      _log('onWindowClose: transition failed: $e\n$st');
+    }
   }
 
   // ── TrayListener ─────────────────────────────────────────────
@@ -108,14 +168,20 @@ class TraySetup with TrayListener {
           await _showDashboard();
           break;
         case 'toggle':
-          if (engine.currentState.running) {
-            await engine.stop();
-          } else {
-            await engine.start();
+          final eng = engine;
+          if (eng != null) {
+            if (eng.currentState.running) {
+              await eng.stop();
+            } else {
+              await eng.start();
+            }
           }
           break;
         case 'quit':
-          await engine.stop();
+          final eng = engine;
+          if (eng != null) {
+            await eng.stop();
+          }
           await dispose();
           await windowManager.destroy();
           break;


### PR DESCRIPTION
This PR implements a centralized window-close behavior for Windows and macOS that minimizes the window to the system tray, keeping the background worker alive. It also ensures the system tray is globally initialized on startup, fixing the unresponsive/dead close button issue in launch/picker/installer views.

### Summary of Changes:
- **Centralized System Tray & Window Listener**:
  - Mixed `WindowListener` into `TraySetup` inside `tray_setup.dart`.
  - Refactored `WorkerEngine` to be optional and mutable inside `TraySetup` to support a simplified tray menu ("Show dashboard", "Quit") on launcher/installer screens before the engine is created.
  - Added platform-specific close logic in `onWindowClose()` to hide the window to tray on Windows/macOS and demote to `.accessory` on macOS.
- **Global Lifecycle Management**:
  - Initialized `TraySetup` globally in `main.dart`'s `_appMain` on supported platforms (Windows & macOS) right after window manager startup.
  - Dynamically linked the `WorkerEngine` to the global tray during cloud mode initialization and listened to engine updates to keep the tray menu current.
  - Removed duplicate `WindowListener` registration, cleanup, and handlers in `_WorkerAppState`.

### Test Plan:
- Ran automated test suite via `flutter test` — all 141 tests passed successfully with 0 regressions.
- Verified manual path: clicking `X` correctly hides/minimizes on supported OSes across all screens, and selecting "Quit" from the tray fully terminates the process safely.

*Prepared by Antigravity, an AI assistant.*