### PR TITLE
fix(windows): resolve installer path compilation errors and download steps

### DIFF
--- a/.github/scripts/prepend_appcast_item.py
+++ b/.github/scripts/prepend_appcast_item.py
@@ -71,18 +71,21 @@ def main() -> None:
 
     manifest = json.loads(args.manifest.read_text())
     
-    if args.os == "macos":
-        signature = manifest["edSignature"]
-        sig_attr = "sparkle:edSignature"
-        os_name = "macos"
-        title_suffix = "(macOS)"
-    else:
-        signature = manifest["dsaSignature"]
-        sig_attr = "sparkle:dsaSignature"
-        os_name = "windows"
-        title_suffix = "(Windows)"
+    try:
+        if args.os == "macos":
+            signature = manifest["edSignature"]
+            sig_attr = "sparkle:edSignature"
+            os_name = "macos"
+            title_suffix = "(macOS)"
+        else:
+            signature = manifest["dsaSignature"]
+            sig_attr = "sparkle:dsaSignature"
+            os_name = "windows"
+            title_suffix = "(Windows)"
 
-    length = int(manifest["length"])
+        length = int(manifest["length"])
+    except (KeyError, ValueError) as e:
+        raise SystemExit(f"Manifest at {args.manifest} is malformed or missing required keys: {e}")
 
     appcast = args.appcast.read_text()
 

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -304,6 +304,7 @@ jobs:
           if (-not (Test-Path $src)) {
             $src = "build/windows/runner/Release"
           }
+          $src = [System.IO.Path]::GetFullPath($src)
           iscc /dMyAppVersion="${{ needs.version.outputs.version }}" /dSourceDir="$src" windows/installer.iss
 
       - name: Sign installer for WinSparkle (DSA)
@@ -408,6 +409,12 @@ jobs:
         with:
           name: macos
           path: artifacts/macos
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows
+          path: artifacts/windows
 
       - name: Prepend appcast item (macOS)
         env:

--- a/worker_flutter/windows/installer.iss
+++ b/worker_flutter/windows/installer.iss
@@ -7,7 +7,7 @@
 #endif
 
 #ifndef SourceDir
-  #define SourceDir "build\windows\x64\runner\Release"
+  #define SourceDir "..\build\windows\x64\runner\Release"
 #endif
 
 [Setup]
@@ -22,7 +22,7 @@ OutputBaseFilename=MagicBracketWorker-Installer
 Compression=lzma
 SolidCompression=yes
 PrivilegesRequired=lowest
-SetupIconFile=assets\tray_icon.ico
+SetupIconFile=..\assets\tray_icon.ico
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
### Summary
This PR fixes path resolution issues during Inno Setup compilation on Windows runner and ensures that the `update-appcast` job downloads the Windows artifact to prepend it correctly to the Sparkle appcast feed.

### Details
1. **Script Path Correction**: Modified [installer.iss](file:///Users/tylerholland/.gemini/antigravity/worktrees/MagicBracketSimulator/fix-flutter-installer-mechanism/worker_flutter/windows/installer.iss) default paths (`SourceDir` and `SetupIconFile`) to be relative to the script directory using `..\`.
2. **Absolute Path Compilation**: Updated [.github/workflows/release-worker.yml](file:///Users/tylerholland/.gemini/antigravity/worktrees/MagicBracketSimulator/fix-flutter-installer-mechanism/.github/workflows/release-worker.yml) to resolve the source dir to a fully qualified absolute path before compilation.
3. **Missing Windows Download Step**: Updated [.github/workflows/release-worker.yml](file:///Users/tylerholland/.gemini/antigravity/worktrees/MagicBracketSimulator/fix-flutter-installer-mechanism/.github/workflows/release-worker.yml) `update-appcast` job to download the Windows build artifact before executing `prepend_appcast_item.py` for Windows, resolving file-not-found issues.

_Note: Prepared by an AI assistant._
