### PR TITLE
fix(windows): use version string for sparkle:version on windows and update existing entries

### DIFF
--- a/.github/scripts/prepend_appcast_item.py
+++ b/.github/scripts/prepend_appcast_item.py
@@ -48,7 +48,7 @@ def build_item(
         f"      <title>Version {version} {title_suffix}</title>\n"
         f"      <sparkle:os>{os_name}</sparkle:os>\n"
         f"      <pubDate>{pub_date}</pubDate>\n"
-        f"      <sparkle:version>{build_number}</sparkle:version>\n"
+        f"      <sparkle:version>{build_number if os_name == 'macos' else version}</sparkle:version>\n"
         f"      <sparkle:shortVersionString>{version}</sparkle:shortVersionString>\n"
         f"      <sparkle:minimumSystemVersion>{'11.0' if os_name == 'macos' else '10.0'}</sparkle:minimumSystemVersion>\n"
         f'      <enclosure url="{enclosure_url}"\n'

--- a/.github/scripts/prepend_appcast_item_test.py
+++ b/.github/scripts/prepend_appcast_item_test.py
@@ -127,12 +127,14 @@ class PrependAppcastItemTest(unittest.TestCase):
         self.assertIn("<sparkle:os>macos</sparkle:os>", text)
         self.assertIn('sparkle:edSignature="abcED_SIG=="', text)
         self.assertIn('length="12345"', text)
+        self.assertIn("<sparkle:version>8</sparkle:version>", text)
 
         # Verify Windows properties exist in prepended item
         self.assertIn("<title>Version 0.2.1 (Windows)</title>", text)
         self.assertIn("<sparkle:os>windows</sparkle:os>", text)
         self.assertIn('sparkle:dsaSignature="xyzDSA_SIG=="', text)
         self.assertIn('length="54321"', text)
+        self.assertIn("<sparkle:version>0.2.1</sparkle:version>", text)
 
     def test_existing_comments_are_preserved(self) -> None:
         self.run_script_macos()

--- a/worker_flutter/appcast.xml
+++ b/worker_flutter/appcast.xml
@@ -26,7 +26,7 @@
       <title>Version 0.2.135 (Windows)</title>
       <sparkle:os>windows</sparkle:os>
       <pubDate>Sat, 23 May 2026 05:45:34 +0000</pubDate>
-      <sparkle:version>158</sparkle:version>
+      <sparkle:version>0.2.135</sparkle:version>
       <sparkle:shortVersionString>0.2.135</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
       <enclosure url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.2.135/MagicBracketWorker-Installer.exe"
@@ -50,7 +50,7 @@
       <title>Version 0.2.134 (Windows)</title>
       <sparkle:os>windows</sparkle:os>
       <pubDate>Sat, 23 May 2026 05:15:30 +0000</pubDate>
-      <sparkle:version>157</sparkle:version>
+      <sparkle:version>0.2.134</sparkle:version>
       <sparkle:shortVersionString>0.2.134</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
       <enclosure url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.2.134/MagicBracketWorker-Installer.exe"
@@ -74,7 +74,7 @@
       <title>Version 0.2.133 (Windows)</title>
       <sparkle:os>windows</sparkle:os>
       <pubDate>Sat, 23 May 2026 04:44:25 +0000</pubDate>
-      <sparkle:version>156</sparkle:version>
+      <sparkle:version>0.2.133</sparkle:version>
       <sparkle:shortVersionString>0.2.133</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
       <enclosure url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.2.133/MagicBracketWorker-Installer.exe"
@@ -98,7 +98,7 @@
       <title>Version 0.2.132 (Windows)</title>
       <sparkle:os>windows</sparkle:os>
       <pubDate>Sat, 23 May 2026 04:16:38 +0000</pubDate>
-      <sparkle:version>155</sparkle:version>
+      <sparkle:version>0.2.132</sparkle:version>
       <sparkle:shortVersionString>0.2.132</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
       <enclosure url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.2.132/MagicBracketWorker-Installer.exe"
@@ -122,7 +122,7 @@
       <title>Version 0.2.131 (Windows)</title>
       <sparkle:os>windows</sparkle:os>
       <pubDate>Sat, 23 May 2026 03:48:26 +0000</pubDate>
-      <sparkle:version>154</sparkle:version>
+      <sparkle:version>0.2.131</sparkle:version>
       <sparkle:shortVersionString>0.2.131</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
       <enclosure url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.2.131/MagicBracketWorker-Installer.exe"
@@ -146,7 +146,7 @@
       <title>Version 0.2.130 (Windows)</title>
       <sparkle:os>windows</sparkle:os>
       <pubDate>Sat, 23 May 2026 03:19:57 +0000</pubDate>
-      <sparkle:version>153</sparkle:version>
+      <sparkle:version>0.2.130</sparkle:version>
       <sparkle:shortVersionString>0.2.130</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
       <enclosure url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.2.130/MagicBracketWorker-Installer.exe"
@@ -170,7 +170,7 @@
       <title>Version 0.2.129 (Windows)</title>
       <sparkle:os>windows</sparkle:os>
       <pubDate>Sat, 23 May 2026 02:53:02 +0000</pubDate>
-      <sparkle:version>152</sparkle:version>
+      <sparkle:version>0.2.129</sparkle:version>
       <sparkle:shortVersionString>0.2.129</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
       <enclosure url="https://github.com/TytaniumDev/MagicBracketSimulator/releases/download/worker-v0.2.129/MagicBracketWorker-Installer.exe"


### PR DESCRIPTION
### Summary
This PR resolves an issue where the Windows auto-updater (WinSparkle) incorrectly prompts users of a newer version (e.g., `0.2.136`) to "upgrade" to an older version (e.g., `0.2.135`).

### Cause
WinSparkle compares the appcast's `sparkle:version` against the installed executable's `FileVersion` string.
- Previously, `sparkle:version` was written as the raw build number/integer (like `158`).
- The executable's `FileVersion` is the version string (like `"0.2.136"`).
- Since `"158"` starts with `1` and `"0.2.136"` starts with `0`, WinSparkle incorrectly thinks `158` is a newer version (`158 > 0`).

### Solution
1. **Script Fix**: Modified [prepend_appcast_item.py](file:///Users/tylerholland/.gemini/antigravity/worktrees/MagicBracketSimulator/fix-flutter-installer-mechanism/.github/scripts/prepend_appcast_item.py) to use the full version string (e.g. `0.2.135`) for `sparkle:version` on Windows, while keeping the build number (e.g. `158`) on macOS.
2. **Existing Entries**: Updated all 7 existing Windows entries in [appcast.xml](file:///Users/tylerholland/.gemini/antigravity/worktrees/MagicBracketSimulator/fix-flutter-installer-mechanism/worker_flutter/appcast.xml) to use version strings instead of build numbers in `<sparkle:version>`.
3. **Tests**: Expanded [prepend_appcast_item_test.py](file:///Users/tylerholland/.gemini/antigravity/worktrees/MagicBracketSimulator/fix-flutter-installer-mechanism/.github/scripts/prepend_appcast_item_test.py) to assert this custom logic.

_Note: Prepared by an AI assistant._
